### PR TITLE
#3317 Quarantine order download does not reliably start

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/docgeneration/QuarantineOrderLayout.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/docgeneration/QuarantineOrderLayout.java
@@ -137,10 +137,8 @@ public class QuarantineOrderLayout extends VerticalLayout {
 		StreamResource streamResource = new StreamResource((StreamSource) () -> {
 			QuarantineOrderFacade quarantineOrderFacade = FacadeProvider.getQuarantineOrderFacade();
 			try {
-				ByteArrayInputStream byteArrayInputStream =
-					new ByteArrayInputStream(quarantineOrderFacade.getGeneratedDocument(templateFile, caseReferenceDto, readAdditionalVariables()));
-				closeWindow();
-				return byteArrayInputStream;
+				return new ByteArrayInputStream(
+					quarantineOrderFacade.getGeneratedDocument(templateFile, caseReferenceDto, readAdditionalVariables()));
 			} catch (IOException | IllegalArgumentException e) {
 				new Notification("Document generation failed", e.getMessage(), Notification.Type.ERROR_MESSAGE).show(Page.getCurrent());
 				return null;


### PR DESCRIPTION
The download of generated documents does not reliably start.
The problem seems to be a race condition between creating a FileDownloadResource and closing the modal window.
The solution is not to close the modal window automatically.