### PR TITLE
CVE-2020-14389

### DIFF
--- a/sormas-base/pom.xml
+++ b/sormas-base/pom.xml
@@ -31,7 +31,7 @@
 		<vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>
 		<swagger.version>2.1.6</swagger.version>
 		<bouncycastle.version>1.67</bouncycastle.version>
-		<keycloak.version>11.0.3</keycloak.version>
+		<keycloak.version>12.0.0</keycloak.version>
 		<xdocreport.version>2.0.2</xdocreport.version>
 
 		<!-- Attention: Compile dependencies with versions are maintained redundantly in sormas-app/app/build.gradle -->


### PR DESCRIPTION
Signed-off-by: Axel Nennker <axel.nennker@telekom.de>

It was found that Keycloak before version 12.0.0 would permit a user with only view-profile role to manage the resources in the new account console, allowing access and modification of data the user was not intended to have.
https://nvd.nist.gov/vuln/detail/CVE-2020-14389

Closes https://github.com/hzi-braunschweig/SORMAS-Project/issues/3766
