### PR TITLE
remove duplicate code, remove usage of deprecated method, NotNull

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/action/ActionService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/action/ActionService.java
@@ -115,7 +115,7 @@ public class ActionService extends AbstractAdoService<Action> {
 	 */
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Action> actionPath) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends Action> actionPath) {
 
 		// National users can access all actions in the system
 		User currentUser = getCurrentUser();

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/campaign/CampaignService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/campaign/CampaignService.java
@@ -32,7 +32,7 @@ public class CampaignService extends AbstractCoreAdoService<Campaign> {
 	 */
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Campaign> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends Campaign> from) {
 		return null;
 	}
 
@@ -96,22 +96,9 @@ public class CampaignService extends AbstractCoreAdoService<Campaign> {
 		CriteriaQuery<Campaign> cq = cb.createQuery(getElementClass());
 		Root<Campaign> root = cq.from(getElementClass());
 
-		Predicate filter = createUserFilter(cb, cq, root);
-		if (since != null) {
-			Predicate dateFilter = createChangeDateFilter(cb, root, since);
-			if (filter != null) {
-				filter = cb.and(filter, dateFilter);
-			} else {
-				filter = dateFilter;
-			}
-		}
-		if (filter != null) {
-			cq.where(filter);
-		}
-		cq.orderBy(cb.desc(root.get(AbstractDomainObject.CHANGE_DATE)));
+		addSinceFilter(since, cb, cq, root);
 
-		List<Campaign> resultList = em.createQuery(cq).getResultList();
-		return resultList;
+		return em.createQuery(cq).getResultList();
 	}
 
 	public List<Campaign> getAllActive() {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/campaign/data/CampaignFormDataService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/campaign/data/CampaignFormDataService.java
@@ -90,7 +90,7 @@ public class CampaignFormDataService extends AbstractAdoService<CampaignFormData
 	}
 
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, CampaignFormData> campaignPath) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends CampaignFormData> campaignPath) {
 		final User currentUser = getCurrentUser();
 		if (currentUser == null) {
 			return null;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/campaign/diagram/CampaignDiagramDefinitionService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/campaign/diagram/CampaignDiagramDefinitionService.java
@@ -12,7 +12,6 @@ import javax.persistence.criteria.Root;
 import javax.validation.constraints.NotNull;
 
 import de.symeda.sormas.backend.common.AbstractAdoService;
-import de.symeda.sormas.backend.common.AbstractDomainObject;
 
 @Stateless
 @LocalBean
@@ -23,7 +22,7 @@ public class CampaignDiagramDefinitionService extends AbstractAdoService<Campaig
 	}
 
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, CampaignDiagramDefinition> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends CampaignDiagramDefinition> from) {
 		return null;
 	}
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/campaign/form/CampaignFormMetaService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/campaign/form/CampaignFormMetaService.java
@@ -15,7 +15,6 @@ import javax.persistence.criteria.Root;
 import de.symeda.sormas.api.campaign.form.CampaignFormMetaReferenceDto;
 import de.symeda.sormas.backend.campaign.Campaign;
 import de.symeda.sormas.backend.common.AbstractAdoService;
-import de.symeda.sormas.backend.common.AbstractDomainObject;
 import de.symeda.sormas.backend.user.User;
 
 @Stateless
@@ -27,7 +26,7 @@ public class CampaignFormMetaService extends AbstractAdoService<CampaignFormMeta
 	}
 
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, CampaignFormMeta> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends CampaignFormMeta> from) {
 		return null;
 	}
 
@@ -37,19 +36,7 @@ public class CampaignFormMetaService extends AbstractAdoService<CampaignFormMeta
 		CriteriaQuery<CampaignFormMeta> cq = cb.createQuery(getElementClass());
 		Root<CampaignFormMeta> root = cq.from(getElementClass());
 
-		Predicate filter = createUserFilter(cb, cq, root);
-		if (since != null) {
-			Predicate dateFilter = createChangeDateFilter(cb, root, since);
-			if (filter != null) {
-				filter = cb.and(filter, dateFilter);
-			} else {
-				filter = dateFilter;
-			}
-		}
-		if (filter != null) {
-			cq.where(filter);
-		}
-		cq.orderBy(cb.desc(root.get(AbstractDomainObject.CHANGE_DATE)));
+		addSinceFilter(since, cb, cq, root);
 
 		List<CampaignFormMeta> resultList = em.createQuery(cq).getResultList();
 		return resultList;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseService.java
@@ -800,7 +800,7 @@ public class CaseService extends AbstractCoreAdoService<Case> {
 	}
 
 	@Override
-	public Predicate createChangeDateFilter(CriteriaBuilder cb, From<?, Case> casePath, Timestamp date) {
+	public Predicate createChangeDateFilter(CriteriaBuilder cb, From<?, ? extends Case> casePath, Timestamp date) {
 		return createChangeDateFilter(cb, casePath, date, false);
 	}
 
@@ -813,7 +813,7 @@ public class CaseService extends AbstractCoreAdoService<Case> {
 	 *            additional change dates filters for: sample, pathogenTests, patient and location
 	 * @return
 	 */
-	public Predicate createChangeDateFilter(CriteriaBuilder cb, From<?, Case> casePath, Timestamp date, boolean includeExtendedChangeDateFilters) {
+	public Predicate createChangeDateFilter(CriteriaBuilder cb, From<?, ? extends Case> casePath, Timestamp date, boolean includeExtendedChangeDateFilters) {
 
 		Builder<Predicate> filters = Stream.builder();
 
@@ -851,7 +851,7 @@ public class CaseService extends AbstractCoreAdoService<Case> {
 	}
 
 	@SuppressWarnings("rawtypes")
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Case> casePath, CaseUserFilterCriteria userFilterCriteria) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends Case> casePath, CaseUserFilterCriteria userFilterCriteria) {
 
 		User currentUser = getCurrentUser();
 		if (currentUser == null) {
@@ -950,7 +950,7 @@ public class CaseService extends AbstractCoreAdoService<Case> {
 
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Case> casePath) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends Case> casePath) {
 		return createUserFilter(cb, cq, casePath, null);
 	}
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/maternalhistory/MaternalHistoryService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/maternalhistory/MaternalHistoryService.java
@@ -19,7 +19,7 @@ public class MaternalHistoryService extends AbstractAdoService<MaternalHistory> 
 
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, MaternalHistory> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends MaternalHistory> from) {
 		// A user should not directly query for this
 		throw new UnsupportedOperationException();
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/porthealthinfo/PortHealthInfoService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/porthealthinfo/PortHealthInfoService.java
@@ -19,7 +19,7 @@ public class PortHealthInfoService extends AbstractAdoService<PortHealthInfo> {
 
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, PortHealthInfo> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends PortHealthInfo> from) {
 		// A user should not directly query for this
 		throw new UnsupportedOperationException();
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/clinicalcourse/ClinicalCourseService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/clinicalcourse/ClinicalCourseService.java
@@ -19,7 +19,7 @@ public class ClinicalCourseService extends AbstractAdoService<ClinicalCourse> {
 
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ClinicalCourse> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends ClinicalCourse> from) {
 		// A user should not directly query for this
 		throw new UnsupportedOperationException();
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/clinicalcourse/ClinicalVisitService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/clinicalcourse/ClinicalVisitService.java
@@ -136,7 +136,7 @@ public class ClinicalVisitService extends AbstractAdoService<ClinicalVisit> {
 	}
 
 	@Override
-	public Predicate createChangeDateFilter(CriteriaBuilder cb, From<?, ClinicalVisit> path, Timestamp date) {
+	public Predicate createChangeDateFilter(CriteriaBuilder cb, From<?, ? extends ClinicalVisit> path, Timestamp date) {
 
 		Predicate dateFilter = cb.greaterThan(path.get(ClinicalVisit.CHANGE_DATE), date);
 
@@ -148,7 +148,7 @@ public class ClinicalVisitService extends AbstractAdoService<ClinicalVisit> {
 
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ClinicalVisit> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends ClinicalVisit> from) {
 		Join<ClinicalVisit, ClinicalCourse> clinicalCourse = from.join(ClinicalVisit.CLINICAL_COURSE, JoinType.LEFT);
 		return caseService.createUserFilter(cb, cq, clinicalCourse.join(ClinicalCourse.CASE, JoinType.LEFT));
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/clinicalcourse/HealthConditionsService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/clinicalcourse/HealthConditionsService.java
@@ -19,7 +19,7 @@ public class HealthConditionsService extends AbstractAdoService<HealthConditions
 
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, HealthConditions> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends HealthConditions> from) {
 		// A user should not directly query for this
 		throw new UnsupportedOperationException();
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/messaging/ManualMessageLogService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/messaging/ManualMessageLogService.java
@@ -26,7 +26,7 @@ public class ManualMessageLogService extends AbstractAdoService<ManualMessageLog
 	}
 
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ManualMessageLog> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends ManualMessageLog> from) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/contact/ContactService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/contact/ContactService.java
@@ -171,12 +171,12 @@ public class ContactService extends AbstractCoreAdoService<Contact> {
 	}
 
 	@Override
-	public Predicate createChangeDateFilter(CriteriaBuilder cb, From<?, Contact> from, Date date) {
+	public Predicate createChangeDateFilter(CriteriaBuilder cb, From<?, ? extends Contact> from, Date date) {
 		return createChangeDateFilter(cb, from, DateHelper.toTimestampUpper(date));
 	}
 
 	@Override
-	public Predicate createChangeDateFilter(CriteriaBuilder cb, From<?, Contact> from, Timestamp date) {
+	public Predicate createChangeDateFilter(CriteriaBuilder cb, From<?, ? extends Contact> from, Timestamp date) {
 
 		Predicate dateFilter = changeDateFilter(cb, date, from);
 		dateFilter = cb.or(dateFilter, epiDataService.createChangeDateFilter(cb, from.join(Contact.EPI_DATA, JoinType.LEFT), date));
@@ -888,17 +888,17 @@ public class ContactService extends AbstractCoreAdoService<Contact> {
 	 */
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Contact> contactPath) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends Contact> contactPath) {
 		return createUserFilterForJoin(cb, cq, contactPath);
 	}
 
 	@SuppressWarnings("rawtypes")
-	public Predicate createUserFilterForJoin(CriteriaBuilder cb, CriteriaQuery cq, From<?, Contact> contactPath) {
+	public Predicate createUserFilterForJoin(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends Contact> contactPath) {
 		return createUserFilterForJoin(cb, cq, contactPath, null);
 	}
 
 	@SuppressWarnings("rawtypes")
-	public Predicate createUserFilterForJoin(CriteriaBuilder cb, CriteriaQuery cq, From<?, Contact> contactPath, ContactCriteria contactCriteria) {
+	public Predicate createUserFilterForJoin(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends Contact> contactPath, ContactCriteria contactCriteria) {
 
 //		Predicate userFilter = null;
 
@@ -914,7 +914,7 @@ public class ContactService extends AbstractCoreAdoService<Contact> {
 		return filter;
 	}
 
-	public Predicate createUserFilterWithoutCase(CriteriaBuilder cb, CriteriaQuery cq, From<?, Contact> contactPath) {
+	public Predicate createUserFilterWithoutCase(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends Contact> contactPath) {
 		return createUserFilterWithoutCase(cb, cq, contactPath, null);
 	}
 
@@ -922,7 +922,7 @@ public class ContactService extends AbstractCoreAdoService<Contact> {
 	public Predicate createUserFilterWithoutCase(
 		CriteriaBuilder cb,
 		CriteriaQuery cq,
-		From<?, Contact> contactPath,
+		From<?, ? extends Contact> contactPath,
 		ContactCriteria contactCriteria) {
 
 		// National users can access all contacts in the system

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/disease/DiseaseConfigurationService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/disease/DiseaseConfigurationService.java
@@ -43,7 +43,7 @@ public class DiseaseConfigurationService extends AbstractAdoService<DiseaseConfi
 
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, DiseaseConfiguration> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends DiseaseConfiguration> from) {
 		return null;
 	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/document/DocumentService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/document/DocumentService.java
@@ -27,7 +27,6 @@ import javax.persistence.criteria.Root;
 
 import de.symeda.sormas.api.document.DocumentRelatedEntityType;
 import de.symeda.sormas.backend.common.AbstractAdoService;
-import de.symeda.sormas.backend.event.Event;
 
 @Stateless
 @LocalBean
@@ -39,7 +38,7 @@ public class DocumentService extends AbstractAdoService<Document> {
 
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Document> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends Document> from) {
 		return null;
 	}
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/epidata/EpiDataService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/epidata/EpiDataService.java
@@ -50,13 +50,13 @@ public class EpiDataService extends AbstractAdoService<EpiData> {
 
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, EpiData> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends EpiData> from) {
 		// A user should not directly query for this
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public Predicate createChangeDateFilter(CriteriaBuilder cb, From<?, EpiData> epiData, Timestamp date) {
+	public Predicate createChangeDateFilter(CriteriaBuilder cb, From<?, ? extends EpiData> epiData, Timestamp date) {
 		Predicate dateFilter = greaterThanAndNotNull(cb, epiData.get(AbstractDomainObject.CHANGE_DATE), date);
 
 		Join<EpiData, Exposure> exposures = epiData.join(EpiData.EXPOSURES, JoinType.LEFT);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/event/EventParticipantService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/event/EventParticipantService.java
@@ -197,11 +197,11 @@ public class EventParticipantService extends AbstractCoreAdoService<EventPartici
 	 */
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, EventParticipant> eventParticipantPath) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends EventParticipant> eventParticipantPath) {
 		return createUserFilterForJoin(cb, cq, eventParticipantPath);
 	}
 
-	public Predicate createUserFilterForJoin(CriteriaBuilder cb, CriteriaQuery cq, From<?, EventParticipant> eventParticipantPath) {
+	public Predicate createUserFilterForJoin(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends EventParticipant> eventParticipantPath) {
 		// can see the participants of all accessible events
 		EventUserFilterCriteria eventUserFilterCriteria = new EventUserFilterCriteria();
 		eventUserFilterCriteria.includeUserCaseFilter(true);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/event/EventService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/event/EventService.java
@@ -313,7 +313,7 @@ public class EventService extends AbstractCoreAdoService<Event> {
 
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Event> eventPath) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends Event> eventPath) {
 		return createUserFilter(cb, cq, eventPath, null);
 	}
 
@@ -321,7 +321,7 @@ public class EventService extends AbstractCoreAdoService<Event> {
 	public Predicate createUserFilter(
 		CriteriaBuilder cb,
 		CriteriaQuery cq,
-		From<?, Event> eventPath,
+		From<?, ? extends Event> eventPath,
 		EventUserFilterCriteria eventUserFilterCriteria) {
 
 		final User currentUser = getCurrentUser();
@@ -372,7 +372,7 @@ public class EventService extends AbstractCoreAdoService<Event> {
 		return filter;
 	}
 
-	public Predicate createCaseFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Event> eventPath) {
+	public Predicate createCaseFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends Event> eventPath) {
 
 		Predicate filter = null;
 
@@ -391,7 +391,7 @@ public class EventService extends AbstractCoreAdoService<Event> {
 	}
 
 	@Override
-	public Predicate createChangeDateFilter(CriteriaBuilder cb, From<?, Event> eventPath, Timestamp date) {
+	public Predicate createChangeDateFilter(CriteriaBuilder cb, From<?, ? extends Event> eventPath, Timestamp date) {
 
 		Predicate dateFilter = greaterThanAndNotNull(cb, eventPath.get(AbstractDomainObject.CHANGE_DATE), date);
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/exposure/ExposureService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/exposure/ExposureService.java
@@ -47,7 +47,7 @@ public class ExposureService extends AbstractAdoService<Exposure> {
 
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Exposure> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends Exposure> from) {
 		// A user should not directly query for this
 		throw new UnsupportedOperationException();
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/facility/FacilityService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/facility/FacilityService.java
@@ -191,7 +191,7 @@ public class FacilityService extends AbstractInfrastructureAdoService<Facility> 
 
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Facility> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends Facility> from) {
 		// no filter by user needed
 		return null;
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/feature/FeatureConfigurationService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/feature/FeatureConfigurationService.java
@@ -95,7 +95,7 @@ public class FeatureConfigurationService extends AbstractAdoService<FeatureConfi
 
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, FeatureConfiguration> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends FeatureConfiguration> from) {
 
 		User currentUser = getCurrentUser();
 		if (currentUser == null) {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/hospitalization/HospitalizationService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/hospitalization/HospitalizationService.java
@@ -44,7 +44,7 @@ public class HospitalizationService extends AbstractAdoService<Hospitalization> 
 
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Hospitalization> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends Hospitalization> from) {
 		// A user should not directly query for this
 		throw new UnsupportedOperationException();
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/hospitalization/PreviousHospitalizationService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/hospitalization/PreviousHospitalizationService.java
@@ -43,7 +43,7 @@ public class PreviousHospitalizationService extends AbstractAdoService<PreviousH
 
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, PreviousHospitalization> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends PreviousHospitalization> from) {
 		// A user should not directly query for this
 		throw new UnsupportedOperationException();
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/importexport/ExportConfigurationService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/importexport/ExportConfigurationService.java
@@ -19,7 +19,7 @@ public class ExportConfigurationService extends AbstractAdoService<ExportConfigu
 
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ExportConfiguration> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends ExportConfiguration> from) {
 		// A user should not query for this
 		throw new UnsupportedOperationException();
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/PointOfEntryService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/PointOfEntryService.java
@@ -118,7 +118,7 @@ public class PointOfEntryService extends AbstractInfrastructureAdoService<PointO
 
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, PointOfEntry> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends PointOfEntry> from) {
 		return null;
 	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/PopulationDataService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/PopulationDataService.java
@@ -48,7 +48,7 @@ public class PopulationDataService extends AbstractAdoService<PopulationData> {
 
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, PopulationData> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends PopulationData> from) {
 		return null;
 	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/labmessage/LabMessageService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/labmessage/LabMessageService.java
@@ -14,7 +14,7 @@ public class LabMessageService extends AbstractAdoService<LabMessage> {
 	}
 
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, LabMessage> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends LabMessage> from) {
 		throw new UnsupportedOperationException();
 	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/location/LocationService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/location/LocationService.java
@@ -36,7 +36,7 @@ public class LocationService extends AbstractAdoService<Location> {
 
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Location> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends Location> from) {
 		// A user should not directly query for this
 		throw new UnsupportedOperationException();
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/outbreak/OutbreakService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/outbreak/OutbreakService.java
@@ -106,7 +106,7 @@ public class OutbreakService extends AbstractAdoService<Outbreak> {
 
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Outbreak> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends Outbreak> from) {
 		// no filter by user needed
 		return null;
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonService.java
@@ -447,13 +447,13 @@ public class PersonService extends AbstractAdoService<Person> {
 
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Person> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends Person> from) {
 		// getAllUuids and getAllAfter have custom implementations
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public Predicate createChangeDateFilter(CriteriaBuilder cb, From<?, Person> from, Timestamp date) {
+	public Predicate createChangeDateFilter(CriteriaBuilder cb, From<?, ? extends Person> from, Timestamp date) {
 
 		Predicate dateFilter = cb.greaterThan(from.get(AbstractDomainObject.CHANGE_DATE), date);
 		Join<Person, Location> address = from.join(Person.ADDRESS);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/region/AreaService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/region/AreaService.java
@@ -7,8 +7,6 @@ import javax.ejb.Stateless;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.From;
-import javax.persistence.criteria.Join;
-import javax.persistence.criteria.JoinType;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
@@ -27,7 +25,7 @@ public class AreaService extends AbstractInfrastructureAdoService<Area> {
 	}
 
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Area> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends Area> from) {
 		return null;
 	}
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/region/CommunityService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/region/CommunityService.java
@@ -68,7 +68,7 @@ public class CommunityService extends AbstractInfrastructureAdoService<Community
 
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Community> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends Community> from) {
 		// no filter by user needed
 		return null;
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/region/CountryService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/region/CountryService.java
@@ -87,7 +87,7 @@ public class CountryService extends AbstractInfrastructureAdoService<Country> {
 
     @SuppressWarnings("rawtypes")
     @Override
-    public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Country> from) {
+    public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends Country> from) {
         // no filter by user needed
         return null;
     }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/region/DistrictService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/region/DistrictService.java
@@ -86,7 +86,7 @@ public class DistrictService extends AbstractInfrastructureAdoService<District> 
 
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, District> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends District> from) {
 		// no filter by user needed
 		return null;
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/region/RegionService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/region/RegionService.java
@@ -59,7 +59,7 @@ public class RegionService extends AbstractInfrastructureAdoService<Region> {
 
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Region> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends Region> from) {
 		// no filter by user needed
 		return null;
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/report/AggregateReportService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/report/AggregateReportService.java
@@ -81,7 +81,7 @@ public class AggregateReportService extends AbstractAdoService<AggregateReport> 
 
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, AggregateReport> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends AggregateReport> from) {
 
 		User currentUser = getCurrentUser();
 		final JurisdictionLevel jurisdictionLevel = currentUser.getJurisdictionLevel();

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/report/WeeklyReportEntryService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/report/WeeklyReportEntryService.java
@@ -57,7 +57,7 @@ public class WeeklyReportEntryService extends AbstractAdoService<WeeklyReportEnt
 	 */
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, WeeklyReportEntry> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends WeeklyReportEntry> from) {
 		return weeklyReportService.createUserFilter(cb, cq, from.join(WeeklyReportEntry.WEEKLY_REPORT, JoinType.LEFT));
 	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/report/WeeklyReportService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/report/WeeklyReportService.java
@@ -121,7 +121,7 @@ public class WeeklyReportService extends AbstractAdoService<WeeklyReport> {
 	 */
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, WeeklyReport> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends WeeklyReport> from) {
 
 		User currentUser = getCurrentUser();
 		// National users can access all reports in the system

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/AdditionalTestService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/AdditionalTestService.java
@@ -51,7 +51,7 @@ public class AdditionalTestService extends AbstractAdoService<AdditionalTest> {
 
 	private Predicate addUserFilter(User user,
 									@NotNull CriteriaBuilder cb,
-									CriteriaQuery<AdditionalTest> cq,
+									CriteriaQuery cq,
 									@NotNull Root<AdditionalTest> from)
 	{
 		Join<AdditionalTest, Sample> sample = from.join(AdditionalTest.SAMPLE, JoinType.LEFT);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/AdditionalTestService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/AdditionalTestService.java
@@ -13,7 +13,9 @@ import javax.persistence.criteria.Join;
 import javax.persistence.criteria.JoinType;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
+import javax.validation.constraints.NotNull;
 
+import de.symeda.sormas.api.sample.SampleCriteria;
 import de.symeda.sormas.backend.caze.Case;
 import de.symeda.sormas.backend.common.AbstractAdoService;
 import de.symeda.sormas.backend.user.User;
@@ -97,12 +99,11 @@ public class AdditionalTestService extends AbstractAdoService<AdditionalTest> {
 	 */
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, AdditionalTest> additionalTestPath) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, @NotNull From<?, ? extends AdditionalTest> additionalTestPath) {
 
 		// whoever created the sample the additional test is associated with is allowed to access it
 		Join<Sample, Sample> sampleJoin = additionalTestPath.join(AdditionalTest.SAMPLE);
-		Predicate filter = sampleService.createUserFilter(cb, cq, sampleJoin);
-
-		return filter;
+		// Predicate filter = sampleService.createUserFilter(cb, cq, sampleJoin);
+		return sampleService.createUserFilter(cq, cb, new SampleJoins<>(sampleJoin), new SampleCriteria());
 	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/AdditionalTestService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/AdditionalTestService.java
@@ -103,7 +103,6 @@ public class AdditionalTestService extends AbstractAdoService<AdditionalTest> {
 
 		// whoever created the sample the additional test is associated with is allowed to access it
 		Join<Sample, Sample> sampleJoin = additionalTestPath.join(AdditionalTest.SAMPLE);
-		// Predicate filter = sampleService.createUserFilter(cb, cq, sampleJoin);
 		return sampleService.createUserFilter(cq, cb, new SampleJoins<>(sampleJoin), new SampleCriteria());
 	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/PathogenTestService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/PathogenTestService.java
@@ -200,7 +200,7 @@ public class PathogenTestService extends AbstractCoreAdoService<PathogenTest> {
 	 */
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, PathogenTest> sampleTestPath) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends PathogenTest> sampleTestPath) {
 
 		// whoever created the sample the sample test is associated with is allowed to
 		// access it

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/SampleService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/SampleService.java
@@ -66,7 +66,6 @@ import de.symeda.sormas.backend.person.Person;
 import de.symeda.sormas.backend.region.District;
 import de.symeda.sormas.backend.region.Region;
 import de.symeda.sormas.backend.user.User;
-import de.symeda.sormas.backend.util.QueryHelper;
 
 @Stateless
 @LocalBean
@@ -283,8 +282,8 @@ public class SampleService extends AbstractCoreAdoService<Sample> {
 	@Override
 	@SuppressWarnings("rawtypes")
 	@Deprecated
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Sample> samplePath) {
-		return createUserFilter(cq, cb, new SampleJoins<>(samplePath), new SampleCriteria());
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends Sample> samplePath) {
+		return createUserFilter(cq, cb, new SampleJoins(samplePath), new SampleCriteria());
 	}
 
 	@SuppressWarnings("rawtypes")

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/SampleService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/SampleService.java
@@ -38,6 +38,7 @@ import javax.persistence.criteria.Join;
 import javax.persistence.criteria.JoinType;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
+import javax.validation.constraints.NotNull;
 
 import de.symeda.sormas.backend.util.IterableHelper;
 import de.symeda.sormas.backend.util.ModelConstants;
@@ -287,7 +288,7 @@ public class SampleService extends AbstractCoreAdoService<Sample> {
 	}
 
 	@SuppressWarnings("rawtypes")
-	public Predicate createUserFilter(CriteriaQuery cq, CriteriaBuilder cb, SampleJoins joins, SampleCriteria criteria) {
+	public Predicate createUserFilter(CriteriaQuery cq, CriteriaBuilder cb, SampleJoins joins, @NotNull SampleCriteria criteria) {
 
 		Predicate filter = createUserFilterWithoutCase(cb, joins);
 
@@ -303,7 +304,7 @@ public class SampleService extends AbstractCoreAdoService<Sample> {
 		return filter;
 	}
 
-	public Predicate createUserFilterWithoutCase(CriteriaBuilder cb, SampleJoins joins) {
+	public Predicate createUserFilterWithoutCase(@NotNull CriteriaBuilder cb, SampleJoins joins) {
 		Predicate filter = null;
 		// user that reported it is not able to access it. Otherwise they would also need to access the case
 		//filter = cb.equal(samplePath.get(Sample.REPORTING_USER), user);
@@ -332,7 +333,7 @@ public class SampleService extends AbstractCoreAdoService<Sample> {
 		return filter;
 	}
 
-	public Predicate buildCriteriaFilter(SampleCriteria criteria, CriteriaBuilder cb, SampleJoins joins) {
+	public Predicate buildCriteriaFilter(@NotNull SampleCriteria criteria, CriteriaBuilder cb, @NotNull SampleJoins joins) {
 		final From<?, ?> sample = joins.getRoot();
 
 		Predicate filter = null;
@@ -455,7 +456,7 @@ public class SampleService extends AbstractCoreAdoService<Sample> {
 	}
 
 	@Override
-	public void delete(Sample sample) {
+	public void delete(@NotNull Sample sample) {
 
 		// Mark all pathogen tests of this sample as deleted
 		for (PathogenTest pathogenTest : sample.getPathogenTests()) {
@@ -481,7 +482,7 @@ public class SampleService extends AbstractCoreAdoService<Sample> {
 	 * Creates a filter that excludes all samples that are either {@link CoreAdo#deleted} or associated with
 	 * cases that are {@link Case#archived}.
 	 */
-	public Predicate createActiveSamplesFilter(CriteriaBuilder cb, Root<Sample> root) {
+	public Predicate createActiveSamplesFilter(CriteriaBuilder cb, @NotNull Root<Sample> root) {
 
 		Join<Sample, Case> caze = root.join(Sample.ASSOCIATED_CASE, JoinType.LEFT);
 		return cb.and(cb.isFalse(caze.get(Case.ARCHIVED)), cb.isFalse(root.get(Case.DELETED)));
@@ -491,7 +492,7 @@ public class SampleService extends AbstractCoreAdoService<Sample> {
 	 * Creates a default filter that should be used as the basis of queries that do not use {@link SampleCriteria}.
 	 * This essentially removes {@link CoreAdo#deleted} samples from the queries.
 	 */
-	public Predicate createDefaultFilter(CriteriaBuilder cb, Root<Sample> root) {
+	public Predicate createDefaultFilter(@NotNull CriteriaBuilder cb, @NotNull Root<Sample> root) {
 		return cb.isFalse(root.get(Sample.DELETED));
 	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasOriginInfoService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasOriginInfoService.java
@@ -33,7 +33,7 @@ public class SormasToSormasOriginInfoService extends AbstractAdoService<SormasTo
 	}
 
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, SormasToSormasOriginInfo> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends SormasToSormasOriginInfo> from) {
 		// no user filter needed right now
 		return null;
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasShareInfoService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasShareInfoService.java
@@ -40,7 +40,7 @@ public class SormasToSormasShareInfoService extends AbstractAdoService<SormasToS
 	}
 
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, SormasToSormasShareInfo> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends SormasToSormasShareInfo> from) {
 		// no user filter needed right now
 		return null;
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/symptoms/SymptomsService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/symptoms/SymptomsService.java
@@ -36,7 +36,7 @@ public class SymptomsService extends AbstractAdoService<Symptoms> {
 
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Symptoms> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends Symptoms> from) {
 		// A user should not directly query for this
 		throw new UnsupportedOperationException();
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/task/TaskService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/task/TaskService.java
@@ -122,7 +122,7 @@ public class TaskService extends AbstractAdoService<Task> {
 	 */
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Task> taskPath) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends Task> taskPath) {
 
 		Join<Object, User> assigneeUser = taskPath.join(Task.ASSIGNEE_USER, JoinType.LEFT);
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/therapy/PrescriptionService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/therapy/PrescriptionService.java
@@ -150,7 +150,7 @@ public class PrescriptionService extends AbstractAdoService<Prescription> {
 
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Prescription> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends Prescription> from) {
 
 		Join<Prescription, Therapy> therapy = from.join(Prescription.THERAPY, JoinType.LEFT);
 		return caseService.createUserFilter(cb, cq, therapy.join(Therapy.CASE, JoinType.LEFT));

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/therapy/TherapyService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/therapy/TherapyService.java
@@ -19,7 +19,7 @@ public class TherapyService extends AbstractAdoService<Therapy> {
 
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Therapy> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends Therapy> from) {
 		// A user should not directly query for this
 		throw new UnsupportedOperationException();
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/therapy/TreatmentService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/therapy/TreatmentService.java
@@ -150,7 +150,7 @@ public class TreatmentService extends AbstractAdoService<Treatment> {
 
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Treatment> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends Treatment> from) {
 		Join<Treatment, Therapy> therapy = from.join(Treatment.THERAPY, JoinType.LEFT);
 		return caseService.createUserFilter(cb, cq, therapy.join(Therapy.CASE, JoinType.LEFT));
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/user/UserRoleConfigService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/user/UserRoleConfigService.java
@@ -50,7 +50,7 @@ public class UserRoleConfigService extends AbstractAdoService<UserRoleConfig> {
 
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, UserRoleConfig> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends UserRoleConfig> from) {
 		// a user can read all user role configurations
 		return null;
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/user/UserService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/user/UserService.java
@@ -347,7 +347,7 @@ public class UserService extends AbstractAdoService<User> {
 
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, User> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends User> from) {
 		// a user can read all other users
 		return null;
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/visit/VisitService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/visit/VisitService.java
@@ -37,6 +37,7 @@ import javax.persistence.criteria.Join;
 import javax.persistence.criteria.JoinType;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
+import javax.validation.constraints.NotNull;
 
 import de.symeda.sormas.api.Disease;
 import de.symeda.sormas.api.caze.CaseLogic;
@@ -254,13 +255,13 @@ public class VisitService extends AbstractAdoService<Visit> {
 
 	@SuppressWarnings("rawtypes")
 	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Visit> from) {
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ? extends Visit> from) {
 		// getAllUuids and getAllAfter have custom implementations
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public Predicate createChangeDateFilter(CriteriaBuilder cb, From<?, Visit> visitPath, Timestamp date) {
+	public Predicate createChangeDateFilter(@NotNull CriteriaBuilder cb, @NotNull From<?, ? extends Visit> visitPath, @NotNull Timestamp date) {
 
 		Predicate dateFilter = cb.greaterThan(visitPath.get(Visit.CHANGE_DATE), date);
 


### PR DESCRIPTION
Signed-off-by: Axel Nennker <axel.nennker@telekom.de>

remove duplicate code by creating and using addSinceFilter
remove usage of deprecated method sampleService.createUserFilter
added some NotNull
