### PR TITLE
[IMIS] 3360 reference dto required UUID

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/ReferenceDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/ReferenceDto.java
@@ -17,6 +17,8 @@
  *******************************************************************************/
 package de.symeda.sormas.api;
 
+import de.symeda.sormas.api.utils.Required;
+
 import java.io.Serializable;
 
 import org.apache.commons.lang3.ObjectUtils;
@@ -26,6 +28,7 @@ public abstract class ReferenceDto implements Serializable, HasUuid, Comparable<
 
 	public static final String CAPTION = "caption";
 
+	@Required
 	private String uuid;
 	private String caption;
 

--- a/sormas-rest/src/main/java/de/symeda/sormas/rest/swagger/AttributeConverter.java
+++ b/sormas-rest/src/main/java/de/symeda/sormas/rest/swagger/AttributeConverter.java
@@ -1,0 +1,98 @@
+package de.symeda.sormas.rest.swagger;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.symeda.sormas.api.Disease;
+import de.symeda.sormas.api.utils.*;
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverter;
+import io.swagger.v3.core.converter.ModelConverterContext;
+import io.swagger.v3.core.jackson.ModelResolver;
+import io.swagger.v3.oas.models.media.Schema;
+
+import java.lang.annotation.Annotation;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+public class AttributeConverter extends ModelResolver {
+    public static final String XPROP_PREFIX = "x-sormas-";
+    public static final String XPROP_PERSONAL_DATA = XPROP_PREFIX + "personal-data";
+    public static final String XPROP_FOR_COUNTRIES = XPROP_PREFIX + "countries-for";
+    public static final String XPROP_EXCEPT_COUNTRIES = XPROP_PREFIX + "countries-except";
+    public static final String XPROP_DEPENDS_ON = XPROP_PREFIX + "depends-on";
+    public static final String XPROP_DISEASES = XPROP_PREFIX + "diseases";
+    public static final String XPROP_OUTBREAKS = XPROP_PREFIX + "outbreaks";
+    public static final String XPROP_COMPLICATIONS = XPROP_PREFIX + "complications";
+
+    public AttributeConverter(ObjectMapper mapper) {
+        super(mapper);
+    }
+
+    @Override
+    protected void applyBeanValidatorAnnotations(Schema property, Annotation[] annotations, Schema parent) {
+        super.applyBeanValidatorAnnotations(property, annotations, parent);
+        Map<String, Annotation> annos = new HashMap<String, Annotation>();
+        if (annotations != null) {
+            for (Annotation anno : annotations) {
+                annos.put(anno.annotationType().getName(), anno);
+            }
+        }
+        if (parent != null && annos.containsKey("de.symeda.sormas.api.utils.Required")) {
+            addRequiredItem(parent, property.getName());
+        }
+    }
+
+
+    @Override
+    public Schema<?> resolve(AnnotatedType annotatedType, ModelConverterContext modelConverterContext, Iterator<ModelConverter> iterator) {
+        Schema schema = super.resolve(annotatedType, modelConverterContext, iterator);
+
+        //@formatter:off
+        if (schema != null && annotatedType.getCtxAnnotations() != null
+                && annotatedType.isSchemaProperty()) {
+
+            for (Annotation a : annotatedType.getCtxAnnotations()) {
+                if (a.annotationType() == PersonalData.class) {
+                    // Outbreak visibility documentation
+                    schema.addExtension(XPROP_PERSONAL_DATA, true);
+
+                } else if (a.annotationType() == Outbreaks.class) {
+                    // Complications documentation
+                    schema.addExtension(XPROP_OUTBREAKS, true);
+
+                } else if (a.annotationType() == Complication.class) {
+                    // Complications documentation
+                    schema.addExtension(XPROP_COMPLICATIONS, true);
+
+                } else if (a.annotationType() == Diseases.class) {
+                    // Disease association documentation
+                    Disease[] diseases = ((Diseases) a).value();
+                    if (diseases.length > 0) {
+                        schema.addExtension(XPROP_DISEASES, diseases);
+                    }
+
+                } else if (a.annotationType() == DependantOn.class) {
+                    // Field dependency documentation
+                    schema.addExtension(XPROP_DEPENDS_ON, ((DependantOn) a).value());
+
+                } else if (a.annotationType() == HideForCountries.class) {
+                    // Documentation of countries to hide the field from
+                    if (schema.getExtensions() != null) {
+                        schema.getExtensions().remove(XPROP_FOR_COUNTRIES);
+                    }
+                    schema.addExtension(XPROP_EXCEPT_COUNTRIES, ((HideForCountries) a).countries());
+
+                } else if (a.annotationType() == HideForCountriesExcept.class) {
+                    // Documentation of countries to show field for
+                    if (schema.getExtensions() == null || !schema.getExtensions().containsKey(XPROP_EXCEPT_COUNTRIES)) {
+                        schema.addExtension(XPROP_FOR_COUNTRIES, ((HideForCountriesExcept) a).countries());
+                    }
+                }
+            }
+            //@formatter:on
+        }
+
+        return schema;
+
+    }
+}

--- a/sormas-rest/src/main/java/de/symeda/sormas/rest/swagger/SormasSwaggerExtensions.java
+++ b/sormas-rest/src/main/java/de/symeda/sormas/rest/swagger/SormasSwaggerExtensions.java
@@ -17,127 +17,33 @@
  *******************************************************************************/
 package de.symeda.sormas.rest.swagger;
 
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
-import java.util.Iterator;
-import java.util.List;
-
-import de.symeda.sormas.api.Disease;
-import de.symeda.sormas.api.utils.Complication;
-import de.symeda.sormas.api.utils.DependantOn;
-import de.symeda.sormas.api.utils.Diseases;
-import de.symeda.sormas.api.utils.HideForCountries;
-import de.symeda.sormas.api.utils.HideForCountriesExcept;
-import de.symeda.sormas.api.utils.Outbreaks;
-import de.symeda.sormas.api.utils.PersonalData;
-import de.symeda.sormas.api.utils.Required;
-import io.swagger.v3.core.converter.AnnotatedType;
-import io.swagger.v3.core.converter.ModelConverter;
-import io.swagger.v3.core.converter.ModelConverterContext;
 import io.swagger.v3.jaxrs2.ext.AbstractOpenAPIExtension;
 import io.swagger.v3.jaxrs2.ext.OpenAPIExtension;
 import io.swagger.v3.oas.models.Operation;
-import io.swagger.v3.oas.models.media.Schema;
+
+import java.lang.reflect.Method;
+import java.util.Iterator;
 
 /**
  * Provides Swagger documentation support for SORMAS' custom annotations.
- *
- * @author Jan-Niklas Brandes
  */
-public class SormasSwaggerExtensions extends AbstractOpenAPIExtension implements ModelConverter {
+public class SormasSwaggerExtensions extends AbstractOpenAPIExtension {
 
-	public static final String XPROP_PREFIX = "x-sormas-";
-	public static final String XPROP_PERSONAL_DATA = XPROP_PREFIX + "personal-data";
-	public static final String XPROP_FOR_COUNTRIES = XPROP_PREFIX + "countries-for";
-	public static final String XPROP_EXCEPT_COUNTRIES = XPROP_PREFIX + "countries-except";
-	public static final String XPROP_DEPENDS_ON = XPROP_PREFIX + "depends-on";
-	public static final String XPROP_DISEASES = XPROP_PREFIX + "diseases";
-	public static final String XPROP_OUTBREAKS = XPROP_PREFIX + "outbreaks";
-	public static final String XPROP_COMPLICATIONS = XPROP_PREFIX + "complications";
+    @Override
+    public void decorateOperation(Operation operation, Method method, Iterator<OpenAPIExtension> chain) {
+        super.decorateOperation(operation, method, chain);
 
-	@Override
-	public void decorateOperation(Operation operation, Method method, Iterator<OpenAPIExtension> chain) {
-		super.decorateOperation(operation, method, chain);
+        if (operation.getTags() == null || operation.getTags().size() == 0) {
+            // Add name of the declaring controller as tag for operation grouping
+            operation.addTagsItem(this.getControllerLabel(method.getDeclaringClass()));
+        }
+    }
 
-		if (operation.getTags() == null || operation.getTags().size() == 0) {
-			// Add name of the declaring controller as tag for operation grouping
-			operation.addTagsItem(this.getControllerLabel(method.getDeclaringClass()));
-		}
-	}
 
-	@Override
-	public Schema<?> resolve(AnnotatedType annotatedType, ModelConverterContext modelConverterContext, Iterator<ModelConverter> iterator) {
-
-		if (!iterator.hasNext()) {
-			return null;
-		} else {
-			ModelConverter next = iterator.next();
-			Schema<?> schema = next.resolve(annotatedType, modelConverterContext, iterator);
-
-			//@formatter:off
-			if (schema != null && annotatedType.getCtxAnnotations() != null
-				&& annotatedType.isSchemaProperty()) {
-
-				for (Annotation a : annotatedType.getCtxAnnotations()) {
-					if (a.annotationType() == Required.class) {
-						// Required field documentation
-						String propName = annotatedType.getPropertyName();
-						List<String> currRequired = annotatedType.getParent().getRequired();
-
-						if (currRequired == null || currRequired.stream()
-							.noneMatch((String prop) -> prop.equals(propName))) {
-
-							annotatedType.getParent().addRequiredItem(propName);
-						}
-
-					} else if (a.annotationType() == PersonalData.class) {
-						// Outbreak visibility documentation
-						schema.addExtension(XPROP_PERSONAL_DATA, true);
-
-					} else if (a.annotationType() == Outbreaks.class) {
-						// Complications documentation
-						schema.addExtension(XPROP_OUTBREAKS, true);
-
-					} else if (a.annotationType() == Complication.class) {
-						// Complications documentation
-						schema.addExtension(XPROP_COMPLICATIONS, true);
-
-					} else if (a.annotationType() == Diseases.class) {
-						// Disease association documentation
-						Disease[] diseases = ((Diseases) a).value();
-						if (diseases.length > 0) {
-							schema.addExtension(XPROP_DISEASES, diseases);
-						}
-
-					} else if (a.annotationType() == DependantOn.class) {
-						// Field dependency documentation
-						schema.addExtension(XPROP_DEPENDS_ON, ((DependantOn) a).value());
-
-					} else if (a.annotationType() == HideForCountries.class) {
-						// Documentation of countries to hide the field from
-						if (schema.getExtensions() != null) {
-							schema.getExtensions().remove(XPROP_FOR_COUNTRIES);
-						}
-						schema.addExtension(XPROP_EXCEPT_COUNTRIES, ((HideForCountries) a).countries());
-
-					} else if (a.annotationType() == HideForCountriesExcept.class) {
-						// Documentation of countries to show field for
-						if (schema.getExtensions() == null || !schema.getExtensions().containsKey(XPROP_EXCEPT_COUNTRIES)) {
-							schema.addExtension(XPROP_FOR_COUNTRIES, ((HideForCountriesExcept) a).countries());
-						}
-					}
-				}
-				//@formatter:on
-			}
-
-			return schema;
-		}
-	}
-
-	/**
-	 * Generate a user-friendly name label for the given controller class.
-	 */
-	public String getControllerLabel(Class<?> clazz) {
-		return clazz.getSimpleName().replaceAll("Resource$", "").replaceAll("(?<!^)[A-Z]", " $0") + " Controller";
-	}
+    /**
+     * Generate a user-friendly name label for the given controller class.
+     */
+    public String getControllerLabel(Class<?> clazz) {
+        return clazz.getSimpleName().replaceAll("Resource$", "").replaceAll("(?<!^)[A-Z]", " $0") + " Controller";
+    }
 }

--- a/sormas-rest/src/main/java/de/symeda/sormas/rest/swagger/SwaggerConfig.java
+++ b/sormas-rest/src/main/java/de/symeda/sormas/rest/swagger/SwaggerConfig.java
@@ -17,69 +17,59 @@
  *******************************************************************************/
 package de.symeda.sormas.rest.swagger;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-
 import io.swagger.v3.core.converter.ModelConverters;
 import io.swagger.v3.core.jackson.ModelResolver;
 import io.swagger.v3.core.util.Json;
-import io.swagger.v3.jaxrs2.ext.OpenAPIExtension;
 import io.swagger.v3.jaxrs2.ext.OpenAPIExtensions;
 
 /**
  * SORMAS Swagger Configuration.
  * This class is the preferred spot for specifying API-related Swagger metadata via Swagger annotations,
  * as well as for Swagger extension registration.
- *
- * @author Jan-Niklas Brandes
  */
 public class SwaggerConfig {
 
-	static {
-		// Real initialization routine
-		registerExtensions();
+    static {
+        // Real initialization routine
+        registerExtensions();
 
-		// Swagger uses a Jackson ObjectMapper in the process of type resolution; there are some
-		// settings for that ObjectMapper and Swagger-related classes we need to adjust for the
-		// Swagger Specification to be correct
-		tweakConfig(Json.mapper());
-	}
+        // Swagger uses a Jackson ObjectMapper in the process of type resolution; there are some
+        // settings for that ObjectMapper and Swagger-related classes we need to adjust for the
+        // Swagger Specification to be correct
+        tweakConfig(Json.mapper());
+    }
 
-	public static void init() {
-		// Solemnly there for triggering the static initializer
-	}
+    public static void init() {
+        // Solemnly there for triggering the static initializer
+    }
 
-	/**
-	 * Register Swagger Generator Extensions
-	 */
-	private static void registerExtensions() {
+    /**
+     * Register Swagger Generator Extensions
+     */
+    private static void registerExtensions() {
+        // rewrite controller strings
+        OpenAPIExtensions.getExtensions().add(new SormasSwaggerExtensions());
 
-		SormasSwaggerExtensions sormasSwaggerExtension = new SormasSwaggerExtensions();
+        // include annotations in openAPI specs
+        ModelConverters.getInstance().addConverter(new AttributeConverter(Json.mapper()));
+    }
 
-		// Operations-Level extensions
-		List<OpenAPIExtension> swaggerExtensions = new ArrayList<>(OpenAPIExtensions.getExtensions());
-		swaggerExtensions.add(sormasSwaggerExtension);
+    /**
+     * Set configuration parameters for Swagger-related classes.
+     *
+     * @param swaggerObjectMapper ObjectMapper instance used by Swagger
+     */
+    private static void tweakConfig(ObjectMapper swaggerObjectMapper) {
+        // Do not use toString() on enum values
+        swaggerObjectMapper.disable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
 
-		OpenAPIExtensions.setExtensions(swaggerExtensions);
+        // Specify enumerations as separate schemas, instead of incorporating them into the
+        // schemas for every field/property of their type
+        ModelResolver.enumsAsRef = true;
+    }
 
-		// Schema-Level extensions
-		ModelConverters modelConverters = ModelConverters.getInstance();
-		modelConverters.addConverter(sormasSwaggerExtension);
-	}
-
-	/**
-	 * Set configuration parameters for Swagger-related classes.
-	 * @param swaggerObjectMapper ObjectMapper instance used by Swagger
-	 */
-	private static void tweakConfig(ObjectMapper swaggerObjectMapper) {
-		// Do not use toString() on enum values
-		swaggerObjectMapper.disable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
-
-		// Specify enumerations as separate schemas, instead of incorporating them into the
-		// schemas for every field/property of their type
-		ModelResolver.enumsAsRef = true;
-	}
 }
+
+

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/action/ActionEditForm.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/action/ActionEditForm.java
@@ -24,7 +24,6 @@ import static de.symeda.sormas.ui.utils.LayoutUtil.loc;
 import static de.symeda.sormas.ui.utils.LayoutUtil.locs;
 
 import com.vaadin.v7.ui.ComboBox;
-import com.vaadin.v7.ui.Field;
 import com.vaadin.v7.ui.Label;
 import com.vaadin.v7.ui.RichTextArea;
 import com.vaadin.v7.ui.TextField;
@@ -162,18 +161,16 @@ public class ActionEditForm extends AbstractEditForm<ActionDto> {
 	}
 
 	private void updateByActionContext() {
-		NullableOptionGroup field = (NullableOptionGroup) getFieldGroup().getField(ActionDto.ACTION_CONTEXT);
-		ActionContext actionContext = (ActionContext) field.getNullableValue();
+		Object fieldValueActionContext = getFieldGroup().getField(ActionDto.ACTION_CONTEXT).getValue();
+		ActionContext actionContext = fieldValueActionContext == null ? null : (ActionContext) fieldValueActionContext;
 
 		// context reference depending on action context
 		// ready for adding new context
 		ComboBox eventField = (ComboBox) getFieldGroup().getField(ActionDto.EVENT);
 		if (actionContext != null) {
-			switch (actionContext) {
-			case EVENT:
+			if (actionContext == ActionContext.EVENT) {
 				FieldHelper.setFirstVisibleClearOthers(eventField);
 				FieldHelper.setFirstRequired(eventField);
-				break;
 			}
 		} else {
 			FieldHelper.setFirstVisibleClearOthers(null, eventField);

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/action/ActionEditForm.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/action/ActionEditForm.java
@@ -24,6 +24,7 @@ import static de.symeda.sormas.ui.utils.LayoutUtil.loc;
 import static de.symeda.sormas.ui.utils.LayoutUtil.locs;
 
 import com.vaadin.v7.ui.ComboBox;
+import com.vaadin.v7.ui.Field;
 import com.vaadin.v7.ui.Label;
 import com.vaadin.v7.ui.RichTextArea;
 import com.vaadin.v7.ui.TextField;
@@ -161,16 +162,18 @@ public class ActionEditForm extends AbstractEditForm<ActionDto> {
 	}
 
 	private void updateByActionContext() {
-		Object fieldValueActionContext = getFieldGroup().getField(ActionDto.ACTION_CONTEXT).getValue();
-		ActionContext actionContext = fieldValueActionContext == null ? null : (ActionContext) fieldValueActionContext;
+		NullableOptionGroup field = (NullableOptionGroup) getFieldGroup().getField(ActionDto.ACTION_CONTEXT);
+		ActionContext actionContext = (ActionContext) field.getNullableValue();
 
 		// context reference depending on action context
 		// ready for adding new context
 		ComboBox eventField = (ComboBox) getFieldGroup().getField(ActionDto.EVENT);
 		if (actionContext != null) {
-			if (actionContext == ActionContext.EVENT) {
+			switch (actionContext) {
+			case EVENT:
 				FieldHelper.setFirstVisibleClearOthers(eventField);
 				FieldHelper.setFirstRequired(eventField);
+				break;
 			}
 		} else {
 			FieldHelper.setFirstVisibleClearOthers(null, eventField);


### PR DESCRIPTION
Ticks partially one box of #3360 
This fix makes the `uuid` fields of all reference DTOs required. -> this makes the `uuid` fields in the openAPI description required -> clients generated from this api spec validate automatically that uuids are set correctly in the request -> this solves (partially) my problem

Please note that this does not add any server side validation, providing empty `uuid` values in references still triggers an internal server error (500) and is not gracefully handled (i.e., 400). This is left as future work, but having this change included in the repo would tremendously help me to debug the API.