### PR TITLE
document responsible disclosure process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,8 @@
 
 Please read adhere to the following guidelines when submitting new issues. This allows us to process your request as quickly as possible. Make sure to always use the templates that are automatically provided when creating an issue.
 
+If you want to report a **security issue**, please follow our guideline for [*Responsible Disclosure*](SECURITY.md).
+
 **Important:** Whenever creating a new issue, **please search the repository for similar issues first** to avoid duplicates. You can do this manually or by using the search functionality in the header and limiting your results to the SORMAS repository.
 
 * [Bug Report](#bug-report)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ You can give SORMAS a try on our play server at https://sormas.helmholtz-hzi.de!
 Read through our [*Contributing Readme*](CONTRIBUTING.md) and contact us at sormas@helmholtz-hzi.de or join our [developer chat on Gitter](https://gitter.im/SORMAS-Project) to learn how you can help to drive the development of SORMAS forward and to get development support from our core developers. SORMAS is a community-driven project, and we'd love to have you on board! If you want to contribute to the code, please strictly adhere to the [*Development Environment*](DEVELOPMENT_ENVIRONMENT.md) guide to ensure that everything is set up correctly. Please also make sure that you've read the [*Development Contributing Guidelines*](CONTRIBUTING.md#development-contributing-guidelines) before you start to develop.
 
 #### How Can I Report a Bug or Request a Feature?
-Please [create a new issue](https://github.com/hzi-braunschweig/SORMAS-Project/issues/new/choose) and read the [*Submitting an Issue*](CONTRIBUTING.md#submitting-an-issue) guide for more detailed instructions. We appreciate your help!
+If you want to report a **security issue**, please follow our guideline for [*Responsible Disclosure*](SECURITY.md).  
+For bugs without security implications, change and feature requests, please [create a new issue](https://github.com/hzi-braunschweig/SORMAS-Project/issues/new/choose) and read the [*Submitting an Issue*](CONTRIBUTING.md#submitting-an-issue) guide for more detailed instructions. We appreciate your help!
 
 #### Which Browsers and Android Versions Are Supported?
 SORMAS officially supports and is tested on **Chromium-based browsers** (like Google Chrome) and **Mozilla Firefox**, and all Android versions starting from **Android 7.0** (Nougat). In principle, SORMAS should be usable with all web browsers that are supported by Vaadin 8 (Chrome, Firefox, Safari, Edge, Internet Explorer 11; see https://vaadin.com/faq).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,47 @@
+# Security Policies and Procedures
+
+This document outlines security procedures and general policies for the SORMAS
+project.
+
+  * [Reporting a Security Bug](#reporting-a-security-bug)
+  * [Disclosure Policy](#disclosure-policy)
+  * [Comments on this Policy](#comments-on-this-policy)
+  
+If you want to report a bug which is not security sensible, please [submit an issue](https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/CONTRIBUTING.md#submitting-an-issue). 
+
+## Reporting a Security Bug
+
+Our team and community take all security bugs in SORMAS seriously.
+Thank you for improving the security of SORMAS. We appreciate your efforts and
+responsible disclosure and will make every effort to acknowledge your
+contributions.  
+Unfortunately, SORMAS does not offer a paid bug bounty programme or other forms of compensation.
+
+Report security bugs by emailing at **security@sormas.org**.
+
+We will acknowledge your email within 48 hours, and will send a
+more detailed response within 48 hours indicating the next steps in handling
+your report. After the initial reply to your report, the security team will
+endeavor to keep you informed of the progress towards a fix and full
+announcement, and may ask for additional information or guidance.
+
+Report security bugs in third-party modules to the person or team maintaining
+the module.
+
+
+## Disclosure Policy
+
+When the security team receives a security bug report, they will assign it to a
+primary handler. This person will coordinate the fix and release process,
+involving the following steps:
+
+  * Confirm the problem and determine the affected versions.
+  * Audit code to find any potential similar problems.
+  * Prepare fixes for all releases still under maintenance. These fixes will be
+    released as fast as possible.
+
+## Comments on this Policy
+
+If you have suggestions on how this process could be improved please submit a
+pull request.
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,7 +19,8 @@ Unfortunately, SORMAS does not offer a paid bug bounty programme or other forms 
 
 Report security bugs by emailing at **security@sormas.org**.
 
-We will acknowledge your email and follow up with a response within 10 business days, or explain why a reply may take longer. The response will indicate the next steps in handling your report.
+We will acknowledge your email and follow up with a response within 10 business days, or explain why a reply may take longer. The response will indicate the next steps in handling your report.  
+After the initial reply to your report, the security team will endeavor to keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
 
 Report security bugs in third-party modules to the person or team maintaining
 the module.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,11 +19,7 @@ Unfortunately, SORMAS does not offer a paid bug bounty programme or other forms 
 
 Report security bugs by emailing at **security@sormas.org**.
 
-We will acknowledge your email within 48 hours, and will send a
-more detailed response within 48 hours indicating the next steps in handling
-your report. After the initial reply to your report, the security team will
-endeavor to keep you informed of the progress towards a fix and full
-announcement, and may ask for additional information or guidance.
+We will acknowledge your email and follow up with a response within 10 business days, or explain why a reply may take longer. The response will indicate the next steps in handling your report.
 
 Report security bugs in third-party modules to the person or team maintaining
 the module.


### PR DESCRIPTION
Include a `SECURITY.md` which states how we handle responsible disclosure as discussed internally.
Kudos to @chThie for creating the file!
@markusmann-vg @MartinWahnschaffeSymeda @kwa20 