### PR TITLE
[IMIS] fix for issue #2812

### DIFF
--- a/sormas-ui/src/main/webapp/VAADIN/themes/sormas/components/grid.scss
+++ b/sormas-ui/src/main/webapp/VAADIN/themes/sormas/components/grid.scss
@@ -124,6 +124,7 @@ $v-grid-cell-focused-border: none !default;
 	  .v-treegrid-cell {
 	    border-left: none;
 	    border-bottom: none;
+        background-color: #FEFEFE;
       }
       
       .v-grid-column-header-content,


### PR DESCRIPTION
Set fixed background-color for VAADIN grid header cells to in-transparent white