### PR TITLE
make build for openjdk 11 pass

### DIFF
--- a/sormas-base/pom.xml
+++ b/sormas-base/pom.xml
@@ -389,12 +389,16 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.5</version>
 			</plugin>
 
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.1</version>
+				<configuration>
+					<release>11</release>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -482,7 +486,7 @@
 
 				<plugin>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>2.19.1</version>
+					<version>2.22.0</version>
 				</plugin>
 
 				<plugin>


### PR DESCRIPTION
The maven build failed for me locally with `openjdk version "11.0.8" 2020-07-14`, pinning the `jacoco-maven-plugin` to its latest version fixed the issue.

Let's see what Travis says... 