### PR TITLE
Security update of dependency versions

### DIFF
--- a/sormas-backend/pom.xml
+++ b/sormas-backend/pom.xml
@@ -85,6 +85,12 @@
 			<artifactId>freemarker</artifactId>
 		</dependency>
 
+                <!-- https://mvnrepository.com/artifact/org.glassfish.soteria/javax.security.enterprise -->
+                <dependency>
+                    <groupId>org.glassfish.soteria</groupId>
+                    <artifactId>javax.security.enterprise</artifactId>
+                    <version>1.0</version>
+                </dependency>
 
 		<!-- Testing -->
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/importexport/ImportFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/importexport/ImportFacadeEjb.java
@@ -71,7 +71,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.auth0.jwt.internal.org.apache.commons.lang3.text.WordUtils;
+import org.apache.commons.lang3.text.WordUtils;
 import com.opencsv.CSVWriter;
 
 import de.symeda.sormas.api.AgeGroup;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonFacadeEjb.java
@@ -42,7 +42,7 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import javax.validation.constraints.NotNull;
 
-import com.auth0.jwt.internal.org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import de.symeda.sormas.api.Disease;
 import de.symeda.sormas.api.caze.CaseCriteria;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/therapy/PrescriptionService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/therapy/PrescriptionService.java
@@ -15,7 +15,7 @@ import javax.persistence.criteria.JoinType;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
-import com.auth0.jwt.internal.org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import de.symeda.sormas.api.therapy.PrescriptionCriteria;
 import de.symeda.sormas.backend.caze.Case;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/therapy/TreatmentService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/therapy/TreatmentService.java
@@ -15,7 +15,7 @@ import javax.persistence.criteria.JoinType;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
-import com.auth0.jwt.internal.org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import de.symeda.sormas.api.therapy.TreatmentCriteria;
 import de.symeda.sormas.backend.caze.Case;

--- a/sormas-base/pom.xml
+++ b/sormas-base/pom.xml
@@ -9,22 +9,24 @@
 
 	<properties>
 		<slf4j.version>1.7.30</slf4j.version>
-		<logback.version>1.1.7</logback.version>
+		<logback.version>1.2.3</logback.version>
 		<vaadin.version.warning>TODO: Remove bootstrap.js in widgetset</vaadin.version.warning>
-		<vaadin.version>8.11.1</vaadin.version>
+		<vaadin.version>8.12.0</vaadin.version>
 		<vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>
-		<jersey.version>2.29.1</jersey.version>
-		<jackson.version>2.9.8</jackson.version>
-		<swagger.version>2.1.2</swagger.version>
+		<jersey.version>2.30.1</jersey.version>
+		<jackson.version>2.11.3</jackson.version>
+		<swagger.version>2.1.5</swagger.version>
 		<bouncycastle.version>1.66</bouncycastle.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<!-- Versions used for release. Overwrite them in settings.xml for local development with different versions -->
-		<payara.version>5.2020.2</payara.version>
+		<payara.version>5.2020.6</payara.version>
 		<payara.oidc.version>1.1.0</payara.oidc.version>
 		<microprofile.api.version>1.4</microprofile.api.version>
 
-		<keycloak.version>11.0.0</keycloak.version>
+		<keycloak.version>11.0.3</keycloak.version>
+
+                <jetty.version>9.4.35.v20201120</jetty.version>
 
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
@@ -39,42 +41,42 @@
 			<dependency>
 				<groupId>junit</groupId>
 				<artifactId>junit</artifactId>
-				<version>4.12</version>
+				<version>4.13.1</version>
 				<scope>test</scope>
 			</dependency>
 
 			<dependency>
 				<groupId>org.hamcrest</groupId>
 				<artifactId>hamcrest-core</artifactId>
-				<version>1.3</version>
+				<version>2.2</version>
 				<scope>test</scope>
 			</dependency>
 
 			<dependency>
 				<groupId>org.hamcrest</groupId>
 				<artifactId>hamcrest-library</artifactId>
-				<version>1.3</version>
+				<version>2.2</version>
 				<scope>test</scope>
 			</dependency>
 
 			<dependency>
 				<groupId>org.mockito</groupId>
 				<artifactId>mockito-inline</artifactId>
-				<version>3.5.13</version>
+				<version>3.6.28</version>
 				<scope>test</scope>
 			</dependency>
 
 			<dependency>
 				<groupId>org.hibernate</groupId>
 				<artifactId>hibernate-core</artifactId>
-				<version>5.4.18.Final</version>
+				<version>5.4.24.Final</version>
 				<scope>provided</scope>
 			</dependency>
 
 			<dependency>
 				<groupId>org.hibernate.validator</groupId>
 				<artifactId>hibernate-validator</artifactId>
-				<version>6.1.5.Final</version>
+				<version>6.1.6.Final</version>
 				<scope>test</scope>
 			</dependency>
 
@@ -105,14 +107,63 @@
 			<dependency>
 				<groupId>org.apache.geronimo.config</groupId>
 				<artifactId>geronimo-config-impl</artifactId>
-				<version>1.0</version>
+				<version>1.2.2</version>
 				<scope>test</scope>
 			</dependency>
+
+                        <!-- https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-webapp -->
+                        <dependency>
+                            <groupId>org.eclipse.jetty</groupId>
+                            <artifactId>jetty-webapp</artifactId>
+                            <version>${jetty.version}</version>
+                        </dependency>
+
+                        <!-- https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-servlets -->
+                        <dependency>
+                            <groupId>org.eclipse.jetty</groupId>
+                            <artifactId>jetty-servlets</artifactId>
+                            <version>${jetty.version}</version>
+                        </dependency>
+
+                        <!-- https://mvnrepository.com/artifact/org.eclipse.jetty/apache-jsp -->
+                        <dependency>
+                          <groupId>org.eclipse.jetty</groupId>
+                          <artifactId>apache-jsp</artifactId>
+                          <version>${jetty.version}</version>
+                        </dependency>
+
+                        <!-- https://mvnrepository.com/artifact/org.mortbay.jasper/apache-jsp -->
+                        <dependency>
+                            <groupId>org.mortbay.jasper</groupId>
+                            <artifactId>apache-jsp</artifactId>
+                            <version>10.0.0-1-M7</version>
+                        </dependency>
+
+                        <!-- https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-server -->
+                        <dependency>
+                            <groupId>org.eclipse.jetty</groupId>
+                            <artifactId>jetty-server</artifactId>
+                            <version>${jetty.version}</version>
+                        </dependency>
+
+                        <!-- https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-xml -->
+                        <dependency>
+                            <groupId>org.eclipse.jetty</groupId>
+                            <artifactId>jetty-xml</artifactId>
+                            <version>${jetty.version}</version>
+                        </dependency>
+
+                        <!-- https://mvnrepository.com/artifact/org.eclipse.jetty.websocket/websocket-client -->
+                        <dependency>
+                            <groupId>org.eclipse.jetty.websocket</groupId>
+                            <artifactId>websocket-client</artifactId>
+                            <version>${jetty.version}</version>
+                        </dependency>
 
 			<dependency>
 				<groupId>p6spy</groupId>
 				<artifactId>p6spy</artifactId>
-				<version>3.9.0</version>
+				<version>3.9.1</version>
 				<scope>test</scope>
 			</dependency>
 
@@ -131,7 +182,7 @@
 			<dependency>
 				<groupId>org.freemarker</groupId>
 				<artifactId>freemarker</artifactId>
-				<version>2.3.20</version>
+				<version>2.3.30</version>
 			</dependency>
 
 			<!-- Java EE -->
@@ -146,13 +197,13 @@
 				<groupId>javax</groupId>
 				<artifactId>javaee-web-api</artifactId>
 				<scope>provided</scope>
-				<version>8.0</version>
+				<version>8.0.1</version>
 			</dependency>
 			<dependency>
 				<groupId>javax</groupId>
 				<artifactId>javaee-api</artifactId>
 				<scope>provided</scope>
-				<version>8.0</version>
+				<version>8.0.1</version>
 			</dependency>
 			<dependency>
 				<groupId>javax.security.enterprise</groupId>
@@ -160,19 +211,25 @@
 				<version>1.0</version>
 				<scope>provided</scope>
 			</dependency>
+                        <!-- https://mvnrepository.com/artifact/org.glassfish.soteria/javax.security.enterprise -->
+                        <dependency>
+                            <groupId>org.glassfish.soteria</groupId>
+                            <artifactId>javax.security.enterprise</artifactId>
+                            <version>1.0</version>
+                        </dependency>
 
 			<!-- compile dependencies -->
 
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-lang3</artifactId>
-				<version>3.10</version>
+				<version>3.11</version>
 			</dependency>
 
 			<dependency>
 				<groupId>commons-validator</groupId>
 				<artifactId>commons-validator</artifactId>
-				<version>1.6</version>
+				<version>1.7</version>
 			</dependency>
 
 			<dependency>
@@ -184,12 +241,7 @@
 			<dependency>
 				<groupId>joda-time</groupId>
 				<artifactId>joda-time</artifactId>
-				<version>2.9.4</version>
-			</dependency>
-			<dependency>
-				<groupId>com.googlecode.libphonenumber</groupId>
-				<artifactId>libphonenumber</artifactId>
-				<version>8.12.11</version>
+				<version>2.10.8</version>
 			</dependency>
 
 			<dependency>
@@ -214,7 +266,7 @@
 			<dependency>
 				<groupId>com.googlecode.libphonenumber</groupId>
 				<artifactId>libphonenumber</artifactId>
-				<version>8.12.11</version>
+				<version>8.12.13</version>
 				<!-- TODO #3449: avoid scope compile -->
 			</dependency>
 
@@ -384,6 +436,12 @@
 			</dependency>
 
 			<!-- Vaadin -->
+                        <!-- https://mvnrepository.com/artifact/net.sourceforge.htmlunit/htmlunit -->
+                        <dependency>
+                            <groupId>net.sourceforge.htmlunit</groupId>
+                            <artifactId>htmlunit</artifactId>
+                            <version>2.45.0</version>
+                        </dependency>
 
 			<dependency>
 				<groupId>com.vaadin</groupId>
@@ -431,14 +489,14 @@
 			<dependency>
 				<groupId>org.geotools</groupId>
 				<artifactId>gt-shapefile</artifactId>
-				<version>21.4</version>
+				<version>24.1</version>
 			</dependency>
 
 			<!-- Nexmo SMS API -->
 			<dependency>
 				<groupId>com.nexmo</groupId>
 				<artifactId>client</artifactId>
-				<version>3.3.0</version>
+				<version>3.10.0</version>
 			</dependency>
 
 			<!-- OpenCSV -->
@@ -495,6 +553,13 @@
 			<artifactId>mockito-inline</artifactId>
 		</dependency>
 
+                <!-- https://mvnrepository.com/artifact/net.minidev/accessors-smart -->
+                <dependency>
+                    <groupId>net.minidev</groupId>
+                    <artifactId>accessors-smart</artifactId>
+                    <version>1.2</version>
+                </dependency>
+
 	</dependencies>
 
 	<build>
@@ -518,7 +583,24 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
 			</plugin>
-		</plugins>
+<!--
+		        <plugin>
+                            <groupId>org.owasp</groupId>
+                            <artifactId>dependency-check-maven</artifactId>
+                            <version>6.0.2</version>
+                            <configuration>
+                              <failBuildOnCVSS>8</failBuildOnCVSS>
+                            </configuration>
+                            <executions>
+                             <execution>
+                                <goals>
+                                   <goal>check</goal>
+                                </goals>
+                              </execution>
+                            </executions>
+                      </plugin>
+-->
+                </plugins>
 		<pluginManagement>
 			<plugins>
 
@@ -530,7 +612,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-resources-plugin</artifactId>
-					<version>3.1.0</version>
+					<version>3.2.0</version>
 				</plugin>
 
 				<plugin>
@@ -545,7 +627,7 @@
 				<plugin>
 					<groupId>org.jacoco</groupId>
 					<artifactId>jacoco-maven-plugin</artifactId>
-					<version>0.8.5</version>
+					<version>0.8.6</version>
 					<inherited>true</inherited>
 					<executions>
 						<execution>
@@ -590,7 +672,7 @@
 
 				<plugin>
 					<artifactId>maven-failsafe-plugin</artifactId>
-					<version>2.19.1</version>
+					<version>2.22.2</version>
 					<executions>
 						<execution>
 							<id>integration-test</id>
@@ -611,13 +693,13 @@
 
 				<plugin>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>2.22.0</version>
+					<version>2.22.2</version>
 				</plugin>
 
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-ear-plugin</artifactId>
-					<version>3.0.1</version>
+					<version>3.1.0</version>
 					<configuration>
 						<version>7</version>
 						<defaultLibBundleDir>lib</defaultLibBundleDir>
@@ -626,7 +708,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-ejb-plugin</artifactId>
-					<version>3.0.1</version>
+					<version>3.1.0</version>
 					<configuration>
 						<ejbVersion>3.2</ejbVersion>
 					</configuration>
@@ -634,7 +716,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-war-plugin</artifactId>
-					<version>3.2.3</version>
+					<version>3.3.1</version>
 					<configuration>
 						<outputFileNameMapping>@{artifactId}@.@{extension}@</outputFileNameMapping>
 						<failOnMissingWebXml>false</failOnMissingWebXml>
@@ -648,7 +730,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-jar-plugin</artifactId>
-					<version>3.1.1</version>
+					<version>3.2.0</version>
 					<configuration>
 						<archive>
 							<manifest>

--- a/sormas-rest/pom.xml
+++ b/sormas-rest/pom.xml
@@ -42,7 +42,7 @@
 		    <artifactId>jersey-media-json-jackson</artifactId>
 		</dependency>
 
-      	<dependency>
+      	        <dependency>
 			<groupId>javax.security.enterprise</groupId>
 			<artifactId>javax.security.enterprise-api</artifactId>
 		</dependency>

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/security/config/DefaultOpenIdAuthenticationDefinition.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/security/config/DefaultOpenIdAuthenticationDefinition.java
@@ -19,6 +19,7 @@
 package de.symeda.sormas.ui.security.config;
 
 import fish.payara.security.annotations.ClaimsDefinition;
+import fish.payara.security.annotations.LogoutDefinition;
 import fish.payara.security.annotations.OpenIdAuthenticationDefinition;
 import fish.payara.security.annotations.OpenIdProviderMetadata;
 import fish.payara.security.openid.api.DisplayType;
@@ -67,6 +68,11 @@ public class DefaultOpenIdAuthenticationDefinition implements OpenIdAuthenticati
 			}
 
 			@Override
+			public String endSessionEndpoint() {
+				return "";
+			}
+
+			@Override
 			public String jwksURI() {
 				return "";
 			}
@@ -92,6 +98,11 @@ public class DefaultOpenIdAuthenticationDefinition implements OpenIdAuthenticati
 				return OpenIdConstant.GROUPS;
 			}
 		};
+	}
+
+	@Override
+	public LogoutDefinition logout() {
+		return null;
 	}
 
 	@Override

--- a/sormas-widgetset/pom.xml
+++ b/sormas-widgetset/pom.xml
@@ -35,6 +35,12 @@
 		   <groupId>org.vaadin.addons</groupId>
 		   <artifactId>extended-token-field</artifactId>
 		</dependency>
+                <!-- https://mvnrepository.com/artifact/org.eclipse.jetty/apache-jsp -->
+                <dependency>
+                  <groupId>org.eclipse.jetty</groupId>
+                  <artifactId>apache-jsp</artifactId>
+                </dependency>
+
     </dependencies>
 
     <build>


### PR DESCRIPTION
This PR updates most of the project's dependencies to their latest version.

I cloned the project, cd-ed into sormas-base and `mvn clean install` failed.
With this PR the build succeeds.

```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for sormas-base 1.53.0-SNAPSHOT:
[INFO] 
[INFO] sormas-base ........................................ SUCCESS [  0.890 s]
[INFO] sormas-widgetset ................................... SUCCESS [ 42.486 s]
[INFO] sormas-api ......................................... SUCCESS [  8.536 s]
[INFO] sormas-backend ..................................... SUCCESS [06:52 min]
[INFO] sormas-ear ......................................... SUCCESS [  0.881 s]
[INFO] sormas-rest ........................................ SUCCESS [  5.008 s]
[INFO] sormas-ui .......................................... SUCCESS [ 48.215 s]
[INFO] sormas-serverlibs .................................. SUCCESS [  7.814 s]
[INFO] sormas-cargoserver ................................. SUCCESS [  0.279 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  08:47 min
[INFO] Finished at: 2020-11-29T07:32:32+01:00
[INFO] ------------------------------------------------------------------------
```

The build uses 
```
axelnennker@Axels-MBP sormas-base (development) $ mvn -version
Apache Maven 3.6.3 (cecedd343002696d0abb50b32b541b8a6ba2883f)
Maven home: /usr/local/apache-maven-3.6.3
Java version: 15, vendor: Oracle Corporation, runtime: /Library/Java/JavaVirtualMachines/jdk-15.jdk/Contents/Home
Default locale: en_DE, platform encoding: UTF-8
OS name: "mac os x", version: "10.15.7", arch: "x86_64", family: "mac"
axelnennker@Axels-MBP sormas-base (development) $ 
```

I used dependency-check-maven to check for security vulnerabilities and updated the dependencies that were flagged as not secure. The bulk of the added dependencies are due to vulnerable packages.
The last two remaining not-secure packages have no patch yet.

```
		        <plugin>
                            <groupId>org.owasp</groupId>
                            <artifactId>dependency-check-maven</artifactId>
                            <version>6.0.2</version>
                            <configuration>
                              <failBuildOnCVSS>8</failBuildOnCVSS>
                            </configuration>
                            <executions>
                             <execution>
                                <goals>
                                   <goal>check</goal>
                                </goals>
                              </execution>
                            </executions>
                      </plugin>
```

I suggest using dependency-check-maven for all builds but I commented this out because having security vulnerabilities prevents the build to succeed.

Hope this helps
Axel

I did not update Vaadin to the recommended version of 14. Updating it from version 8 to 14 is its own project.
