### PR TITLE
fix maven warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: java
 jdk:
   - openjdk8
 before_install: cd sormas-base
-install: mvn test -B
+install: mvn test -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn

--- a/sormas-backend/pom.xml
+++ b/sormas-backend/pom.xml
@@ -73,7 +73,7 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.hibernate</groupId>
+			<groupId>org.hibernate.validator</groupId>
 			<artifactId>hibernate-validator</artifactId>
 		</dependency>
 			

--- a/sormas-base/pom.xml
+++ b/sormas-base/pom.xml
@@ -7,10 +7,6 @@
 	<packaging>pom</packaging>
 	<version>1.46.0-SNAPSHOT</version>
 
-	<prerequisites>
-		<maven>3.0</maven>
-	</prerequisites>
-
 	<properties>
 		<slf4j.version>1.7.30</slf4j.version>
 		<logback.version>1.1.7</logback.version>

--- a/sormas-base/pom.xml
+++ b/sormas-base/pom.xml
@@ -70,7 +70,7 @@
 			</dependency>
 
 			<dependency>
-				<groupId>org.hibernate</groupId>
+				<groupId>org.hibernate.validator</groupId>
 				<artifactId>hibernate-validator</artifactId>
 				<version>6.1.5.Final</version>
 				<scope>test</scope>

--- a/sormas-base/pom.xml
+++ b/sormas-base/pom.xml
@@ -545,7 +545,9 @@
 							<hotfixBranchPrefix>hotfix-</hotfixBranchPrefix>
 							<versionTagPrefix>v</versionTagPrefix>
 						</flowInitContext>
+						<!--suppress MavenModelInspection -->
 						<username>${github.sormas.user}</username>
+						<!--suppress MavenModelInspection -->
 						<password>${github.sormas.password}</password>
 						<scmCommentPrefix>[GITFLOW]</scmCommentPrefix>
 						<pushReleases>true</pushReleases>

--- a/sormas-base/pom.xml
+++ b/sormas-base/pom.xml
@@ -28,7 +28,7 @@
 	<dependencyManagement>
 		<dependencies>
 
-			<!-- Baseline for tests, so that in all projects in any case the test 
+			<!-- Baseline for tests, so that in all projects in any case the test
 				libs are available -->
 			<dependency>
 				<groupId>junit</groupId>
@@ -184,25 +184,25 @@
 				<version>${jersey.version}</version>
 				<scope>provided</scope>
 			</dependency>
-			
+
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-core</artifactId>
 				<version>${jackson.version}</version>
 			</dependency>
-			
+
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-databind</artifactId>
 				<version>${jackson.version}</version>
 			</dependency>
-			
+
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-annotations</artifactId>
 				<version>${jackson.version}</version>
 			</dependency>
-			
+
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-module-jaxm-annotations</artifactId>
@@ -214,7 +214,7 @@
 				<artifactId>jackson-module-jaxb-annotations</artifactId>
 				<version>${jackson.version}</version>
 			</dependency>
-			
+
 			<!-- serverlibs -->
 
 			<dependency>
@@ -331,7 +331,7 @@
 				<artifactId>opencsv</artifactId>
 				<version>4.1</version>
 			</dependency>
-			
+
 			<dependency>
 				<groupId>org.jsoup</groupId>
 				<artifactId>jsoup</artifactId>
@@ -616,7 +616,7 @@
 			<name>Open Source Geospatial Foundation Repository</name>
 			<url>https://repo.osgeo.org/repository/release/</url>
 		</repository>
-	</repositories>	
+	</repositories>
 
 	<pluginRepositories>
 		<pluginRepository>

--- a/sormas-base/pom.xml
+++ b/sormas-base/pom.xml
@@ -407,9 +407,10 @@
 
 				<plugin>
 					<artifactId>maven-javadoc-plugin</artifactId>
+					<version>3.2.0</version>
 					<configuration>
 						<!-- Deactivate javadoc validation (active by default since Java 1.8) -->
-						<additionalparam>-Xdoclint:none</additionalparam>
+						<additionalJOption>-Xdoclint:none</additionalJOption>
 					</configuration>
 				</plugin>
 

--- a/sormas-ui/pom.xml
+++ b/sormas-ui/pom.xml
@@ -87,7 +87,7 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.hibernate</groupId>
+			<groupId>org.hibernate.validator</groupId>
 			<artifactId>hibernate-validator</artifactId>
 		</dependency>
 			


### PR DESCRIPTION
Some maven warnings are fixed in this PR
 * [x]  The artifact org.hibernate:hibernate-validator:jar:6.1.5.Final has been relocated to org.hibernate.validator:hibernate-validator:jar:6.1.5.Final
 * [x] maven-javadoc-plugin additionalparam -> additionalJOption 
 * [x] The project uses prerequisites which is only intended for maven-plugin projects
 * [x] suppress MavenModelInspection warnings 
 * [x] formatting
 * [x] make test-log more readable 

fixes #2583