### PR TITLE
[IMIS] sticky button panel for long forms (fixes #3377)

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/CommitDiscardWrapperComponent.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/CommitDiscardWrapperComponent.java
@@ -148,6 +148,8 @@ public class CommitDiscardWrapperComponent<C extends Component> extends Vertical
 		buttonsPanel.setComponentAlignment(commitButton, Alignment.BOTTOM_RIGHT);
 		buttonsPanel.setExpandRatio(commitButton, 0);
 
+		addStyleName(CssStyles.STICKY_BOTTOM_BAR);
+
 		addComponent(buttonsPanel);
 		setComponentAlignment(buttonsPanel, Alignment.BOTTOM_RIGHT);
 

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/CssStyles.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/CssStyles.java
@@ -238,6 +238,7 @@ public final class CssStyles {
 	public static final String ROOT_COMPONENT = "root-component";
 	public static final String MAIN_COMPONENT = "main-component";
 	public static final String SIDE_COMPONENT = "side-component";
+	public static final String STICKY_BOTTOM_BAR = "sticky-bottom-bar";
 
 	// Statistics layout
 	public static final String STATISTICS_TITLE_BOX = "title-box";

--- a/sormas-ui/src/main/webapp/VAADIN/themes/sormas/global.scss
+++ b/sormas-ui/src/main/webapp/VAADIN/themes/sormas/global.scss
@@ -322,6 +322,30 @@
     padding-top: 16px;
     z-index: 11;
   }
+  .sticky-bottom-bar > :last-child::after {
+    content: " ";
+    position: absolute;
+    bottom: -7px;
+    left: 50%;
+    margin-left: -12px;
+    border-width: 12px;
+    border-style: solid;
+    border-color: red transparent transparent transparent;
+  }
+  .sticky-bottom-bar > :nth-last-child(2) {
+    position:relative;
+  }
+  .sticky-bottom-bar > :nth-last-child(2)::after {
+    content: " ";
+    position: absolute;
+    bottom: -63px;
+    left: 50%;
+    @include transform(translateX(-50%));
+    width: 29px;
+    height: 19px;
+    background-color: white;
+    z-index:12;
+  }
 
   .spacing-small {
   	.v-spacing {

--- a/sormas-ui/src/main/webapp/VAADIN/themes/sormas/global.scss
+++ b/sormas-ui/src/main/webapp/VAADIN/themes/sormas/global.scss
@@ -314,6 +314,14 @@
     padding: 12px 20px;
     margin-bottom: 24px;
   }
+  .sticky-bottom-bar > :last-child {
+    position: sticky;
+    bottom: 0;
+    @include background-image(linear-gradient(top, transparent, white, 40px, white));
+    padding-bottom: 16px;
+    padding-top: 16px;
+    z-index: 11;
+  }
 
   .spacing-small {
   	.v-spacing {


### PR DESCRIPTION
This fix makes the commit/discard button panel sticky at the bottom for long forms. "Save" and "discard" buttons are always visible now. This has no visible effect for shorter forms.
![image](https://user-images.githubusercontent.com/5616564/98051576-741b2200-1e34-11eb-8eba-3ec30ffb58c0.png)
![image](https://user-images.githubusercontent.com/5616564/98051605-81381100-1e34-11eb-8f59-c9cc60bab15a.png)
