### PR TITLE
The filter layout on Table Pages to wrap the filter controls

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/samples/SampleGridComponent.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/samples/SampleGridComponent.java
@@ -125,6 +125,7 @@ public class SampleGridComponent extends VerticalLayout {
 		filterLayout.setMargin(false);
 		filterLayout.setSpacing(true);
 		filterLayout.setSizeUndefined();
+		filterLayout.addStyleName("wrap");
 
 		UserDto user = UserProvider.getCurrent().getUser();
 

--- a/sormas-ui/src/main/webapp/VAADIN/themes/sormas/components/orderedlayout.scss
+++ b/sormas-ui/src/main/webapp/VAADIN/themes/sormas/components/orderedlayout.scss
@@ -42,5 +42,9 @@
 				height: 36px;
 			}
 		}
+		
+		&.wrap{
+		    white-space: normal !important
+		}
 	}
 }


### PR DESCRIPTION
#2144 

PROBLEM:
The filter layout on Table Pages does not wrap the child controls. Hence the need to scroll horizontally to access all filter controls

SOLUTION:
Layout wrap style added to css
added the style to filterLayout on Sample list page