### PR TITLE
[IMIS] #3653 locale aware DB migration

### DIFF
--- a/sormas-backend/src/main/resources/sql/sormas_schema.sql
+++ b/sormas-backend/src/main/resources/sql/sormas_schema.sql
@@ -5894,4 +5894,13 @@ ALTER TABLE contact ADD column firstcontactdate timestamp;
 
 INSERT INTO schema_version (version_number, comment) VALUES (282, 'Add date of first contact #3408');
 
+-- 2020-12-01 Add locale aware DB migration #3408
+CREATE TABLE schema_version_locale
+(
+  version_number integer NOT NULL PRIMARY KEY,
+  changedate timestamp without time zone NOT NULL DEFAULT now(),
+  comment character varying(255)
+);
+
+INSERT INTO schema_version (version_number, comment) VALUES (283, 'Enable locale aware DB migration #3653');
 -- *** Insert new sql commands BEFORE this line ***

--- a/sormas-backend/src/main/resources/sql/sormas_schema_de.sql
+++ b/sormas-backend/src/main/resources/sql/sormas_schema_de.sql
@@ -1,0 +1,7 @@
+/*CREATE TABLE a_table
+(
+    id integer NOT NULL PRIMARY KEY,
+    a_field integer NOT NULL
+);
+
+INSERT INTO schema_version_locale (version_number, comment) VALUES (1, 'Enable locale aware DB migration #3653');*/


### PR DESCRIPTION
Closes #3653 
Currently a draft as I don't know the best way to include a similar logic in the App. Ideas would be highly appreciated  @MateStrysewske 

---

I reused mainly the existing logic. A new table `schema_version_locale` is introduced to store the version of the migration.

Changing the locale will not rollback the applied changeset as:

1. I don' think this will occur on production systems (Correct me if I'm wrong)
2. This would require significant logic. If we want to have this in general, I think a library like [liquibase](https://www.liquibase.org/) is better suited than doing this by ourselves. 