### PR TITLE
Swagger adjustments

### DIFF
--- a/sormas-base/pom.xml
+++ b/sormas-base/pom.xml
@@ -19,6 +19,7 @@
 		<vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>
 		<jersey.version>2.29.1</jersey.version>
 		<jackson.version>2.9.8</jackson.version>
+		<swagger.version>2.1.2</swagger.version>
 		<jetty.plugin.version>9.2.3.v20140905</jetty.plugin.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -339,7 +340,7 @@
 			<dependency>
 				<groupId>io.swagger.core.v3</groupId>
 				<artifactId>swagger-jaxrs2</artifactId>
-				<version>2.1.2</version>
+				<version>${swagger.version}</version>
 			</dependency>
 
 		</dependencies>
@@ -565,6 +566,14 @@
 							</goals>
 						</execution>
 					</executions>
+					<dependencies>
+						<!-- Currently necessary to get the latest bugfixes in swagger-core -->
+						<dependency>
+							<groupId>io.swagger.core.v3</groupId>
+							<artifactId>swagger-jaxrs2</artifactId>
+							<version>${swagger.version}</version>
+						</dependency>
+					</dependencies>
 				</plugin>
 
 			</plugins>

--- a/sormas-rest/README.md
+++ b/sormas-rest/README.md
@@ -7,9 +7,10 @@ The SORMAS REST API is automatically documented using the [`swagger-maven-plugin
  Swagger Annotation Framework<sup>[[1]]([SwaggerAnnotations])</sup>. Corresponding specification files in JSON and YAML format are produced
  automatically during the build process and can be found at `${Project Root}/sormas-rest/target/swagger.{json,yaml}` paths.
  
- If you are only interested in these OpenAPI specification files, execute the following command inside the `sormas-base` module's directory
- (*requires Maven to be installed*):
+ If you are only interested in these OpenAPI specification files, you may either download a recent SORMAS release which has these files included
+  in its `openapi` directory, or execute the following command inside the `sormas-base` module's directory to build them yourself:
  ```
+ # Requires Maven to be installed!
  mvn package --projects ../sormas-rest --also-make -Dmaven.test.skip=true
  ```
  The specification files should then pop up at the paths specified above.

--- a/sormas-rest/build.xml
+++ b/sormas-rest/build.xml
@@ -7,4 +7,21 @@
 	<property name="maven.artifactId" value="sormas-rest" />
 	<property name="file.suffix" value="war" />
 
+	<target name="3-collect" description="Kopiert das Artefakt nach deploy/apps.">
+
+		<property name="copy.path" value="../deploy/apps" />
+		<antcall inheritAll="true" target="--copy-artifact" />
+		<antcall inheritall="true" target="--copy-openapi-spec" />
+	</target>
+
+	<target name="--copy-openapi-spec" description="Copies the OpenAPI/Swagger specification for the SORMAS REST API to deploy/openapi.">
+		<copy todir="../deploy/openapi" preservelastmodified="true" verbose="true">
+			<fileset dir="./target">
+				<include name="swagger.json" />
+				<include name="swagger.yaml" />
+			</fileset>
+			<mapper type="glob" from="swagger.*" to="sormas-rest.*" />
+		</copy>
+	</target>
+
 </project>

--- a/sormas-rest/src/main/java/de/symeda/sormas/rest/swagger/SwaggerConfig.java
+++ b/sormas-rest/src/main/java/de/symeda/sormas/rest/swagger/SwaggerConfig.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
 import io.swagger.v3.core.converter.ModelConverters;
+import io.swagger.v3.core.jackson.ModelResolver;
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.jaxrs2.ext.OpenAPIExtension;
 import io.swagger.v3.jaxrs2.ext.OpenAPIExtensions;
@@ -42,8 +43,9 @@ public class SwaggerConfig {
 		registerExtensions();
 
 		// Swagger uses a Jackson ObjectMapper in the process of type resolution; there are some
-		// settings for that ObjectMapper we need to adjust for the Swagger Specification to be correct
-		tweakObjectMapping(Json.mapper());
+		// settings for that ObjectMapper and Swagger-related classes we need to adjust for the
+		// Swagger Specification to be correct
+		tweakConfig(Json.mapper());
 	}
 
 	public static void init() {
@@ -68,8 +70,16 @@ public class SwaggerConfig {
 		modelConverters.addConverter(sormasSwaggerExtension);
 	}
 
-	private static void tweakObjectMapping(ObjectMapper swaggerObjectMapper) {
+	/**
+	 * Set configuration parameters for Swagger-related classes.
+	 * @param swaggerObjectMapper ObjectMapper instance used by Swagger
+	 */
+	private static void tweakConfig(ObjectMapper swaggerObjectMapper) {
 		// Do not use toString() on enum values
 		swaggerObjectMapper.disable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
+
+		// Specify enumerations as separate schemas, instead of incorporating them into the
+		// schemas for every field/property of their type
+		ModelResolver.enumsAsRef = true;
 	}
 }


### PR DESCRIPTION
This pull request proposes two enhancements to the current Swagger documentation process:

### Schemas for Enum types
Let enums be specified by their own named schemas, instead of being specified as inline value constraints. This should be helpful for API clients since enum types become referencable by name. It should also reduce specification file overhead, since an enum's values are only defined once.

### OpenAPI-Specifications in release artifacts
In order to gain access to the OpenAPI files describing the SORMAS REST API, one currently needs to check out the repository and execute the required tasks, which may pose a challenge for those not familiar with the SORMAS build system. It may be easier for potential API users if such specifications are included in the release bundles. Therefore, the `sormas-rest/build.xml` file is adjusted such that the generated OpenAPI specification files are collected alongside the `sormas-rest.war` artifact by `collect-artifacts` build target. The specification files are put into `deploy/openapi` directory as `sormas-rest.{json,yaml}` files.