### PR TITLE
Feature 2240 unify grid itemclicklistener for navigate and avoid NPE

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/campaign/CampaignGrid.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/campaign/CampaignGrid.java
@@ -18,6 +18,7 @@ import de.symeda.sormas.api.utils.SortProperty;
 import de.symeda.sormas.ui.ControllerProvider;
 import de.symeda.sormas.ui.ViewModelProviders;
 import de.symeda.sormas.ui.utils.FilteredGrid;
+import de.symeda.sormas.ui.utils.ShowDetailsListener;
 import de.symeda.sormas.ui.utils.UuidRenderer;
 import de.symeda.sormas.ui.utils.ViewConfiguration;
 
@@ -55,11 +56,8 @@ public class CampaignGrid extends FilteredGrid<CampaignIndexDto, CampaignCriteri
 			column.setCaption(I18nProperties.getPrefixCaption(CampaignIndexDto.I18N_PREFIX, column.getId().toString(), column.getCaption()));
 		}
 
-		addItemClickListener(e -> {
-			if ((e.getColumn() != null && CampaignIndexDto.UUID.equals(e.getColumn().getId())) || e.getMouseEventDetails().isDoubleClick()) {
-				ControllerProvider.getCampaignController().createOrEdit(e.getItem().getUuid());
-			}
-		});
+		addItemClickListener(
+			new ShowDetailsListener<>(CampaignIndexDto.UUID, e -> ControllerProvider.getCampaignController().createOrEdit(e.getUuid())));
 	}
 
 	public void setLazyDataProvider() {

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/AbstractCaseGrid.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/AbstractCaseGrid.java
@@ -48,6 +48,7 @@ import de.symeda.sormas.ui.UserProvider;
 import de.symeda.sormas.ui.ViewModelProviders;
 import de.symeda.sormas.ui.utils.CssStyles;
 import de.symeda.sormas.ui.utils.FilteredGrid;
+import de.symeda.sormas.ui.utils.ShowDetailsListener;
 import de.symeda.sormas.ui.utils.UuidRenderer;
 import de.symeda.sormas.ui.utils.ViewConfiguration;
 
@@ -75,11 +76,7 @@ public abstract class AbstractCaseGrid<IndexDto extends CaseIndexDto> extends Fi
 
 		initColumns();
 
-		addItemClickListener(e -> {
-			if ((e.getColumn() != null && CaseIndexDto.UUID.equals(e.getColumn().getId())) || e.getMouseEventDetails().isDoubleClick()) {
-				ControllerProvider.getCaseController().navigateToCase(e.getItem().getUuid());
-			}
-		});
+		addItemClickListener(new ShowDetailsListener<>(CaseIndexDto.UUID, e -> ControllerProvider.getCaseController().navigateToCase(e.getUuid())));
 	}
 
 	@SuppressWarnings("unchecked")

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/configuration/infrastructure/AreasGrid.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/configuration/infrastructure/AreasGrid.java
@@ -39,9 +39,7 @@ public class AreasGrid extends FilteredGrid<AreaDto, AreaCriteria> {
 		setColumns(AreaDto.NAME, AreaDto.EXTERNAL_ID);
 
 		if (UserProvider.getCurrent().hasUserRight(UserRight.INFRASTRUCTURE_EDIT)) {
-			addEditColumn(e -> {
-				ControllerProvider.getInfrastructureController().editArea(e.getItem().getUuid());
-			});
+			addEditColumn(e -> ControllerProvider.getInfrastructureController().editArea(e.getUuid()));
 		}
 
 		for (Column<?, ?> column : getColumns()) {

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/configuration/infrastructure/CommunitiesGrid.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/configuration/infrastructure/CommunitiesGrid.java
@@ -58,7 +58,7 @@ public class CommunitiesGrid extends FilteredGrid<CommunityDto, CommunityCriteri
 		setColumns(CommunityDto.NAME, CommunityDto.REGION, CommunityDto.DISTRICT, CommunityDto.EXTERNAL_ID);
 
 		if (UserProvider.getCurrent().hasUserRight(UserRight.INFRASTRUCTURE_EDIT)) {
-			addEditColumn(e -> ControllerProvider.getInfrastructureController().editCommunity(e.getItem().getUuid()));
+			addEditColumn(e -> ControllerProvider.getInfrastructureController().editCommunity(e.getUuid()));
 		}
 
 		for (Column<?, ?> column : getColumns()) {

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/configuration/infrastructure/DistrictsGrid.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/configuration/infrastructure/DistrictsGrid.java
@@ -64,7 +64,7 @@ public class DistrictsGrid extends FilteredGrid<DistrictIndexDto, DistrictCriter
 			DistrictIndexDto.GROWTH_RATE);
 
 		if (UserProvider.getCurrent().hasUserRight(UserRight.INFRASTRUCTURE_EDIT)) {
-			addEditColumn(e -> ControllerProvider.getInfrastructureController().editDistrict(e.getItem().getUuid()));
+			addEditColumn(e -> ControllerProvider.getInfrastructureController().editDistrict(e.getUuid()));
 		}
 
 		for (Column<?, ?> column : getColumns()) {

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/configuration/infrastructure/FacilitiesGrid.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/configuration/infrastructure/FacilitiesGrid.java
@@ -66,7 +66,7 @@ public class FacilitiesGrid extends FilteredGrid<FacilityDto, FacilityCriteria> 
 			FacilityDto.EXTERNAL_ID);
 
 		if (UserProvider.getCurrent().hasUserRight(UserRight.INFRASTRUCTURE_EDIT)) {
-			addEditColumn(e -> ControllerProvider.getInfrastructureController().editHealthFacility(e.getItem().getUuid()));
+			addEditColumn(e -> ControllerProvider.getInfrastructureController().editHealthFacility(e.getUuid()));
 		}
 
 		for (Column<?, ?> column : getColumns()) {

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/configuration/infrastructure/PointsOfEntryGrid.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/configuration/infrastructure/PointsOfEntryGrid.java
@@ -49,9 +49,7 @@ public class PointsOfEntryGrid extends FilteredGrid<PointOfEntryDto, PointOfEntr
 			PointOfEntryDto.ACTIVE);
 
 		if (UserProvider.getCurrent().hasUserRight(UserRight.INFRASTRUCTURE_EDIT)) {
-			addEditColumn(e -> {
-				ControllerProvider.getInfrastructureController().editPointOfEntry(e.getItem().getUuid());
-			});
+			addEditColumn(e -> ControllerProvider.getInfrastructureController().editPointOfEntry(e.getUuid()));
 		}
 
 		for (Column<?, ?> column : getColumns()) {

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/configuration/infrastructure/RegionsGrid.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/configuration/infrastructure/RegionsGrid.java
@@ -69,9 +69,7 @@ public class RegionsGrid extends FilteredGrid<RegionIndexDto, RegionCriteria> {
 		}
 
 		if (UserProvider.getCurrent().hasUserRight(UserRight.INFRASTRUCTURE_EDIT)) {
-			addEditColumn(e -> {
-				ControllerProvider.getInfrastructureController().editRegion(e.getItem().getUuid());
-			});
+			addEditColumn(e -> ControllerProvider.getInfrastructureController().editRegion(e.getUuid()));
 		}
 
 		for (Column<?, ?> column : getColumns()) {

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/contact/AbstractContactGrid.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/contact/AbstractContactGrid.java
@@ -45,6 +45,7 @@ import de.symeda.sormas.ui.UserProvider;
 import de.symeda.sormas.ui.ViewModelProviders;
 import de.symeda.sormas.ui.utils.DateFormatHelper;
 import de.symeda.sormas.ui.utils.FilteredGrid;
+import de.symeda.sormas.ui.utils.ShowDetailsListener;
 import de.symeda.sormas.ui.utils.UuidRenderer;
 import de.symeda.sormas.ui.utils.ViewConfiguration;
 
@@ -78,11 +79,8 @@ public abstract class AbstractContactGrid<IndexDTO extends ContactIndexDto> exte
 
 		initColumns();
 
-		addItemClickListener(e -> {
-			if ((e.getColumn() != null && ContactIndexDto.UUID.equals(e.getColumn().getId())) || e.getMouseEventDetails().isDoubleClick()) {
-				ControllerProvider.getContactController().navigateToData(e.getItem().getUuid());
-			}
-		});
+		addItemClickListener(
+			new ShowDetailsListener<>(ContactIndexDto.UUID, e -> ControllerProvider.getContactController().navigateToData(e.getUuid())));
 	}
 
 	@SuppressWarnings("unchecked")

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/contact/ContactFollowUpGrid.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/contact/ContactFollowUpGrid.java
@@ -25,6 +25,7 @@ import de.symeda.sormas.ui.ControllerProvider;
 import de.symeda.sormas.ui.utils.CssStyles;
 import de.symeda.sormas.ui.utils.DateFormatHelper;
 import de.symeda.sormas.ui.utils.FilteredGrid;
+import de.symeda.sormas.ui.utils.ShowDetailsListener;
 import de.symeda.sormas.ui.utils.UuidRenderer;
 
 @SuppressWarnings("serial")
@@ -63,11 +64,8 @@ public class ContactFollowUpGrid extends FilteredGrid<ContactFollowUpDto, Contac
 			column.setCaption(I18nProperties.getPrefixCaption(ContactFollowUpDto.I18N_PREFIX, column.getId().toString(), column.getCaption()));
 		}
 
-		addItemClickListener(e -> {
-			if ((e.getColumn() != null && ContactFollowUpDto.UUID.equals(e.getColumn().getId())) || e.getMouseEventDetails().isDoubleClick()) {
-				ControllerProvider.getContactController().navigateToData(e.getItem().getUuid());
-			}
-		});
+		addItemClickListener(
+			new ShowDetailsListener<>(ContactFollowUpDto.UUID, e -> ControllerProvider.getContactController().navigateToData(e.getUuid())));
 	}
 
 	public void setVisitColumns(Date referenceDate, int interval, ContactCriteria criteria) {

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/contact/ContactGridDetailed.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/contact/ContactGridDetailed.java
@@ -11,6 +11,7 @@ import de.symeda.sormas.api.contact.ContactCriteria;
 import de.symeda.sormas.api.contact.ContactIndexDetailedDto;
 import de.symeda.sormas.api.utils.SortProperty;
 import de.symeda.sormas.ui.ControllerProvider;
+import de.symeda.sormas.ui.utils.ShowDetailsListener;
 import de.symeda.sormas.ui.utils.UuidRenderer;
 
 public class ContactGridDetailed extends AbstractContactGrid<ContactIndexDetailedDto> {
@@ -67,14 +68,11 @@ public class ContactGridDetailed extends AbstractContactGrid<ContactIndexDetaile
 			.setRenderer(entry -> entry != null ? entry.getUuid() : null, new UuidRenderer());
 		getColumn(ContactIndexDetailedDto.REPORTING_USER).setWidth(150);
 
-		addItemClickListener(e -> {
-			if ((e.getColumn() != null && ContactIndexDetailedDto.CAZE.equals(e.getColumn().getId()))) {
-				CaseReferenceDto caze = e.getItem().getCaze();
-
-				if (caze != null && caze.getUuid() != null) {
-					ControllerProvider.getCaseController().navigateToCase(caze.getUuid());
-				}
+		addItemClickListener(new ShowDetailsListener<>(ContactIndexDetailedDto.CAZE, false, e -> {
+			CaseReferenceDto caze = e.getCaze();
+			if (caze != null && caze.getUuid() != null) {
+				ControllerProvider.getCaseController().navigateToCase(caze.getUuid());
 			}
-		});
+		}));
 	}
 }

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/events/EventGrid.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/events/EventGrid.java
@@ -39,6 +39,7 @@ import de.symeda.sormas.ui.ControllerProvider;
 import de.symeda.sormas.ui.UserProvider;
 import de.symeda.sormas.ui.ViewModelProviders;
 import de.symeda.sormas.ui.utils.FilteredGrid;
+import de.symeda.sormas.ui.utils.ShowDetailsListener;
 import de.symeda.sormas.ui.utils.UuidRenderer;
 import de.symeda.sormas.ui.utils.ViewConfiguration;
 
@@ -105,11 +106,7 @@ public class EventGrid extends FilteredGrid<EventIndexDto, EventCriteria> {
 			column.setCaption(I18nProperties.getPrefixCaption(EventIndexDto.I18N_PREFIX, column.getId().toString(), column.getCaption()));
 		}
 
-		addItemClickListener(e -> {
-			if ((e.getColumn() != null && EventIndexDto.UUID.equals(e.getColumn().getId())) || e.getMouseEventDetails().isDoubleClick()) {
-				ControllerProvider.getEventController().navigateToData(e.getItem().getUuid());
-			}
-		});
+		addItemClickListener(new ShowDetailsListener<>(EventIndexDto.UUID, e -> ControllerProvider.getEventController().navigateToData(e.getUuid())));
 	}
 
 	public void reload() {

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/events/EventParticipantsGrid.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/events/EventParticipantsGrid.java
@@ -31,6 +31,7 @@ import de.symeda.sormas.ui.ControllerProvider;
 import de.symeda.sormas.ui.UserProvider;
 import de.symeda.sormas.ui.utils.CaseUuidRenderer;
 import de.symeda.sormas.ui.utils.FilteredGrid;
+import de.symeda.sormas.ui.utils.ShowDetailsListener;
 import de.symeda.sormas.ui.utils.UuidRenderer;
 
 @SuppressWarnings("serial")
@@ -83,21 +84,18 @@ public class EventParticipantsGrid extends FilteredGrid<EventParticipantIndexDto
 			column.setCaption(I18nProperties.getPrefixCaption(EventParticipantIndexDto.I18N_PREFIX, column.getId().toString(), column.getCaption()));
 		}
 
-		addItemClickListener(e -> {
-			if (e.getColumn() != null && CASE_ID.equals(e.getColumn().getId())) {
-				if (e.getItem().getCaseUuid() != null) {
-					ControllerProvider.getCaseController().navigateToCase(e.getItem().getCaseUuid());
-				} else {
-					EventParticipantDto eventParticipant =
-						FacadeProvider.getEventParticipantFacade().getEventParticipantByUuid(e.getItem().getUuid());
-					ControllerProvider.getCaseController().createFromEventParticipant(eventParticipant);
-				}
-			} else if ((e.getColumn() != null && EventParticipantIndexDto.UUID.equals(e.getColumn().getId()))
-				|| e.getMouseEventDetails().isDoubleClick()) {
-				ControllerProvider.getEventParticipantController().navigateToData(e.getItem().getUuid());
-
+		addItemClickListener(new ShowDetailsListener<>(CASE_ID, false, e -> {
+			if (e.getCaseUuid() != null) {
+				ControllerProvider.getCaseController().navigateToCase(e.getCaseUuid());
+			} else {
+				EventParticipantDto eventParticipant = FacadeProvider.getEventParticipantFacade().getEventParticipantByUuid(e.getUuid());
+				ControllerProvider.getCaseController().createFromEventParticipant(eventParticipant);
 			}
-		});
+		}));
+		addItemClickListener(
+			new ShowDetailsListener<>(
+				EventParticipantIndexDto.UUID,
+				e -> ControllerProvider.getEventParticipantController().navigateToData(e.getUuid())));
 	}
 
 	public void reload() {

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/samples/SampleGrid.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/samples/SampleGrid.java
@@ -66,7 +66,7 @@ public class SampleGrid extends FilteredGrid<SampleIndexDto, SampleCriteria> {
 			setCriteria(criteria);
 		}
 
-		addEditColumn(e -> ControllerProvider.getSampleController().navigateToData(e.getItem().getUuid()));
+		addEditColumn(e -> ControllerProvider.getSampleController().navigateToData(e.getUuid()));
 
 		Column<SampleIndexDto, String> diseaseShortColumn =
 			addColumn(sample -> DiseaseHelper.toString(sample.getDisease(), sample.getDiseaseDetails()));

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/task/TaskGrid.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/task/TaskGrid.java
@@ -23,8 +23,6 @@ import java.util.stream.Collectors;
 import com.vaadin.data.provider.DataProvider;
 import com.vaadin.data.provider.ListDataProvider;
 import com.vaadin.shared.data.sort.SortDirection;
-import com.vaadin.ui.Grid;
-import com.vaadin.ui.components.grid.ItemClickListener;
 import com.vaadin.ui.renderers.DateRenderer;
 import com.vaadin.ui.renderers.HtmlRenderer;
 
@@ -46,10 +44,11 @@ import de.symeda.sormas.ui.utils.CssStyles;
 import de.symeda.sormas.ui.utils.FilteredGrid;
 import de.symeda.sormas.ui.utils.ReferenceDtoHtmlProvider;
 import de.symeda.sormas.ui.utils.ShortStringRenderer;
+import de.symeda.sormas.ui.utils.ShowDetailsListener;
 import de.symeda.sormas.ui.utils.ViewConfiguration;
 
 @SuppressWarnings("serial")
-public class TaskGrid extends FilteredGrid<TaskIndexDto, TaskCriteria> implements ItemClickListener<TaskIndexDto> {
+public class TaskGrid extends FilteredGrid<TaskIndexDto, TaskCriteria> {
 
 	@SuppressWarnings("unchecked")
 	public TaskGrid(TaskCriteria criteria) {
@@ -67,7 +66,7 @@ public class TaskGrid extends FilteredGrid<TaskIndexDto, TaskCriteria> implement
 			setCriteria(criteria);
 		}
 
-		addEditColumn(e -> ControllerProvider.getTaskController().edit(e.getItem(), this::reload));
+		addEditColumn(e -> ControllerProvider.getTaskController().edit(e, this::reload));
 
 		setStyleGenerator(item -> {
 			if (item != null && item.getTaskStatus() != null) {
@@ -152,7 +151,7 @@ public class TaskGrid extends FilteredGrid<TaskIndexDto, TaskCriteria> implement
 			column.setCaption(I18nProperties.getPrefixCaption(TaskIndexDto.I18N_PREFIX, column.getId().toString(), column.getCaption()));
 		}
 
-		addItemClickListener(this);
+		addItemClickListener(new ShowDetailsListener<>(TaskIndexDto.CONTEXT_REFERENCE, false, e -> navigateToData(e)));
 	}
 
 	public void reload() {
@@ -163,29 +162,22 @@ public class TaskGrid extends FilteredGrid<TaskIndexDto, TaskCriteria> implement
 		getDataProvider().refreshAll();
 	}
 
-	@Override
-	public void itemClick(Grid.ItemClick<TaskIndexDto> event) {
-		if (event.getColumn() == null) {
-			return;
-		}
+	private void navigateToData(TaskIndexDto task) {
 
-		TaskIndexDto task = event.getItem();
-		if (TaskIndexDto.CONTEXT_REFERENCE.equals(event.getColumn().getId())) {
-			switch (task.getTaskContext()) {
-			case CASE:
-				ControllerProvider.getCaseController().navigateToCase(task.getCaze().getUuid());
-				return;
-			case CONTACT:
-				ControllerProvider.getContactController().navigateToData(task.getContact().getUuid());
-				return;
-			case EVENT:
-				ControllerProvider.getEventController().navigateToData(task.getEvent().getUuid());
-				return;
-			case GENERAL:
-				return;
-			default:
-				throw new IndexOutOfBoundsException(task.getTaskContext().toString());
-			}
+		switch (task.getTaskContext()) {
+		case CASE:
+			ControllerProvider.getCaseController().navigateToCase(task.getCaze().getUuid());
+			return;
+		case CONTACT:
+			ControllerProvider.getContactController().navigateToData(task.getContact().getUuid());
+			return;
+		case EVENT:
+			ControllerProvider.getEventController().navigateToData(task.getEvent().getUuid());
+			return;
+		case GENERAL:
+			return;
+		default:
+			throw new IndexOutOfBoundsException(task.getTaskContext().toString());
 		}
 	}
 

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/user/UserGrid.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/user/UserGrid.java
@@ -65,7 +65,7 @@ public class UserGrid extends FilteredGrid<UserDto, UserCriteria> {
 			});
 		setDataProvider(dataProvider);
 
-		addEditColumn(e -> ControllerProvider.getUserController().edit(e.getItem()));
+		addEditColumn(e -> ControllerProvider.getUserController().edit(e));
 
 		setColumns(
 			EDIT_BTN_ID,

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/FilteredGrid.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/FilteredGrid.java
@@ -67,16 +67,13 @@ public class FilteredGrid<T, C extends BaseCriteria> extends Grid<T> {
 		return getDataProvider().size(new Query<>());
 	}
 
-	protected void addEditColumn(Consumer<ItemClick<T>> handler) {
+	protected void addEditColumn(Consumer<T> handler) {
+
 		Column<T, String> editColumn = addColumn(entry -> VaadinIcons.EDIT.getHtml(), new HtmlRenderer());
 		editColumn.setId(EDIT_BTN_ID);
 		editColumn.setSortable(false);
 		editColumn.setWidth(20);
 
-		addItemClickListener(e -> {
-			if (e.getColumn() != null && (EDIT_BTN_ID.equals(e.getColumn().getId()) || e.getMouseEventDetails().isDoubleClick())) {
-				handler.accept(e);
-			}
-		});
+		addItemClickListener(new ShowDetailsListener<>(EDIT_BTN_ID, e -> handler.accept(e)));
 	}
 }

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/ShowDetailsListener.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/ShowDetailsListener.java
@@ -1,0 +1,91 @@
+package de.symeda.sormas.ui.utils;
+
+import java.util.function.Consumer;
+
+import com.vaadin.ui.Grid.ItemClick;
+import com.vaadin.ui.components.grid.ItemClickListener;
+
+/**
+ * Opens item details when an item is correctly selected by respective {@code detailsColumn} or by double-click.
+ * 
+ * @param <T>
+ *            data class of the grid.
+ */
+public class ShowDetailsListener<T> implements ItemClickListener<T> {
+
+	private static final long serialVersionUID = 6288304912712800245L;
+
+	private final String detailsColumnId;
+	private final boolean showOnDoubleClick;
+	private final Consumer<T> itemHandler;
+
+	/**
+	 * {@code showOnDoubleClick=true}
+	 * 
+	 * @param detailsColumnId
+	 *            Column to click when to open the item details.
+	 * @param itemHandler
+	 *            Called to show the details of the selected item.
+	 */
+	public ShowDetailsListener(String detailsColumnId, Consumer<T> itemHandler) {
+
+		this(detailsColumnId, true, itemHandler);
+	}
+
+	/**
+	 * @param detailsColumnId
+	 *            Column to click when to open the item details.
+	 * @param showOnDoubleClick
+	 *            {@code true} opens the details when clicking on any column on an item.
+	 * @param itemHandler
+	 *            Called to show the details of the selected item.
+	 */
+	public ShowDetailsListener(String detailsColumnId, boolean showOnDoubleClick, Consumer<T> itemHandler) {
+
+		this.detailsColumnId = detailsColumnId;
+		this.showOnDoubleClick = showOnDoubleClick;
+		this.itemHandler = itemHandler;
+	}
+
+	/**
+	 * @return Column to click when to open the item details.
+	 */
+	public String getDetailsColumnId() {
+		return detailsColumnId;
+	}
+
+	/**
+	 * @return {@code true} opens the details when clicking on any column on an item.
+	 */
+	public boolean isShowOnDoubleClick() {
+		return showOnDoubleClick;
+	}
+
+	/**
+	 * @return Called to show the details of the selected item.
+	 */
+	public Consumer<T> getItemHandler() {
+		return itemHandler;
+	}
+
+	@Override
+	public void itemClick(ItemClick<T> event) {
+
+		if ((event.getColumn() != null && (detailsColumnId.equals(event.getColumn().getId()))
+			|| (showOnDoubleClick && event.getMouseEventDetails().isDoubleClick()))) {
+			handleItemClick(event);
+		}
+	}
+
+	/**
+	 * Called by {@link #itemClick(ItemClick)} when an item is correctly selected.<br />
+	 * This method can be overridden to alter or extend the behavior.
+	 * 
+	 * @param event
+	 *            source event.
+	 */
+	protected void handleItemClick(ItemClick<T> event) {
+
+		itemHandler.accept(event.getItem());
+	}
+}

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/ShowDetailsListener.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/ShowDetailsListener.java
@@ -71,8 +71,9 @@ public class ShowDetailsListener<T> implements ItemClickListener<T> {
 	@Override
 	public void itemClick(ItemClick<T> event) {
 
-		if ((event.getColumn() != null && (detailsColumnId.equals(event.getColumn().getId()))
-			|| (showOnDoubleClick && event.getMouseEventDetails().isDoubleClick()))) {
+		if (event.getItem() != null
+			&& ((event.getColumn() != null && (detailsColumnId.equals(event.getColumn().getId()))
+				|| (showOnDoubleClick && event.getMouseEventDetails().isDoubleClick())))) {
 			handleItemClick(event);
 		}
 	}
@@ -82,7 +83,7 @@ public class ShowDetailsListener<T> implements ItemClickListener<T> {
 	 * This method can be overridden to alter or extend the behavior.
 	 * 
 	 * @param event
-	 *            source event.
+	 *            source event (only called when {@link ItemClick#getItem()} {@code != null}).
 	 */
 	protected void handleItemClick(ItemClick<T> event) {
 

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/visit/VisitGrid.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/visit/VisitGrid.java
@@ -54,7 +54,7 @@ public class VisitGrid extends FilteredGrid<VisitIndexDto, VisitCriteria> {
 			setSelectionMode(SelectionMode.NONE);
 		}
 
-		addEditColumn(e -> ControllerProvider.getVisitController().editVisit(e.getItem().getUuid(), getCriteria().getContact(), r -> reload()));
+		addEditColumn(e -> ControllerProvider.getVisitController().editVisit(e.getUuid(), getCriteria().getContact(), r -> reload()));
 
 		setColumns(
 			EDIT_BTN_ID,

--- a/sormas-ui/src/test/java/de/symeda/sormas/ui/utils/ShowDetailsListenerTest.java
+++ b/sormas-ui/src/test/java/de/symeda/sormas/ui/utils/ShowDetailsListenerTest.java
@@ -1,0 +1,63 @@
+package de.symeda.sormas.ui.utils;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.function.Consumer;
+
+import org.junit.Test;
+
+import com.vaadin.shared.MouseEventDetails;
+import com.vaadin.ui.Grid.Column;
+import com.vaadin.ui.Grid.ItemClick;
+
+import de.symeda.sormas.api.contact.ContactIndexDto;
+
+/**
+ * @see ShowDetailsListener
+ */
+public class ShowDetailsListenerTest {
+
+	@Test
+	@SuppressWarnings({
+		"rawtypes",
+		"unchecked" })
+	public void testItemClickDoesNotCallHandlerWhenItemIsNull() {
+
+		Consumer<ContactIndexDto> handler = mock(Consumer.class);
+		String detailsColumnId = ContactIndexDto.UUID;
+		ShowDetailsListener<ContactIndexDto> cut = new ShowDetailsListener<>(detailsColumnId, handler);
+
+		ItemClick<ContactIndexDto> event = mock(ItemClick.class);
+		ContactIndexDto item = mock(ContactIndexDto.class);
+
+		// 1a. ColumnClick
+		Column column = mock(Column.class);
+		when(event.getColumn()).thenReturn(column);
+		when(column.getId()).thenReturn(detailsColumnId);
+		cut.itemClick(event);
+		verify(handler, never()).accept(null);
+
+		// 1b. ColumnClick doing it when item is set
+		when(event.getItem()).thenReturn(item);
+		cut.itemClick(event);
+		verify(handler).accept(item);
+
+		reset(handler, event);
+
+		// 2a. DoubleClick
+		MouseEventDetails mouseEventDetails = mock(MouseEventDetails.class);
+		when(event.getMouseEventDetails()).thenReturn(mouseEventDetails);
+		when(mouseEventDetails.isDoubleClick()).thenReturn(true);
+		cut.itemClick(event);
+		verify(handler, never()).accept(null);
+
+		// 2b. DoubleClick doing it when item is set
+		when(event.getItem()).thenReturn(item);
+		cut.itemClick(event);
+		verify(handler).accept(item);
+	}
+}


### PR DESCRIPTION
I was not able to reproduce the NPE, but refactored all `ItemClickListener`s to the new `ShowDetailsListener` which does not execute the `itemHandler` if `event.getItem() == null`.