### PR TITLE
[IMIS] #3220 Fix classification-rule HTML formatting, add helper method to unescape specific tags

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/caze/classification/ClassificationHtmlRenderer.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/caze/classification/ClassificationHtmlRenderer.java
@@ -17,8 +17,8 @@
  *******************************************************************************/
 package de.symeda.sormas.api.caze.classification;
 
-import static de.symeda.sormas.api.utils.HtmlHelper.escapeAndUnescapeTags;
-import static de.symeda.sormas.api.utils.HtmlHelper.unescapeTags;
+import static de.symeda.sormas.api.utils.HtmlHelper.escapeAndUnescapeBasicTags;
+import static de.symeda.sormas.api.utils.HtmlHelper.unescapeBasicTags;
 
 import java.util.Date;
 import java.util.List;
@@ -241,7 +241,7 @@ public final class ClassificationHtmlRenderer {
 		for (ClassificationCriteriaDto subCriteria : ((ClassificationCollectiveCriteria) criteria).getSubCriteria()) {
 			if (!(subCriteria instanceof ClassificationCollectiveCriteria) || subCriteria instanceof ClassificationCompactCriteria) {
 				// For non-collective or compact collective criteria, add the description as a list item
-				subCriteriaSb.append("- " + escapeAndUnescapeTags(subCriteria.buildDescription() + "</br>"));
+				subCriteriaSb.append("- " + escapeAndUnescapeBasicTags(subCriteria.buildDescription() + "</br>"));
 			} else if (subCriteria instanceof ClassificationCollectiveCriteria
 				&& !(subCriteria instanceof ClassificationAllOfCriteriaDto)
 				&& !(subCriteria.getClass() == ClassificationXOfCriteriaDto.class)) {
@@ -296,11 +296,11 @@ public final class ClassificationHtmlRenderer {
 	 * Creates a div containing an info text.
 	 */
 	private static String createInfoDiv() {
-		return unescapeTags(StringEscapeUtils.escapeHtml4(I18nProperties.getString(Strings.classificationInfoText)));
+		return unescapeBasicTags(StringEscapeUtils.escapeHtml4(I18nProperties.getString(Strings.classificationInfoText)));
 	}
 
 	private static String createInfoDiv(int requirementsNumber) {
-		return unescapeTags(
+		return unescapeBasicTags(
 			StringEscapeUtils.escapeHtml4(
 				String.format(I18nProperties.getString(Strings.classificationInfoNumberText), DataHelper.parseNumberToString(requirementsNumber))));
 	}
@@ -331,9 +331,10 @@ public final class ClassificationHtmlRenderer {
 
 	/**
 	 * Creates the div for an actual criteria containing its description.
+	 * Specific tags are allowed to be contained in i18n strings and are thus unescaped
 	 */
 	private static String createCriteriaItemDiv(String text) {
-		return unescapeTags(StringEscapeUtils.escapeHtml4(text) + "<br>");
+		return unescapeBasicTags(StringEscapeUtils.escapeHtml4(text) + "<br>");
 	}
 
 	private enum ClassificationCriteriaType {

--- a/sormas-api/src/main/java/de/symeda/sormas/api/caze/classification/ClassificationHtmlRenderer.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/caze/classification/ClassificationHtmlRenderer.java
@@ -134,18 +134,16 @@ public final class ClassificationHtmlRenderer {
 				"  padding: 8px;\r\n" + 
 				"}\r\n" + 
 				".classification-rules .main-criteria.main-criteria-suspect {\r\n" + 
-				"  background: rgba(255, 215, 0, 0.6);\r\n" + 
-				"  margin-bottom: 16px;\r\n" + 
+				"  background: rgba(255, 215, 0, 0.6);\r\n" +
 				"}\r\n" + 
 				".classification-rules .main-criteria.main-criteria-probable {\r\n" + 
-				"  background: rgba(255, 140, 0, 0.6);\r\n" + 
-				"  margin-bottom: 16px;\r\n" + 
+				"  background: rgba(255, 140, 0, 0.6);\r\n" +
 				"}\r\n" + 
 				".classification-rules .main-criteria.main-criteria-confirmed {\r\n" + 
 				"  background: rgba(255, 0, 0, 0.6);\r\n" + 
 				"}\r\n" +
 				".classification-rules .main-criteria.main-criteria-not_a_case {\r\n" + 
-				"  background: rgba(201, 201, 201, 0.6);\r\n" + 
+				"  background: rgba(160, 160, 160, 0.6);\r\n" + 
 				"}\r\n" + 
 				".classification-rules .headline {\r\n" + 
 				"  font-weight: bold;\r\n" + 
@@ -191,6 +189,7 @@ public final class ClassificationHtmlRenderer {
 				html.append(createSuspectHtmlString(diseaseCriteria));
 				html.append(createProbableHtmlString(diseaseCriteria));
 				html.append(createConfirmedHtmlString(diseaseCriteria));
+				html.append(createNotACaseHtmlString(diseaseCriteria));
 			}
 		}
 		html.append("</body></html>");

--- a/sormas-api/src/main/java/de/symeda/sormas/api/caze/classification/ClassificationHtmlRenderer.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/caze/classification/ClassificationHtmlRenderer.java
@@ -17,6 +17,7 @@
  *******************************************************************************/
 package de.symeda.sormas.api.caze.classification;
 
+import static de.symeda.sormas.api.utils.HtmlHelper.escapeAndUnescapeTags;
 import static de.symeda.sormas.api.utils.HtmlHelper.unescapeTags;
 
 import java.util.Date;
@@ -241,7 +242,7 @@ public final class ClassificationHtmlRenderer {
 		for (ClassificationCriteriaDto subCriteria : ((ClassificationCollectiveCriteria) criteria).getSubCriteria()) {
 			if (!(subCriteria instanceof ClassificationCollectiveCriteria) || subCriteria instanceof ClassificationCompactCriteria) {
 				// For non-collective or compact collective criteria, add the description as a list item
-				subCriteriaSb.append("- " + subCriteria.buildDescription() + "</br>");
+				subCriteriaSb.append("- " + escapeAndUnescapeTags(subCriteria.buildDescription() + "</br>"));
 			} else if (subCriteria instanceof ClassificationCollectiveCriteria
 				&& !(subCriteria instanceof ClassificationAllOfCriteriaDto)
 				&& !(subCriteria.getClass() == ClassificationXOfCriteriaDto.class)) {
@@ -296,12 +297,13 @@ public final class ClassificationHtmlRenderer {
 	 * Creates a div containing an info text.
 	 */
 	private static String createInfoDiv() {
-		return StringEscapeUtils.escapeHtml4(I18nProperties.getString(Strings.classificationInfoText)) + "<br/>";
+		return unescapeTags(StringEscapeUtils.escapeHtml4(I18nProperties.getString(Strings.classificationInfoText)));
 	}
 
 	private static String createInfoDiv(int requirementsNumber) {
-		return StringEscapeUtils.escapeHtml4(
-			String.format(I18nProperties.getString(Strings.classificationInfoNumberText), DataHelper.parseNumberToString(requirementsNumber)));
+		return unescapeTags(
+			StringEscapeUtils.escapeHtml4(
+				String.format(I18nProperties.getString(Strings.classificationInfoNumberText), DataHelper.parseNumberToString(requirementsNumber))));
 	}
 
 	/**
@@ -323,7 +325,7 @@ public final class ClassificationHtmlRenderer {
 
 		//@formatter:off
 		return "<div class='sub-criteria'><div class='sub-criteria-content'>"
-				+ StringEscapeUtils.escapeHtml4(content)
+				+ content
 				+ "</div></div>";
 		//@formatter:on
 	}
@@ -332,9 +334,7 @@ public final class ClassificationHtmlRenderer {
 	 * Creates the div for an actual criteria containing its description.
 	 */
 	private static String createCriteriaItemDiv(String text) {
-		text = StringEscapeUtils.escapeHtml4(text) + "<br/>";
-		text = unescapeTags(text);
-		return text;
+		return unescapeTags(StringEscapeUtils.escapeHtml4(text) + "<br>");
 	}
 
 	private enum ClassificationCriteriaType {

--- a/sormas-api/src/main/java/de/symeda/sormas/api/caze/classification/ClassificationHtmlRenderer.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/caze/classification/ClassificationHtmlRenderer.java
@@ -17,10 +17,13 @@
  *******************************************************************************/
 package de.symeda.sormas.api.caze.classification;
 
+import static de.symeda.sormas.api.utils.HtmlHelper.unescapeTags;
+
 import java.util.Date;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import de.symeda.sormas.api.Disease;
 import de.symeda.sormas.api.FacadeProvider;
@@ -31,7 +34,6 @@ import de.symeda.sormas.api.i18n.Strings;
 import de.symeda.sormas.api.utils.DataHelper;
 import de.symeda.sormas.api.utils.DateHelper;
 import de.symeda.sormas.api.utils.InfoProvider;
-import org.apache.commons.text.StringEscapeUtils;
 
 /**
  * Provides methods that create HTML Strings to visualize the automatic classification rules.
@@ -273,7 +275,7 @@ public final class ClassificationHtmlRenderer {
 				+ "<div class='main-criteria main-criteria-"
 				+ StringEscapeUtils.escapeHtml4(criteriaType.toString())
 				+ "'>"
-				+ StringEscapeUtils.escapeHtml4(content)
+				+ content
 				+ "</div></div>";
 		//@formatter:on
 	}
@@ -294,11 +296,12 @@ public final class ClassificationHtmlRenderer {
 	 * Creates a div containing an info text.
 	 */
 	private static String createInfoDiv() {
-		return I18nProperties.getString(Strings.classificationInfoText);
+		return StringEscapeUtils.escapeHtml4(I18nProperties.getString(Strings.classificationInfoText)) + "<br/>";
 	}
 
 	private static String createInfoDiv(int requirementsNumber) {
-		return String.format(I18nProperties.getString(Strings.classificationInfoNumberText), DataHelper.parseNumberToString(requirementsNumber));
+		return StringEscapeUtils.escapeHtml4(
+			String.format(I18nProperties.getString(Strings.classificationInfoNumberText), DataHelper.parseNumberToString(requirementsNumber)));
 	}
 
 	/**
@@ -308,7 +311,7 @@ public final class ClassificationHtmlRenderer {
 
 		//@formatter:off
 		return "<div class='criteria'>"
-				+ StringEscapeUtils.escapeHtml4(content)
+				+ content
 				+ "</div>";
 		//@formatter:on
 	}
@@ -329,7 +332,9 @@ public final class ClassificationHtmlRenderer {
 	 * Creates the div for an actual criteria containing its description.
 	 */
 	private static String createCriteriaItemDiv(String text) {
-		return StringEscapeUtils.escapeHtml4(text) + "<br/>";
+		text = StringEscapeUtils.escapeHtml4(text) + "<br/>";
+		text = unescapeTags(text);
+		return text;
 	}
 
 	private enum ClassificationCriteriaType {

--- a/sormas-api/src/main/java/de/symeda/sormas/api/utils/HtmlHelper.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/utils/HtmlHelper.java
@@ -1,0 +1,13 @@
+package de.symeda.sormas.api.utils;
+
+public class HtmlHelper {
+
+	// unescape tags escaped using 
+	public static String unescapeTags(String escapedString) {
+		String res = escapedString;
+		res.replaceAll("&lt;.b&gt;", "<b>");
+		res.replaceAll("&lt;./b&gt;", "</b>");
+		res.replaceAll("&lt;br.&gt;", "<br/>");
+		return res;
+	}
+}

--- a/sormas-api/src/main/java/de/symeda/sormas/api/utils/HtmlHelper.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/utils/HtmlHelper.java
@@ -1,13 +1,32 @@
 package de.symeda.sormas.api.utils;
 
+import org.apache.commons.text.StringEscapeUtils;
+
 public class HtmlHelper {
 
-	// unescape tags escaped using 
+	// unescape specific tags (<b>,<i>,<br>) escaped using StringEscapeUtils.escapeHtml4(String)
 	public static String unescapeTags(String escapedString) {
 		String res = escapedString;
-		res.replaceAll("&lt;.b&gt;", "<b>");
-		res.replaceAll("&lt;./b&gt;", "</b>");
-		res.replaceAll("&lt;br.&gt;", "<br/>");
+
+		// <b> Tags
+		res = res.replaceAll("&lt;b&gt;", "<b>");
+		res = res.replaceAll("&lt;/b&gt;", "</b>");
+		res = res.replaceAll("&lt;.b&gt;", "<b>");
+		res = res.replaceAll("&lt;./b&gt;", "</b>");
+		// <i> Tags
+		res = res.replaceAll("&lt;i&gt;", "<i>");
+		res = res.replaceAll("&lt;/i&gt;", "</i>");
+		res = res.replaceAll("&lt;.i&gt;", "<i>");
+		res = res.replaceAll("&lt;./i&gt;", "</i>");
+		// <br> Tags
+		res = res.replaceAll("&lt;br.&gt;", "<br>");
+		res = res.replaceAll("&lt;.br&gt;", "<br>");
+
 		return res;
+	}
+
+	// escapes html4 and then unescapes specific tags
+	public static String escapeAndUnescapeTags(String text) {
+		return unescapeTags(StringEscapeUtils.escapeHtml4(text));
 	}
 }

--- a/sormas-api/src/main/java/de/symeda/sormas/api/utils/HtmlHelper.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/utils/HtmlHelper.java
@@ -4,29 +4,32 @@ import org.apache.commons.text.StringEscapeUtils;
 
 public class HtmlHelper {
 
-	// unescape specific tags (<b>,<i>,<br>) escaped using StringEscapeUtils.escapeHtml4(String)
-	public static String unescapeTags(String escapedString) {
+	// unescape specific tags (<b>,<i>,<br>,<li>,<ul>) escaped using StringEscapeUtils.escapeHtml4(String)
+	public static String unescapeBasicTags(String escapedString) {
 		String res = escapedString;
 
 		// <b> Tags
 		res = res.replaceAll("&lt;b&gt;", "<b>");
 		res = res.replaceAll("&lt;/b&gt;", "</b>");
-		res = res.replaceAll("&lt;.b&gt;", "<b>");
-		res = res.replaceAll("&lt;./b&gt;", "</b>");
 		// <i> Tags
 		res = res.replaceAll("&lt;i&gt;", "<i>");
 		res = res.replaceAll("&lt;/i&gt;", "</i>");
-		res = res.replaceAll("&lt;.i&gt;", "<i>");
-		res = res.replaceAll("&lt;./i&gt;", "</i>");
+		// <ul> Tags
+		res = res.replaceAll("&lt;ul&gt;", "<ul>");
+		res = res.replaceAll("&lt;/ul&gt;", "</ul>");
+		// <li> Tags
+		res = res.replaceAll("&lt;li&gt;", "<li>");
+		res = res.replaceAll("&lt;/li&gt;", "</li>");
 		// <br> Tags
-		res = res.replaceAll("&lt;br.&gt;", "<br>");
-		res = res.replaceAll("&lt;.br&gt;", "<br>");
+		res = res.replaceAll("&lt;br&gt;", "<br>");
+		res = res.replaceAll("&lt;/br&gt;", "<br>");
+		res = res.replaceAll("&lt;br/&gt;", "<br>");
 
 		return res;
 	}
 
 	// escapes html4 and then unescapes specific tags
-	public static String escapeAndUnescapeTags(String text) {
-		return unescapeTags(StringEscapeUtils.escapeHtml4(text));
+	public static String escapeAndUnescapeBasicTags(String text) {
+		return unescapeBasicTags(StringEscapeUtils.escapeHtml4(text));
 	}
 }

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/CaseController.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/CaseController.java
@@ -1084,29 +1084,37 @@ public class CaseController {
 		classificationRulesLayout.setMargin(true);
 
 		if (diseaseCriteria != null) {
-			Label suspectContent = new Label();
-			suspectContent.setContentMode(ContentMode.HTML);
-			suspectContent.setWidth(100, Unit.PERCENTAGE);
-			suspectContent.setValue(ClassificationHtmlRenderer.createSuspectHtmlString(diseaseCriteria));
-			classificationRulesLayout.addComponent(suspectContent);
+			if (diseaseCriteria.getSuspectCriteria() != null) {
+				Label suspectContent = new Label();
+				suspectContent.setContentMode(ContentMode.HTML);
+				suspectContent.setWidth(100, Unit.PERCENTAGE);
+				suspectContent.setValue(ClassificationHtmlRenderer.createSuspectHtmlString(diseaseCriteria));
+				classificationRulesLayout.addComponent(suspectContent);
+			}
 
-			Label probableContent = new Label();
-			probableContent.setContentMode(ContentMode.HTML);
-			probableContent.setWidth(100, Unit.PERCENTAGE);
-			probableContent.setValue(ClassificationHtmlRenderer.createProbableHtmlString(diseaseCriteria));
-			classificationRulesLayout.addComponent(probableContent);
+			if (diseaseCriteria.getProbableCriteria() != null) {
+				Label probableContent = new Label();
+				probableContent.setContentMode(ContentMode.HTML);
+				probableContent.setWidth(100, Unit.PERCENTAGE);
+				probableContent.setValue(ClassificationHtmlRenderer.createProbableHtmlString(diseaseCriteria));
+				classificationRulesLayout.addComponent(probableContent);
+			}
 
-			Label confirmedContent = new Label();
-			confirmedContent.setContentMode(ContentMode.HTML);
-			confirmedContent.setWidth(100, Unit.PERCENTAGE);
-			confirmedContent.setValue(ClassificationHtmlRenderer.createConfirmedHtmlString(diseaseCriteria));
-			classificationRulesLayout.addComponent(confirmedContent);
+			if (diseaseCriteria.getConfirmedCriteria() != null) {
+				Label confirmedContent = new Label();
+				confirmedContent.setContentMode(ContentMode.HTML);
+				confirmedContent.setWidth(100, Unit.PERCENTAGE);
+				confirmedContent.setValue(ClassificationHtmlRenderer.createConfirmedHtmlString(diseaseCriteria));
+				classificationRulesLayout.addComponent(confirmedContent);
+			}
 
-			Label notACaseContent = new Label();
-			notACaseContent.setContentMode(ContentMode.HTML);
-			notACaseContent.setWidth(100, Unit.PERCENTAGE);
-			notACaseContent.setValue(ClassificationHtmlRenderer.createNotACaseHtmlString(diseaseCriteria));
-			classificationRulesLayout.addComponent(notACaseContent);
+			if (diseaseCriteria.getNotACaseCriteria() != null) {
+				Label notACaseContent = new Label();
+				notACaseContent.setContentMode(ContentMode.HTML);
+				notACaseContent.setWidth(100, Unit.PERCENTAGE);
+				notACaseContent.setValue(ClassificationHtmlRenderer.createNotACaseHtmlString(diseaseCriteria));
+				classificationRulesLayout.addComponent(notACaseContent);
+			}
 		}
 
 		Window popupWindow = VaadinUiUtil.showPopupWindow(classificationRulesLayout);

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/CaseDataForm.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/CaseDataForm.java
@@ -43,6 +43,7 @@ import com.vaadin.icons.VaadinIcons;
 import com.vaadin.server.ThemeResource;
 import com.vaadin.server.UserError;
 import com.vaadin.ui.Button;
+import com.vaadin.ui.GridLayout;
 import com.vaadin.ui.Image;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.Window;
@@ -866,7 +867,10 @@ public class CaseDataForm extends AbstractEditForm<CaseDataDto> {
 				getField(CaseDataDto.CLASSIFICATION_USER).setVisible(false);
 				Label classifiedBySystemLabel = new Label(I18nProperties.getCaption(Captions.system));
 				classifiedBySystemLabel.setCaption(I18nProperties.getPrefixCaption(CaseDataDto.I18N_PREFIX, CaseDataDto.CLASSIFIED_BY));
-				getContent().addComponent(classifiedBySystemLabel, CLASSIFIED_BY_SYSTEM_LOC);
+				// ensure correct formatting
+				GridLayout tempLayout = new GridLayout();
+				tempLayout.addComponent(classifiedBySystemLabel);
+				getContent().addComponent(tempLayout, CLASSIFIED_BY_SYSTEM_LOC);
 			}
 
 			updateFollowUpStatusComponents();

--- a/sormas-ui/src/main/webapp/VAADIN/themes/sormas/views/classification.scss
+++ b/sormas-ui/src/main/webapp/VAADIN/themes/sormas/views/classification.scss
@@ -11,17 +11,15 @@
 			
 			&.main-criteria-suspect {
 				background: rgba(255, 215, 0, 0.6);
-				margin-bottom: 16px;
 			}
 			&.main-criteria-probable {
 				background: rgba(255, 140, 0, 0.6);
-				margin-bottom: 16px;
 			}
 			&.main-criteria-confirmed {
 				background: rgba(255, 0, 0, 0.6);
 			}
 			&.main-criteria-not_a_case {
-				background: rgba(201, 201, 201, 0.6);
+				background: rgba(160, 160, 160, 0.6);
 			}
 		}
 	


### PR DESCRIPTION
closes #3220 

- classification rules are now formatted correctly
- a new helper method `unescapeBasicTags(String escapedString)` has been added, which will re-enable `<b><i><li><ul><br>` tags in an escaped html-string
- cases classified by System will now show so correctly