### PR TITLE
[2654] add samplesLink package

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/CaseDataView.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/CaseDataView.java
@@ -32,7 +32,7 @@ import de.symeda.sormas.api.user.UserRight;
 import de.symeda.sormas.ui.ControllerProvider;
 import de.symeda.sormas.ui.UserProvider;
 import de.symeda.sormas.ui.caze.eventLink.EventListComponent;
-import de.symeda.sormas.ui.samples.SampleListComponent;
+import de.symeda.sormas.ui.samples.sampleLink.SampleListComponent;
 import de.symeda.sormas.ui.task.TaskListComponent;
 import de.symeda.sormas.ui.utils.CommitDiscardWrapperComponent;
 import de.symeda.sormas.ui.utils.CssStyles;

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/contact/ContactDataView.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/contact/ContactDataView.java
@@ -41,7 +41,7 @@ import de.symeda.sormas.api.user.UserRight;
 import de.symeda.sormas.ui.ControllerProvider;
 import de.symeda.sormas.ui.UserProvider;
 import de.symeda.sormas.ui.caze.CaseInfoLayout;
-import de.symeda.sormas.ui.samples.SampleListComponent;
+import de.symeda.sormas.ui.samples.sampleLink.SampleListComponent;
 import de.symeda.sormas.ui.task.TaskListComponent;
 import de.symeda.sormas.ui.utils.ButtonHelper;
 import de.symeda.sormas.ui.utils.CommitDiscardWrapperComponent;

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/events/EventParticipantDataView.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/events/EventParticipantDataView.java
@@ -33,7 +33,7 @@ import de.symeda.sormas.api.user.UserRight;
 import de.symeda.sormas.ui.ControllerProvider;
 import de.symeda.sormas.ui.SubMenu;
 import de.symeda.sormas.ui.UserProvider;
-import de.symeda.sormas.ui.samples.SampleListComponent;
+import de.symeda.sormas.ui.samples.sampleLink.SampleListComponent;
 import de.symeda.sormas.ui.utils.AbstractDetailView;
 import de.symeda.sormas.ui.utils.CommitDiscardWrapperComponent;
 import de.symeda.sormas.ui.utils.CssStyles;

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/samples/sampleLink/SampleList.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/samples/sampleLink/SampleList.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  *******************************************************************************/
-package de.symeda.sormas.ui.samples;
+package de.symeda.sormas.ui.samples.sampleLink;
 
 import java.util.List;
 

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/samples/sampleLink/SampleListComponent.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/samples/sampleLink/SampleListComponent.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  *******************************************************************************/
-package de.symeda.sormas.ui.samples;
+package de.symeda.sormas.ui.samples.sampleLink;
 
 import com.vaadin.icons.VaadinIcons;
 import com.vaadin.ui.Alignment;

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/samples/sampleLink/SampleListEntry.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/samples/sampleLink/SampleListEntry.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  *******************************************************************************/
-package de.symeda.sormas.ui.samples;
+package de.symeda.sormas.ui.samples.sampleLink;
 
 import com.vaadin.icons.VaadinIcons;
 import com.vaadin.ui.Alignment;


### PR DESCRIPTION
This is an example for #2654 with the goal to group related files/functionality together. Makes it easier for new contributors to navigate `ui/samples`.