### PR TITLE
Fewer unsupported operation exception #3906

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/action/ActionService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/action/ActionService.java
@@ -40,7 +40,7 @@ import de.symeda.sormas.api.event.EventActionIndexDto;
 import de.symeda.sormas.api.event.EventCriteria;
 import de.symeda.sormas.api.user.UserRole;
 import de.symeda.sormas.api.utils.SortProperty;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.common.AdoServiceWithUserFilter;
 import de.symeda.sormas.backend.event.Event;
 import de.symeda.sormas.backend.event.EventParticipant;
@@ -69,11 +69,11 @@ public class ActionService extends AdoServiceWithUserFilter<Action> {
 		Predicate filter = null;
 		if (user != null) {
 			Predicate userFilter = createUserFilter(cb, cq, from);
-			filter = AbstractAdoService.and(cb, filter, userFilter);
+			filter = BaseAdoService.and(cb, filter, userFilter);
 		}
 		if (date != null) {
 			Predicate dateFilter = createChangeDateFilter(cb, from, date);
-			filter = AbstractAdoService.and(cb, filter, dateFilter);
+			filter = BaseAdoService.and(cb, filter, dateFilter);
 		}
 		if (filter != null) {
 			cq.where(filter);
@@ -151,7 +151,7 @@ public class ActionService extends AdoServiceWithUserFilter<Action> {
 
 		if (actionCriteria != null) {
 			Predicate criteriaFilter = buildCriteriaFilter(actionCriteria, cb, action);
-			filter = AbstractAdoService.and(cb, filter, criteriaFilter);
+			filter = BaseAdoService.and(cb, filter, criteriaFilter);
 		}
 
 		if (filter != null) {
@@ -176,7 +176,7 @@ public class ActionService extends AdoServiceWithUserFilter<Action> {
 
 		if (actionCriteria != null) {
 			Predicate criteriaFilter = buildCriteriaFilter(actionCriteria, cb, action);
-			filter = AbstractAdoService.and(cb, filter, criteriaFilter);
+			filter = BaseAdoService.and(cb, filter, criteriaFilter);
 		}
 
 		if (filter != null) {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/action/ActionService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/action/ActionService.java
@@ -41,6 +41,7 @@ import de.symeda.sormas.api.event.EventCriteria;
 import de.symeda.sormas.api.user.UserRole;
 import de.symeda.sormas.api.utils.SortProperty;
 import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.AbstractUserAdoService;
 import de.symeda.sormas.backend.event.Event;
 import de.symeda.sormas.backend.event.EventParticipant;
 import de.symeda.sormas.backend.event.EventService;
@@ -52,7 +53,7 @@ import de.symeda.sormas.backend.user.User;
 
 @Stateless
 @LocalBean
-public class ActionService extends AbstractAdoService<Action> {
+public class ActionService extends AbstractUserAdoService<Action> {
 
 	@EJB
 	private EventService eventService;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/action/ActionService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/action/ActionService.java
@@ -41,7 +41,7 @@ import de.symeda.sormas.api.event.EventCriteria;
 import de.symeda.sormas.api.user.UserRole;
 import de.symeda.sormas.api.utils.SortProperty;
 import de.symeda.sormas.backend.common.AbstractAdoService;
-import de.symeda.sormas.backend.common.AbstractUserAdoService;
+import de.symeda.sormas.backend.common.AdoServiceWithUserFilter;
 import de.symeda.sormas.backend.event.Event;
 import de.symeda.sormas.backend.event.EventParticipant;
 import de.symeda.sormas.backend.event.EventService;
@@ -53,7 +53,7 @@ import de.symeda.sormas.backend.user.User;
 
 @Stateless
 @LocalBean
-public class ActionService extends AbstractUserAdoService<Action> {
+public class ActionService extends AdoServiceWithUserFilter<Action> {
 
 	@EJB
 	private EventService eventService;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/campaign/CampaignFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/campaign/CampaignFacadeEjb.java
@@ -44,7 +44,7 @@ import de.symeda.sormas.api.utils.SortProperty;
 import de.symeda.sormas.api.utils.ValidationRuntimeException;
 import de.symeda.sormas.backend.campaign.diagram.CampaignDiagramDefinitionFacadeEjb;
 import de.symeda.sormas.backend.campaign.form.CampaignFormMetaService;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
 import de.symeda.sormas.backend.user.User;
 import de.symeda.sormas.backend.user.UserFacadeEjb;
@@ -83,7 +83,7 @@ public class CampaignFacadeEjb implements CampaignFacade {
 
 		if (campaignCriteria != null) {
 			Predicate criteriaFilter = campaignService.buildCriteriaFilter(campaignCriteria, cb, campaign);
-			filter = AbstractAdoService.and(cb, filter, criteriaFilter);
+			filter = BaseAdoService.and(cb, filter, criteriaFilter);
 		}
 
 		cq.where(filter);
@@ -152,7 +152,7 @@ public class CampaignFacadeEjb implements CampaignFacade {
 
 		if (campaignCriteria != null) {
 			Predicate criteriaFilter = campaignService.buildCriteriaFilter(campaignCriteria, cb, campaign);
-			filter = AbstractAdoService.and(cb, filter, criteriaFilter);
+			filter = BaseAdoService.and(cb, filter, criteriaFilter);
 		}
 
 		cq.where(filter);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/campaign/CampaignService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/campaign/CampaignService.java
@@ -14,7 +14,7 @@ import javax.persistence.criteria.Root;
 import de.symeda.sormas.api.EntityRelevanceStatus;
 import de.symeda.sormas.api.campaign.CampaignCriteria;
 import de.symeda.sormas.api.utils.DataHelper;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.common.AbstractCoreAdoService;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
 import de.symeda.sormas.backend.user.User;
@@ -81,7 +81,7 @@ public class CampaignService extends AbstractCoreAdoService<Campaign> {
 
 		if (getCurrentUser() != null) {
 			Predicate userFilter = createUserFilter(cb, cq, from);
-			filter = AbstractAdoService.and(cb, createActiveCampaignsFilter(cb, from), userFilter);
+			filter = BaseAdoService.and(cb, createActiveCampaignsFilter(cb, from), userFilter);
 		}
 
 		cq.where(filter);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/campaign/data/CampaignFormDataFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/campaign/data/CampaignFormDataFacadeEjb.java
@@ -73,7 +73,7 @@ import de.symeda.sormas.backend.campaign.CampaignService;
 import de.symeda.sormas.backend.campaign.form.CampaignFormMeta;
 import de.symeda.sormas.backend.campaign.form.CampaignFormMetaFacadeEjb;
 import de.symeda.sormas.backend.campaign.form.CampaignFormMetaService;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
 import de.symeda.sormas.backend.infrastructure.PopulationDataFacadeEjb;
 import de.symeda.sormas.backend.region.Area;
@@ -250,7 +250,7 @@ public class CampaignFormDataFacadeEjb implements CampaignFormDataFacade {
 		CriteriaQuery<CampaignFormData> cq = cb.createQuery(CampaignFormData.class);
 		Root<CampaignFormData> root = cq.from(CampaignFormData.class);
 
-		Predicate filter = AbstractAdoService
+		Predicate filter = BaseAdoService
 			.and(cb, campaignFormDataService.createCriteriaFilter(criteria, cb, root), campaignFormDataService.createUserFilter(cb, cq, root));
 		if (filter != null) {
 			cq.where(filter);
@@ -294,7 +294,7 @@ public class CampaignFormDataFacadeEjb implements CampaignFormDataFacade {
 			communityJoin.get(Community.NAME),
 			root.get(CampaignFormData.FORM_DATE));
 
-		Predicate filter = AbstractAdoService
+		Predicate filter = BaseAdoService
 			.and(cb, campaignFormDataService.createCriteriaFilter(criteria, cb, root), campaignFormDataService.createUserFilter(cb, cq, root));
 		if (filter != null) {
 			cq.where(filter);
@@ -705,7 +705,7 @@ public class CampaignFormDataFacadeEjb implements CampaignFormDataFacade {
 		CriteriaQuery<Long> cq = cb.createQuery(Long.class);
 		Root<CampaignFormData> root = cq.from(CampaignFormData.class);
 
-		Predicate filter = AbstractAdoService
+		Predicate filter = BaseAdoService
 			.and(cb, campaignFormDataService.createCriteriaFilter(criteria, cb, root), campaignFormDataService.createUserFilter(cb, cq, root));
 		if (filter != null) {
 			cq.where(filter);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/campaign/data/CampaignFormDataService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/campaign/data/CampaignFormDataService.java
@@ -38,7 +38,7 @@ import de.symeda.sormas.api.user.JurisdictionLevel;
 import de.symeda.sormas.api.utils.DateHelper;
 import de.symeda.sormas.backend.campaign.Campaign;
 import de.symeda.sormas.backend.campaign.form.CampaignFormMeta;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
 import de.symeda.sormas.backend.common.AdoServiceWithUserFilter;
 import de.symeda.sormas.backend.region.Community;
@@ -137,7 +137,7 @@ public class CampaignFormDataService extends AdoServiceWithUserFilter<CampaignFo
 
 		if (getCurrentUser() != null) {
 			Predicate userFilter = createUserFilter(cb, cq, from);
-			filter = AbstractAdoService.and(cb, cb.isFalse(from.get(CampaignFormData.ARCHIVED)), userFilter);
+			filter = BaseAdoService.and(cb, cb.isFalse(from.get(CampaignFormData.ARCHIVED)), userFilter);
 		}
 
 		cq.where(filter);
@@ -155,7 +155,7 @@ public class CampaignFormDataService extends AdoServiceWithUserFilter<CampaignFo
 
 		if (getCurrentUser() != null) {
 			Predicate userFilter = createUserFilter(cb, cq, from);
-			filter = AbstractAdoService.and(cb, cb.isFalse(from.get(CampaignFormData.ARCHIVED)), userFilter);
+			filter = BaseAdoService.and(cb, cb.isFalse(from.get(CampaignFormData.ARCHIVED)), userFilter);
 		}
 
 		if (date != null) {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/campaign/data/CampaignFormDataService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/campaign/data/CampaignFormDataService.java
@@ -40,7 +40,7 @@ import de.symeda.sormas.backend.campaign.Campaign;
 import de.symeda.sormas.backend.campaign.form.CampaignFormMeta;
 import de.symeda.sormas.backend.common.AbstractAdoService;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
-import de.symeda.sormas.backend.common.AbstractUserAdoService;
+import de.symeda.sormas.backend.common.AdoServiceWithUserFilter;
 import de.symeda.sormas.backend.region.Community;
 import de.symeda.sormas.backend.region.District;
 import de.symeda.sormas.backend.region.Region;
@@ -48,7 +48,7 @@ import de.symeda.sormas.backend.user.User;
 
 @Stateless
 @LocalBean
-public class CampaignFormDataService extends AbstractUserAdoService<CampaignFormData> {
+public class CampaignFormDataService extends AdoServiceWithUserFilter<CampaignFormData> {
 
 	public CampaignFormDataService() {
 		super(CampaignFormData.class);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/campaign/data/CampaignFormDataService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/campaign/data/CampaignFormDataService.java
@@ -40,6 +40,7 @@ import de.symeda.sormas.backend.campaign.Campaign;
 import de.symeda.sormas.backend.campaign.form.CampaignFormMeta;
 import de.symeda.sormas.backend.common.AbstractAdoService;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
+import de.symeda.sormas.backend.common.AbstractUserAdoService;
 import de.symeda.sormas.backend.region.Community;
 import de.symeda.sormas.backend.region.District;
 import de.symeda.sormas.backend.region.Region;
@@ -47,7 +48,7 @@ import de.symeda.sormas.backend.user.User;
 
 @Stateless
 @LocalBean
-public class CampaignFormDataService extends AbstractAdoService<CampaignFormData> {
+public class CampaignFormDataService extends AbstractUserAdoService<CampaignFormData> {
 
 	public CampaignFormDataService() {
 		super(CampaignFormData.class);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/campaign/diagram/CampaignDiagramDefinitionService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/campaign/diagram/CampaignDiagramDefinitionService.java
@@ -11,13 +11,11 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import javax.validation.constraints.NotNull;
 
-import de.symeda.sormas.backend.common.AbstractAdoService;
-import de.symeda.sormas.backend.common.AbstractDomainObject;
-import de.symeda.sormas.backend.common.AbstractUserAdoService;
+import de.symeda.sormas.backend.common.AdoServiceWithUserFilter;
 
 @Stateless
 @LocalBean
-public class CampaignDiagramDefinitionService extends AbstractUserAdoService<CampaignDiagramDefinition> {
+public class CampaignDiagramDefinitionService extends AdoServiceWithUserFilter<CampaignDiagramDefinition> {
 
 	public CampaignDiagramDefinitionService() {
 		super(CampaignDiagramDefinition.class);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/campaign/diagram/CampaignDiagramDefinitionService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/campaign/diagram/CampaignDiagramDefinitionService.java
@@ -13,10 +13,11 @@ import javax.validation.constraints.NotNull;
 
 import de.symeda.sormas.backend.common.AbstractAdoService;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
+import de.symeda.sormas.backend.common.AbstractUserAdoService;
 
 @Stateless
 @LocalBean
-public class CampaignDiagramDefinitionService extends AbstractAdoService<CampaignDiagramDefinition> {
+public class CampaignDiagramDefinitionService extends AbstractUserAdoService<CampaignDiagramDefinition> {
 
 	public CampaignDiagramDefinitionService() {
 		super(CampaignDiagramDefinition.class);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/campaign/form/CampaignFormMetaService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/campaign/form/CampaignFormMetaService.java
@@ -16,11 +16,12 @@ import de.symeda.sormas.api.campaign.form.CampaignFormMetaReferenceDto;
 import de.symeda.sormas.backend.campaign.Campaign;
 import de.symeda.sormas.backend.common.AbstractAdoService;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
+import de.symeda.sormas.backend.common.AbstractUserAdoService;
 import de.symeda.sormas.backend.user.User;
 
 @Stateless
 @LocalBean
-public class CampaignFormMetaService extends AbstractAdoService<CampaignFormMeta> {
+public class CampaignFormMetaService extends AbstractUserAdoService<CampaignFormMeta> {
 
 	public CampaignFormMetaService() {
 		super(CampaignFormMeta.class);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/campaign/form/CampaignFormMetaService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/campaign/form/CampaignFormMetaService.java
@@ -14,14 +14,13 @@ import javax.persistence.criteria.Root;
 
 import de.symeda.sormas.api.campaign.form.CampaignFormMetaReferenceDto;
 import de.symeda.sormas.backend.campaign.Campaign;
-import de.symeda.sormas.backend.common.AbstractAdoService;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
-import de.symeda.sormas.backend.common.AbstractUserAdoService;
+import de.symeda.sormas.backend.common.AdoServiceWithUserFilter;
 import de.symeda.sormas.backend.user.User;
 
 @Stateless
 @LocalBean
-public class CampaignFormMetaService extends AbstractUserAdoService<CampaignFormMeta> {
+public class CampaignFormMetaService extends AdoServiceWithUserFilter<CampaignFormMeta> {
 
 	public CampaignFormMetaService() {
 		super(CampaignFormMeta.class);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseFacadeEjb.java
@@ -62,7 +62,6 @@ import javax.persistence.criteria.Selection;
 import javax.persistence.criteria.Subquery;
 import javax.validation.constraints.NotNull;
 
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -175,7 +174,7 @@ import de.symeda.sormas.backend.clinicalcourse.ClinicalVisitFacadeEjb;
 import de.symeda.sormas.backend.clinicalcourse.ClinicalVisitFacadeEjb.ClinicalVisitFacadeEjbLocal;
 import de.symeda.sormas.backend.clinicalcourse.ClinicalVisitService;
 import de.symeda.sormas.backend.clinicalcourse.HealthConditions;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
 import de.symeda.sormas.backend.common.ConfigFacadeEjb.ConfigFacadeEjbLocal;
 import de.symeda.sormas.backend.common.messaging.ManualMessageLogService;
@@ -422,7 +421,7 @@ public class CaseFacadeEjb implements CaseFacade {
 
 		if (caseCriteria != null) {
 			Predicate criteriaFilter = caseService.createCriteriaFilter(caseCriteria, cb, cq, root, joins);
-			filter = AbstractAdoService.and(cb, filter, criteriaFilter);
+			filter = BaseAdoService.and(cb, filter, criteriaFilter);
 		}
 		if (filter != null) {
 			cq.where(filter);
@@ -602,7 +601,7 @@ public class CaseFacadeEjb implements CaseFacade {
 
 		if (caseCriteria != null) {
 			Predicate criteriaFilter = caseService.createCriteriaFilter(caseCriteria, cb, cq, caseRoot, joins);
-			filter = AbstractAdoService.and(cb, filter, criteriaFilter);
+			filter = BaseAdoService.and(cb, filter, criteriaFilter);
 		}
 
 		if (filter != null) {
@@ -958,7 +957,7 @@ public class CaseFacadeEjb implements CaseFacade {
 
 		Predicate filter = caseService.createUserFilter(cb, cq, caze, new CaseUserFilterCriteria().excludeCasesFromContacts(true));
 		Predicate criteriaFilter = caseService.createCriteriaFilter(caseCriteria, cb, cq, caze, joins);
-		filter = AbstractAdoService.and(cb, filter, criteriaFilter);
+		filter = BaseAdoService.and(cb, filter, criteriaFilter);
 
 		if (filter != null) {
 			cq.where(filter);
@@ -1005,7 +1004,7 @@ public class CaseFacadeEjb implements CaseFacade {
 
 		Predicate filter = caseService.createUserFilter(cb, cq, caze, new CaseUserFilterCriteria().excludeCasesFromContacts(false));
 		Predicate criteriaFilter = caseService.createCriteriaFilter(caseCriteria, cb, cq, caze, joins);
-		filter = AbstractAdoService.and(cb, filter, criteriaFilter);
+		filter = BaseAdoService.and(cb, filter, criteriaFilter);
 
 		Predicate dateFilter = buildQuarantineDateFilter(cb, caze, from, to);
 		if (filter != null) {
@@ -1041,7 +1040,7 @@ public class CaseFacadeEjb implements CaseFacade {
 
 		Predicate filter = caseService.createUserFilter(cb, cq, caze, new CaseUserFilterCriteria().excludeCasesFromContacts(false));
 		Predicate criteriaFilter = caseService.createCriteriaFilter(caseCriteria, cb, cq, caze, joins);
-		filter = AbstractAdoService.and(cb, filter, criteriaFilter);
+		filter = BaseAdoService.and(cb, filter, criteriaFilter);
 
 		caze.join(Case.CONVERTED_FROM_CONTACT, JoinType.INNER);
 
@@ -1105,7 +1104,7 @@ public class CaseFacadeEjb implements CaseFacade {
 		Predicate filter =
 			caseService.createUserFilter(cb, cq, caze, new CaseUserFilterCriteria().excludeCasesFromContacts(excludeCasesFromContacts));
 		Predicate criteriaFilter = caseService.createCriteriaFilter(caseCriteria, cb, cq, caze, joins);
-		filter = AbstractAdoService.and(cb, filter, criteriaFilter);
+		filter = BaseAdoService.and(cb, filter, criteriaFilter);
 
 		if (filter != null) {
 			cq.where(filter);
@@ -1134,7 +1133,7 @@ public class CaseFacadeEjb implements CaseFacade {
 		Predicate filter =
 			caseService.createUserFilter(cb, cq, caze, new CaseUserFilterCriteria().excludeCasesFromContacts(excludeCasesFromContacts));
 		Predicate criteriaFilter = caseService.createCriteriaFilter(caseCriteria, cb, cq, caze, joins);
-		filter = AbstractAdoService.and(cb, filter, criteriaFilter);
+		filter = BaseAdoService.and(cb, filter, criteriaFilter);
 
 		if (filter != null) {
 			cq.where(filter);
@@ -1159,7 +1158,7 @@ public class CaseFacadeEjb implements CaseFacade {
 		Predicate filter =
 			caseService.createUserFilter(cb, cq, caze, new CaseUserFilterCriteria().excludeCasesFromContacts(excludeCasesFromContacts));
 
-		filter = AbstractAdoService.and(cb, filter, caseService.createCriteriaFilter(caseCriteria, cb, cq, caze, joins));
+		filter = BaseAdoService.and(cb, filter, caseService.createCriteriaFilter(caseCriteria, cb, cq, caze, joins));
 
 		if (filter != null) {
 			cq.where(filter);
@@ -1183,7 +1182,7 @@ public class CaseFacadeEjb implements CaseFacade {
 		CaseJoins<Case> joins = new CaseJoins<>(caze);
 
 		Predicate filter = caseService.createUserFilter(cb, cq, caze, new CaseUserFilterCriteria().excludeCasesFromContacts(true));
-		filter = AbstractAdoService.and(cb, filter, caseService.createCriteriaFilter(criteria, cb, cq, caze, joins));
+		filter = BaseAdoService.and(cb, filter, caseService.createCriteriaFilter(criteria, cb, cq, caze, joins));
 		if (filter != null) {
 			cq.where(filter);
 		}
@@ -1209,7 +1208,7 @@ public class CaseFacadeEjb implements CaseFacade {
 		Predicate filter =
 			caseService.createUserFilter(cb, cq, caze, new CaseUserFilterCriteria().excludeCasesFromContacts(excludeCasesFromContacts));
 
-		filter = AbstractAdoService.and(cb, filter, caseService.createCriteriaFilter(caseCriteria, cb, cq, caze, joins));
+		filter = BaseAdoService.and(cb, filter, caseService.createCriteriaFilter(caseCriteria, cb, cq, caze, joins));
 
 		if (filter != null) {
 			cq.where(filter);
@@ -1259,11 +1258,11 @@ public class CaseFacadeEjb implements CaseFacade {
 			: null;
 
 		Predicate filter = caseService.createDefaultFilter(cb, root);
-		filter = AbstractAdoService.and(cb, filter, userFilter);
-		filter = AbstractAdoService.and(cb, filter, personSimilarityFilter);
-		filter = AbstractAdoService.and(cb, filter, diseaseFilter);
-		filter = AbstractAdoService.and(cb, filter, regionFilter);
-		filter = AbstractAdoService.and(cb, filter, reportDateFilter);
+		filter = BaseAdoService.and(cb, filter, userFilter);
+		filter = BaseAdoService.and(cb, filter, personSimilarityFilter);
+		filter = BaseAdoService.and(cb, filter, diseaseFilter);
+		filter = BaseAdoService.and(cb, filter, regionFilter);
+		filter = BaseAdoService.and(cb, filter, reportDateFilter);
 
 		cq.where(filter);
 
@@ -1435,7 +1434,7 @@ public class CaseFacadeEjb implements CaseFacade {
 		Predicate filter =
 			caseService.createUserFilter(cb, cq, caze, new CaseUserFilterCriteria().excludeCasesFromContacts(excludeCasesFromContacts));
 
-		filter = AbstractAdoService.and(cb, filter, caseService.createCriteriaFilter(caseCriteria, cb, cq, caze, joins));
+		filter = BaseAdoService.and(cb, filter, caseService.createCriteriaFilter(caseCriteria, cb, cq, caze, joins));
 
 		if (filter != null) {
 			cq.where(filter);
@@ -3038,7 +3037,7 @@ public class CaseFacadeEjb implements CaseFacade {
 			caze.get(Case.DISEASE));
 		cq.multiselect(Stream.concat(select, listQueryBuilder.getJurisdictionSelections(joins)).collect(Collectors.toList()));
 
-		Predicate filter = AbstractAdoService
+		Predicate filter = BaseAdoService
 			.and(cb, caseService.createUserFilter(cb, cq, caze), caseService.createCriteriaFilter(caseCriteria, cb, cq, caze, joins));
 
 		if (filter != null) {
@@ -3085,7 +3084,7 @@ public class CaseFacadeEjb implements CaseFacade {
 			Join<Visit, Symptoms> visitSymptomsJoin = visitsJoin.join(Visit.SYMPTOMS, JoinType.LEFT);
 
 			visitsCq.where(
-				AbstractAdoService.and(
+				BaseAdoService.and(
 					cb,
 					caze.get(AbstractDomainObject.UUID).in(caseUuids),
 					cb.isNotEmpty(visitsCqRoot.get(Case.VISITS)),

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseListCriteriaBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseListCriteriaBuilder.java
@@ -30,7 +30,7 @@ import de.symeda.sormas.api.caze.CaseCriteria;
 import de.symeda.sormas.api.caze.CaseIndexDetailedDto;
 import de.symeda.sormas.api.caze.CaseIndexDto;
 import de.symeda.sormas.api.utils.SortProperty;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
 import de.symeda.sormas.backend.event.Event;
 import de.symeda.sormas.backend.event.EventParticipant;
@@ -152,7 +152,7 @@ public class CaseListCriteriaBuilder {
 
 		if (caseCriteria != null) {
 			Predicate criteriaFilter = caseService.createCriteriaFilter(caseCriteria, cb, cq, caze, joins);
-			filter = AbstractAdoService.and(cb, filter, criteriaFilter);
+			filter = BaseAdoService.and(cb, filter, criteriaFilter);
 		}
 
 		if (filter != null) {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseService.java
@@ -74,7 +74,7 @@ import de.symeda.sormas.api.visit.VisitStatus;
 import de.symeda.sormas.backend.clinicalcourse.ClinicalCourse;
 import de.symeda.sormas.backend.clinicalcourse.ClinicalVisit;
 import de.symeda.sormas.backend.clinicalcourse.ClinicalVisitService;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.common.AbstractCoreAdoService;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
 import de.symeda.sormas.backend.common.CoreAdo;
@@ -229,7 +229,7 @@ public class CaseService extends AbstractCoreAdoService<Case> {
 
 		if (getCurrentUser() != null) {
 			Predicate userFilter = createUserFilter(cb, cq, from);
-			filter = AbstractAdoService.and(cb, filter, userFilter);
+			filter = BaseAdoService.and(cb, filter, userFilter);
 		}
 
 		cq.where(filter);
@@ -307,8 +307,8 @@ public class CaseService extends AbstractCoreAdoService<Case> {
 		Date from,
 		Date to) {
 		Predicate filter = createActiveCasesFilter(cb, root);
-		filter = AbstractAdoService.and(cb, filter, createUserFilter(cb, cq, root, new CaseUserFilterCriteria().excludeCasesFromContacts(true)));
-		filter = AbstractAdoService.and(cb, filter, createCaseRelevanceFilter(cb, root, from, to));
+		filter = BaseAdoService.and(cb, filter, createUserFilter(cb, cq, root, new CaseUserFilterCriteria().excludeCasesFromContacts(true)));
+		filter = BaseAdoService.and(cb, filter, createCaseRelevanceFilter(cb, root, from, to));
 
 		if (region != null) {
 			Predicate regionFilter = cb.equal(root.get(Case.REGION), region);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseStatisticsFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseStatisticsFacadeEjb.java
@@ -53,7 +53,7 @@ import de.symeda.sormas.api.statistics.StatisticsCaseSubAttribute;
 import de.symeda.sormas.api.statistics.StatisticsGroupingKey;
 import de.symeda.sormas.api.statistics.StatisticsHelper;
 import de.symeda.sormas.api.user.UserDto;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.facility.Facility;
 import de.symeda.sormas.backend.facility.FacilityFacadeEjb.FacilityFacadeEjbLocal;
 import de.symeda.sormas.backend.facility.FacilityService;
@@ -1190,7 +1190,7 @@ public class CaseStatisticsFacadeEjb implements CaseStatisticsFacade {
 		}
 
 		filterBuilder.append(tableName).append(".").append(fieldName).append(" IN ");
-		return AbstractAdoService.appendInFilterValues(filterBuilder, filterBuilderParameters, values, valueMapper);
+		return BaseAdoService.appendInFilterValues(filterBuilder, filterBuilderParameters, values, valueMapper);
 	}
 
 	private StringBuilder extendFilterBuilderWithDate(
@@ -1242,7 +1242,7 @@ public class CaseStatisticsFacadeEjb implements CaseStatisticsFacade {
 			.append(fieldName)
 			.append(")  AS integer))")
 			.append(" IN ");
-		return AbstractAdoService.appendInFilterValues(filterBuilder, filterBuilderParameters, values, valueMapper);
+		return BaseAdoService.appendInFilterValues(filterBuilder, filterBuilderParameters, values, valueMapper);
 	}
 
 	private <T> StringBuilder extendFilterBuilderWithEpiWeek(
@@ -1258,7 +1258,7 @@ public class CaseStatisticsFacadeEjb implements CaseStatisticsFacade {
 		}
 
 		filterBuilder.append("epi_week(").append(tableName).append(".").append(fieldName).append(")").append(" IN ");
-		return AbstractAdoService.appendInFilterValues(filterBuilder, filterBuilderParameters, values, valueMapper);
+		return BaseAdoService.appendInFilterValues(filterBuilder, filterBuilderParameters, values, valueMapper);
 	}
 
 	private <T> StringBuilder extendFilterBuilderWithEpiWeekOfYear(
@@ -1285,7 +1285,7 @@ public class CaseStatisticsFacadeEjb implements CaseStatisticsFacade {
 			.append(fieldName)
 			.append("))")
 			.append(" IN ");
-		return AbstractAdoService.appendInFilterValues(filterBuilder, filterBuilderParameters, values, valueMapper);
+		return BaseAdoService.appendInFilterValues(filterBuilder, filterBuilderParameters, values, valueMapper);
 	}
 
 	private <T> StringBuilder extendFilterBuilderWithQuarterOfYear(
@@ -1311,7 +1311,7 @@ public class CaseStatisticsFacadeEjb implements CaseStatisticsFacade {
 			.append(fieldName)
 			.append(") AS integer))")
 			.append(" IN ");
-		return AbstractAdoService.appendInFilterValues(filterBuilder, filterBuilderParameters, values, valueMapper);
+		return BaseAdoService.appendInFilterValues(filterBuilder, filterBuilderParameters, values, valueMapper);
 	}
 
 	private <T> StringBuilder extendFilterBuilderWithMonthOfYear(
@@ -1337,7 +1337,7 @@ public class CaseStatisticsFacadeEjb implements CaseStatisticsFacade {
 			.append(fieldName)
 			.append(") AS integer))")
 			.append(" IN ");
-		return AbstractAdoService.appendInFilterValues(filterBuilder, filterBuilderParameters, values, valueMapper);
+		return BaseAdoService.appendInFilterValues(filterBuilder, filterBuilderParameters, values, valueMapper);
 	}
 
 	private String buildCaseGroupingSelectQuery(StatisticsCaseAttribute grouping, StatisticsCaseSubAttribute subGrouping, String groupAlias) {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/maternalhistory/MaternalHistoryService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/maternalhistory/MaternalHistoryService.java
@@ -2,16 +2,12 @@ package de.symeda.sormas.backend.caze.maternalhistory;
 
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.From;
-import javax.persistence.criteria.Predicate;
 
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 
 @Stateless
 @LocalBean
-public class MaternalHistoryService extends AbstractAdoService<MaternalHistory> {
+public class MaternalHistoryService extends BaseAdoService<MaternalHistory> {
 
 	public MaternalHistoryService() {
 		super(MaternalHistory.class);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/maternalhistory/MaternalHistoryService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/maternalhistory/MaternalHistoryService.java
@@ -17,10 +17,4 @@ public class MaternalHistoryService extends AbstractAdoService<MaternalHistory> 
 		super(MaternalHistory.class);
 	}
 
-	@SuppressWarnings("rawtypes")
-	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, MaternalHistory> from) {
-		// A user should not directly query for this
-		throw new UnsupportedOperationException();
-	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/porthealthinfo/PortHealthInfoService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/porthealthinfo/PortHealthInfoService.java
@@ -2,16 +2,12 @@ package de.symeda.sormas.backend.caze.porthealthinfo;
 
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.From;
-import javax.persistence.criteria.Predicate;
 
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 
 @Stateless
 @LocalBean
-public class PortHealthInfoService extends AbstractAdoService<PortHealthInfo> {
+public class PortHealthInfoService extends BaseAdoService<PortHealthInfo> {
 
 	public PortHealthInfoService() {
 		super(PortHealthInfo.class);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/porthealthinfo/PortHealthInfoService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/porthealthinfo/PortHealthInfoService.java
@@ -17,10 +17,4 @@ public class PortHealthInfoService extends AbstractAdoService<PortHealthInfo> {
 		super(PortHealthInfo.class);
 	}
 
-	@SuppressWarnings("rawtypes")
-	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, PortHealthInfo> from) {
-		// A user should not directly query for this
-		throw new UnsupportedOperationException();
-	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/clinicalcourse/ClinicalCourseService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/clinicalcourse/ClinicalCourseService.java
@@ -2,16 +2,12 @@ package de.symeda.sormas.backend.clinicalcourse;
 
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.From;
-import javax.persistence.criteria.Predicate;
 
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 
 @Stateless
 @LocalBean
-public class ClinicalCourseService extends AbstractAdoService<ClinicalCourse> {
+public class ClinicalCourseService extends BaseAdoService<ClinicalCourse> {
 
 	public ClinicalCourseService() {
 		super(ClinicalCourse.class);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/clinicalcourse/ClinicalCourseService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/clinicalcourse/ClinicalCourseService.java
@@ -17,10 +17,4 @@ public class ClinicalCourseService extends AbstractAdoService<ClinicalCourse> {
 		super(ClinicalCourse.class);
 	}
 
-	@SuppressWarnings("rawtypes")
-	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ClinicalCourse> from) {
-		// A user should not directly query for this
-		throw new UnsupportedOperationException();
-	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/clinicalcourse/ClinicalVisitFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/clinicalcourse/ClinicalVisitFacadeEjb.java
@@ -36,7 +36,7 @@ import de.symeda.sormas.backend.caze.CaseFacadeEjb.CaseFacadeEjbLocal;
 import de.symeda.sormas.backend.caze.CaseJurisdictionChecker;
 import de.symeda.sormas.backend.caze.CaseService;
 import de.symeda.sormas.backend.clinicalcourse.ClinicalCourseFacadeEjb.ClinicalCourseFacadeEjbLocal;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.facility.Facility;
 import de.symeda.sormas.backend.infrastructure.PointOfEntry;
 import de.symeda.sormas.backend.person.Person;
@@ -276,7 +276,7 @@ public class ClinicalVisitFacadeEjb implements ClinicalVisitFacade {
 
 		CaseJoins<ClinicalCourse> caseJoins = new CaseJoins<>(joins.getCaze());
 		Predicate criteriaFilter = caseService.createCriteriaFilter(criteria, cb, cq, joins.getCaze(), caseJoins);
-		filter = AbstractAdoService.and(cb, filter, criteriaFilter);
+		filter = BaseAdoService.and(cb, filter, criteriaFilter);
 		cq.where(filter);
 		cq.orderBy(cb.desc(joins.getCaze().get(Case.UUID)), cb.desc(clinicalVisit.get(ClinicalVisit.VISIT_DATE_TIME)));
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/clinicalcourse/ClinicalVisitService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/clinicalcourse/ClinicalVisitService.java
@@ -22,12 +22,13 @@ import de.symeda.sormas.backend.caze.Case;
 import de.symeda.sormas.backend.caze.CaseService;
 import de.symeda.sormas.backend.common.AbstractAdoService;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
+import de.symeda.sormas.backend.common.AbstractUserAdoService;
 import de.symeda.sormas.backend.symptoms.Symptoms;
 import de.symeda.sormas.backend.user.User;
 
 @Stateless
 @LocalBean
-public class ClinicalVisitService extends AbstractAdoService<ClinicalVisit> {
+public class ClinicalVisitService extends AbstractUserAdoService<ClinicalVisit> {
 
 	@EJB
 	CaseService caseService;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/clinicalcourse/ClinicalVisitService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/clinicalcourse/ClinicalVisitService.java
@@ -20,7 +20,7 @@ import de.symeda.sormas.api.clinicalcourse.ClinicalVisitCriteria;
 import de.symeda.sormas.api.utils.DateHelper;
 import de.symeda.sormas.backend.caze.Case;
 import de.symeda.sormas.backend.caze.CaseService;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
 import de.symeda.sormas.backend.common.AdoServiceWithUserFilter;
 import de.symeda.sormas.backend.symptoms.Symptoms;
@@ -88,12 +88,12 @@ public class ClinicalVisitService extends AdoServiceWithUserFilter<ClinicalVisit
 
 		if (getCurrentUser() != null) {
 			Predicate userFilter = createUserFilter(cb, cq, from);
-			filter = AbstractAdoService.and(cb, filter, userFilter);
+			filter = BaseAdoService.and(cb, filter, userFilter);
 		}
 
 		if (date != null) {
 			Predicate dateFilter = createChangeDateFilter(cb, from, DateHelper.toTimestampUpper(date));
-			filter = AbstractAdoService.and(cb, filter, dateFilter);
+			filter = BaseAdoService.and(cb, filter, dateFilter);
 		}
 
 		cq.where(filter);
@@ -115,7 +115,7 @@ public class ClinicalVisitService extends AdoServiceWithUserFilter<ClinicalVisit
 
 		if (user != null) {
 			Predicate userFilter = createUserFilter(cb, cq, from);
-			filter = AbstractAdoService.and(cb, filter, userFilter);
+			filter = BaseAdoService.and(cb, filter, userFilter);
 		}
 
 		cq.where(filter);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/clinicalcourse/ClinicalVisitService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/clinicalcourse/ClinicalVisitService.java
@@ -22,13 +22,13 @@ import de.symeda.sormas.backend.caze.Case;
 import de.symeda.sormas.backend.caze.CaseService;
 import de.symeda.sormas.backend.common.AbstractAdoService;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
-import de.symeda.sormas.backend.common.AbstractUserAdoService;
+import de.symeda.sormas.backend.common.AdoServiceWithUserFilter;
 import de.symeda.sormas.backend.symptoms.Symptoms;
 import de.symeda.sormas.backend.user.User;
 
 @Stateless
 @LocalBean
-public class ClinicalVisitService extends AbstractUserAdoService<ClinicalVisit> {
+public class ClinicalVisitService extends AdoServiceWithUserFilter<ClinicalVisit> {
 
 	@EJB
 	CaseService caseService;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/clinicalcourse/HealthConditionsService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/clinicalcourse/HealthConditionsService.java
@@ -2,16 +2,12 @@ package de.symeda.sormas.backend.clinicalcourse;
 
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.From;
-import javax.persistence.criteria.Predicate;
 
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 
 @Stateless
 @LocalBean
-public class HealthConditionsService extends AbstractAdoService<HealthConditions> {
+public class HealthConditionsService extends BaseAdoService<HealthConditions> {
 
 	public HealthConditionsService() {
 		super(HealthConditions.class);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/clinicalcourse/HealthConditionsService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/clinicalcourse/HealthConditionsService.java
@@ -17,10 +17,4 @@ public class HealthConditionsService extends AbstractAdoService<HealthConditions
 		super(HealthConditions.class);
 	}
 
-	@SuppressWarnings("rawtypes")
-	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, HealthConditions> from) {
-		// A user should not directly query for this
-		throw new UnsupportedOperationException();
-	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/AbstractAdoService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/AbstractAdoService.java
@@ -59,7 +59,7 @@ import de.symeda.sormas.backend.user.CurrentUserQualifier;
 import de.symeda.sormas.backend.user.User;
 import de.symeda.sormas.backend.util.ModelConstants;
 
-public abstract class AbstractAdoService<ADO extends AbstractDomainObject> implements AdoService<ADO> {
+public class AbstractAdoService<ADO extends AbstractDomainObject> implements AdoService<ADO> {
 
 	// protected to be used by implementations
 	protected final Logger logger = LoggerFactory.getLogger(getClass());
@@ -169,62 +169,6 @@ public abstract class AbstractAdoService<ADO extends AbstractDomainObject> imple
 		return em.createQuery(cq).getSingleResult();
 	}
 
-	public List<ADO> getAllAfter(Date since, User user) {
-
-		CriteriaBuilder cb = em.getCriteriaBuilder();
-		CriteriaQuery<ADO> cq = cb.createQuery(getElementClass());
-		Root<ADO> root = cq.from(getElementClass());
-
-		Predicate filter = createUserFilter(cb, cq, root);
-		if (since != null) {
-			Predicate dateFilter = createChangeDateFilter(cb, root, since);
-			if (filter != null) {
-				filter = cb.and(filter, dateFilter);
-			} else {
-				filter = dateFilter;
-			}
-		}
-		if (filter != null) {
-			cq.where(filter);
-		}
-		cq.orderBy(cb.desc(root.get(AbstractDomainObject.CHANGE_DATE)));
-		cq.distinct(true);
-
-		List<ADO> resultList = em.createQuery(cq).getResultList();
-		return resultList;
-	}
-
-	public List<String> getAllUuids() {
-
-		CriteriaBuilder cb = em.getCriteriaBuilder();
-		CriteriaQuery<String> cq = cb.createQuery(String.class);
-		Root<ADO> from = cq.from(getElementClass());
-
-		Predicate filter = createUserFilter(cb, cq, from);
-		if (filter != null) {
-			cq.where(filter);
-		}
-
-		cq.select(from.get(AbstractDomainObject.UUID));
-		return em.createQuery(cq).getResultList();
-	}
-
-	public List<Long> getAllIds(User user) {
-
-		CriteriaBuilder cb = em.getCriteriaBuilder();
-		CriteriaQuery<Long> cq = cb.createQuery(Long.class);
-		Root<ADO> from = cq.from(getElementClass());
-
-		if (user != null) {
-			Predicate filter = createUserFilter(cb, cq, from);
-			if (filter != null) {
-				cq.where(filter);
-			}
-		}
-
-		cq.select(from.get(AbstractDomainObject.ID));
-		return em.createQuery(cq).getResultList();
-	}
 
 	public List<ADO> getByUuids(List<String> uuids) {
 
@@ -239,12 +183,6 @@ public abstract class AbstractAdoService<ADO extends AbstractDomainObject> imple
 
 		return em.createQuery(cq).getResultList();
 	}
-
-	/**
-	 * Used by most getAll* and getAllUuids methods to filter by user
-	 */
-	@SuppressWarnings("rawtypes")
-	public abstract Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ADO> from);
 
 	public Predicate createChangeDateFilter(CriteriaBuilder cb, From<?, ADO> from, Timestamp date) {
 		Predicate dateFilter = cb.greaterThan(from.get(AbstractDomainObject.CHANGE_DATE), date);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/AbstractCoreAdoService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/AbstractCoreAdoService.java
@@ -11,7 +11,7 @@ import javax.persistence.criteria.Predicate;
 
 import org.apache.commons.lang3.StringUtils;
 
-public abstract class AbstractCoreAdoService<ADO extends CoreAdo> extends AbstractAdoService<ADO> {
+public abstract class AbstractCoreAdoService<ADO extends CoreAdo> extends AbstractUserAdoService<ADO> {
 
 	public static final int NR_OF_LAST_PHONE_DIGITS_TO_SEARCH = 6;
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/AbstractCoreAdoService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/AbstractCoreAdoService.java
@@ -11,7 +11,7 @@ import javax.persistence.criteria.Predicate;
 
 import org.apache.commons.lang3.StringUtils;
 
-public abstract class AbstractCoreAdoService<ADO extends CoreAdo> extends AbstractUserAdoService<ADO> {
+public abstract class AbstractCoreAdoService<ADO extends CoreAdo> extends AdoServiceWithUserFilter<ADO> {
 
 	public static final int NR_OF_LAST_PHONE_DIGITS_TO_SEARCH = 6;
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/AbstractInfrastructureAdoService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/AbstractInfrastructureAdoService.java
@@ -10,7 +10,7 @@ import javax.persistence.criteria.Join;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
-public abstract class AbstractInfrastructureAdoService<ADO extends InfrastructureAdo> extends AbstractUserAdoService<ADO> {
+public abstract class AbstractInfrastructureAdoService<ADO extends InfrastructureAdo> extends AdoServiceWithUserFilter<ADO> {
 
 	public AbstractInfrastructureAdoService(Class<ADO> elementClass) {
 		super(elementClass);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/AbstractInfrastructureAdoService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/AbstractInfrastructureAdoService.java
@@ -10,7 +10,7 @@ import javax.persistence.criteria.Join;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
-public abstract class AbstractInfrastructureAdoService<ADO extends InfrastructureAdo> extends AbstractAdoService<ADO> {
+public abstract class AbstractInfrastructureAdoService<ADO extends InfrastructureAdo> extends AbstractUserAdoService<ADO> {
 
 	public AbstractInfrastructureAdoService(Class<ADO> elementClass) {
 		super(elementClass);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/AbstractUserAdoService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/AbstractUserAdoService.java
@@ -1,0 +1,76 @@
+package de.symeda.sormas.backend.common;
+
+import de.symeda.sormas.backend.user.User;
+
+import javax.persistence.criteria.*;
+import java.util.Date;
+import java.util.List;
+
+public abstract class AbstractUserAdoService<ADO extends AbstractDomainObject> extends AbstractAdoService<ADO> {
+    public AbstractUserAdoService(Class<ADO> elementClass) {
+        super(elementClass);
+    }
+
+    /**
+     * Used by most getAll* and getAllUuids methods to filter by user
+     */
+    @SuppressWarnings("rawtypes")
+    public abstract Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ADO> from);
+
+    public List<ADO> getAllAfter(Date since, User user) {
+
+        CriteriaBuilder cb = em.getCriteriaBuilder();
+        CriteriaQuery<ADO> cq = cb.createQuery(getElementClass());
+        Root<ADO> root = cq.from(getElementClass());
+
+        Predicate filter = createUserFilter(cb, cq, root);
+        if (since != null) {
+            Predicate dateFilter = createChangeDateFilter(cb, root, since);
+            if (filter != null) {
+                filter = cb.and(filter, dateFilter);
+            } else {
+                filter = dateFilter;
+            }
+        }
+        if (filter != null) {
+            cq.where(filter);
+        }
+        cq.orderBy(cb.desc(root.get(AbstractDomainObject.CHANGE_DATE)));
+        cq.distinct(true);
+
+        return em.createQuery(cq).getResultList();
+    }
+
+    public List<String> getAllUuids() {
+
+        CriteriaBuilder cb = em.getCriteriaBuilder();
+        CriteriaQuery<String> cq = cb.createQuery(String.class);
+        Root<ADO> from = cq.from(getElementClass());
+
+        Predicate filter = createUserFilter(cb, cq, from);
+        if (filter != null) {
+            cq.where(filter);
+        }
+
+        cq.select(from.get(AbstractDomainObject.UUID));
+        return em.createQuery(cq).getResultList();
+    }
+
+    public List<Long> getAllIds(User user) {
+
+        CriteriaBuilder cb = em.getCriteriaBuilder();
+        CriteriaQuery<Long> cq = cb.createQuery(Long.class);
+        Root<ADO> from = cq.from(getElementClass());
+
+        if (user != null) {
+            Predicate filter = createUserFilter(cb, cq, from);
+            if (filter != null) {
+                cq.where(filter);
+            }
+        }
+
+        cq.select(from.get(AbstractDomainObject.ID));
+        return em.createQuery(cq).getResultList();
+    }
+
+}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/AdoServiceWithUserFilter.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/AdoServiceWithUserFilter.java
@@ -6,7 +6,7 @@ import javax.persistence.criteria.*;
 import java.util.Date;
 import java.util.List;
 
-public abstract class AdoServiceWithUserFilter<ADO extends AbstractDomainObject> extends AbstractAdoService<ADO> {
+public abstract class AdoServiceWithUserFilter<ADO extends AbstractDomainObject> extends BaseAdoService<ADO> {
     public AdoServiceWithUserFilter(Class<ADO> elementClass) {
         super(elementClass);
     }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/AdoServiceWithUserFilter.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/AdoServiceWithUserFilter.java
@@ -6,8 +6,8 @@ import javax.persistence.criteria.*;
 import java.util.Date;
 import java.util.List;
 
-public abstract class AbstractUserAdoService<ADO extends AbstractDomainObject> extends AbstractAdoService<ADO> {
-    public AbstractUserAdoService(Class<ADO> elementClass) {
+public abstract class AdoServiceWithUserFilter<ADO extends AbstractDomainObject> extends AbstractAdoService<ADO> {
+    public AdoServiceWithUserFilter(Class<ADO> elementClass) {
         super(elementClass);
     }
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/BaseAdoService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/BaseAdoService.java
@@ -77,7 +77,7 @@ public class BaseAdoService<ADO extends AbstractDomainObject> implements AdoServ
 	@PersistenceContext(unitName = ModelConstants.PERSISTENCE_UNIT_NAME)
 	protected EntityManager em;
 
-	public BaseAdoService(Class<ADO> elementClass) {
+	protected BaseAdoService(Class<ADO> elementClass) {
 		this.elementClass = elementClass;
 	}
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/BaseAdoService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/BaseAdoService.java
@@ -59,7 +59,7 @@ import de.symeda.sormas.backend.user.CurrentUserQualifier;
 import de.symeda.sormas.backend.user.User;
 import de.symeda.sormas.backend.util.ModelConstants;
 
-public class AbstractAdoService<ADO extends AbstractDomainObject> implements AdoService<ADO> {
+public class BaseAdoService<ADO extends AbstractDomainObject> implements AdoService<ADO> {
 
 	// protected to be used by implementations
 	protected final Logger logger = LoggerFactory.getLogger(getClass());
@@ -77,7 +77,7 @@ public class AbstractAdoService<ADO extends AbstractDomainObject> implements Ado
 	@PersistenceContext(unitName = ModelConstants.PERSISTENCE_UNIT_NAME)
 	protected EntityManager em;
 
-	public AbstractAdoService(Class<ADO> elementClass) {
+	public BaseAdoService(Class<ADO> elementClass) {
 		this.elementClass = elementClass;
 	}
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/messaging/ManualMessageLogService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/messaging/ManualMessageLogService.java
@@ -6,18 +6,17 @@ import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.From;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import javax.validation.constraints.NotNull;
 
 import de.symeda.sormas.api.messaging.MessageType;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.person.Person;
 
 @Stateless
 @LocalBean
-public class ManualMessageLogService extends AbstractAdoService<ManualMessageLog> {
+public class ManualMessageLogService extends BaseAdoService<ManualMessageLog> {
 
 	public static final int MANUAL_MESSAGE_LOG_LIMIT = 5;
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/messaging/ManualMessageLogService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/messaging/ManualMessageLogService.java
@@ -25,11 +25,6 @@ public class ManualMessageLogService extends AbstractAdoService<ManualMessageLog
 		super(ManualMessageLog.class);
 	}
 
-	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ManualMessageLog> from) {
-		throw new UnsupportedOperationException();
-	}
-
 	public List<ManualMessageLog> getByPersonUuid(@NotNull String personUuid, MessageType messageType) {
 
 		final CriteriaBuilder cb = em.getCriteriaBuilder();

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/contact/ContactFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/contact/ContactFacadeEjb.java
@@ -121,7 +121,7 @@ import de.symeda.sormas.backend.caze.CaseFacadeEjb.CaseFacadeEjbLocal;
 import de.symeda.sormas.backend.caze.CaseJurisdictionChecker;
 import de.symeda.sormas.backend.caze.CaseService;
 import de.symeda.sormas.backend.clinicalcourse.ClinicalCourseFacadeEjb;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
 import de.symeda.sormas.backend.common.TaskCreationException;
 import de.symeda.sormas.backend.epidata.EpiData;
@@ -643,7 +643,7 @@ public class ContactFacadeEjb implements ContactFacade {
 			contactRoot.get(Contact.FOLLOW_UP_UNTIL));
 
 		cq.where(
-			AbstractAdoService.and(
+			BaseAdoService.and(
 				cb,
 				listCriteriaBuilder.buildContactFilter(contactCriteria, cb, contactRoot, cq, contactJoins),
 				cb.isNotEmpty(contactRoot.get(Contact.VISITS))));
@@ -837,7 +837,7 @@ public class ContactFacadeEjb implements ContactFacade {
 			Join<Visit, Symptoms> visitSymptomsJoin = visitsJoin.join(Visit.SYMPTOMS, JoinType.LEFT);
 
 			visitsCq.where(
-				AbstractAdoService.and(
+				BaseAdoService.and(
 					cb,
 					contact.get(AbstractDomainObject.UUID).in(contactUuids),
 					cb.isNotEmpty(visitsCqRoot.get(Contact.VISITS)),
@@ -1506,12 +1506,12 @@ public class ContactFacadeEjb implements ContactFacade {
 
 		final Date reportDate = criteria.getReportDate();
 		final Date lastContactDate = criteria.getLastContactDate();
-		final Predicate recentContactsFilter = AbstractAdoService.and(
+		final Predicate recentContactsFilter = BaseAdoService.and(
 			cb,
 			contactService.recentDateFilter(cb, reportDate, contactRoot.get(Contact.REPORT_DATE_TIME), 30),
 			contactService.recentDateFilter(cb, lastContactDate, contactRoot.get(Contact.LAST_CONTACT_DATE), 30));
 
-		cq.where(AbstractAdoService.and(cb, defaultFilter, userFilter, samePersonFilter, diseaseFilter, cazeFilter, recentContactsFilter));
+		cq.where(BaseAdoService.and(cb, defaultFilter, userFilter, samePersonFilter, diseaseFilter, cazeFilter, recentContactsFilter));
 
 		List<SimilarContactDto> contacts = em.createQuery(cq).getResultList();
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/contact/ContactListCriteriaBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/contact/ContactListCriteriaBuilder.java
@@ -27,7 +27,7 @@ import de.symeda.sormas.api.contact.ContactIndexDto;
 import de.symeda.sormas.api.contact.ContactJurisdictionDto;
 import de.symeda.sormas.api.utils.SortProperty;
 import de.symeda.sormas.backend.caze.Case;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.facility.Facility;
 import de.symeda.sormas.backend.infrastructure.PointOfEntry;
 import de.symeda.sormas.backend.location.Location;
@@ -256,7 +256,7 @@ public class ContactListCriteriaBuilder {
 
 		if (contactCriteria != null) {
 			Predicate criteriaFilter = contactService.buildCriteriaFilter(contactCriteria, cb, contact, joins);
-			filter = AbstractAdoService.and(cb, filter, criteriaFilter);
+			filter = BaseAdoService.and(cb, filter, criteriaFilter);
 		}
 		return filter;
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/contact/ContactService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/contact/ContactService.java
@@ -70,7 +70,7 @@ import de.symeda.sormas.api.visit.VisitStatus;
 import de.symeda.sormas.backend.caze.Case;
 import de.symeda.sormas.backend.caze.CaseService;
 import de.symeda.sormas.backend.clinicalcourse.HealthConditionsService;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.common.AbstractCoreAdoService;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
 import de.symeda.sormas.backend.common.CoreAdo;
@@ -155,12 +155,12 @@ public class ContactService extends AbstractCoreAdoService<Contact> {
 
 		if (getCurrentUser() != null) {
 			Predicate userFilter = createUserFilter(cb, cq, from);
-			filter = AbstractAdoService.and(cb, filter, userFilter);
+			filter = BaseAdoService.and(cb, filter, userFilter);
 		}
 
 		if (date != null) {
 			Predicate dateFilter = createChangeDateFilter(cb, from, date);
-			filter = AbstractAdoService.and(cb, filter, dateFilter);
+			filter = BaseAdoService.and(cb, filter, dateFilter);
 		}
 
 		cq.where(filter);
@@ -196,7 +196,7 @@ public class ContactService extends AbstractCoreAdoService<Contact> {
 
 		if (user != null) {
 			Predicate userFilter = createUserFilter(cb, cq, from);
-			filter = AbstractAdoService.and(cb, filter, userFilter);
+			filter = BaseAdoService.and(cb, filter, userFilter);
 		}
 
 		cq.where(filter);
@@ -456,7 +456,7 @@ public class ContactService extends AbstractCoreAdoService<Contact> {
 		Disease disease,
 		List<String> caseUuids) {
 		Predicate filter = createActiveContactsFilter(cb, contactRoot);
-		filter = AbstractAdoService.and(cb, filter, createUserFilter(cb, cq, contactRoot));
+		filter = BaseAdoService.and(cb, filter, createUserFilter(cb, cq, contactRoot));
 
 		if (!CollectionUtils.isEmpty(caseUuids)) {
 			Path<Object> contactCaseUuid = contactRoot.get(Contact.CAZE).get(Case.UUID);
@@ -475,7 +475,7 @@ public class ContactService extends AbstractCoreAdoService<Contact> {
 			}
 		}
 
-		filter = AbstractAdoService.and(cb, filter, getRegionDistrictDiseasePredicate(region, district, disease, cb, contactRoot, cazeJoin));
+		filter = BaseAdoService.and(cb, filter, getRegionDistrictDiseasePredicate(region, district, disease, cb, contactRoot, cazeJoin));
 
 		// Only retrieve contacts that are currently under follow-up
 		Predicate followUpFilter = cb.equal(contactRoot.get(Contact.FOLLOW_UP_STATUS), FollowUpStatus.FOLLOW_UP);
@@ -496,7 +496,7 @@ public class ContactService extends AbstractCoreAdoService<Contact> {
 		Join<Contact, Case> caze = contact.join(Contact.CAZE, JoinType.LEFT);
 
 		Predicate filter = createDefaultFilter(cb, contact);
-		filter = AbstractAdoService.and(cb, filter, createUserFilter(cb, cq, contact));
+		filter = BaseAdoService.and(cb, filter, createUserFilter(cb, cq, contact));
 
 		Predicate dateFilter = buildDateFilter(cb, contact, from, to);
 		if (filter != null) {
@@ -505,7 +505,7 @@ public class ContactService extends AbstractCoreAdoService<Contact> {
 			filter = dateFilter;
 		}
 
-		filter = AbstractAdoService.and(cb, filter, getRegionDistrictDiseasePredicate(region, district, disease, cb, contact, caze));
+		filter = BaseAdoService.and(cb, filter, getRegionDistrictDiseasePredicate(region, district, disease, cb, contact, caze));
 
 		if (filter != null) {
 			cq.where(filter);
@@ -576,7 +576,7 @@ public class ContactService extends AbstractCoreAdoService<Contact> {
 				cb.equal(contact.get(Contact.REGION), region),
 				cb.and(cb.isNull(contact.get(Contact.REGION)), cb.equal(caze.get(Case.REGION), region)));
 
-			filter = AbstractAdoService.and(cb, filter, regionFilter);
+			filter = BaseAdoService.and(cb, filter, regionFilter);
 		}
 
 		if (district != null) {
@@ -584,13 +584,13 @@ public class ContactService extends AbstractCoreAdoService<Contact> {
 				cb.equal(contact.get(Contact.DISTRICT), district),
 				cb.and(cb.isNull(contact.get(Contact.DISTRICT)), cb.equal(caze.get(Case.DISTRICT), district)));
 
-			filter = AbstractAdoService.and(cb, filter, districtFilter);
+			filter = BaseAdoService.and(cb, filter, districtFilter);
 		}
 
 		if (disease != null) {
 			Predicate diseaseFilter = cb.equal(contact.get(Contact.DISEASE), disease);
 
-			filter = AbstractAdoService.and(cb, filter, diseaseFilter);
+			filter = BaseAdoService.and(cb, filter, diseaseFilter);
 		}
 		return filter;
 	}
@@ -609,13 +609,13 @@ public class ContactService extends AbstractCoreAdoService<Contact> {
 		Join<Contact, Case> caze = contact.join(Contact.CAZE, JoinType.LEFT);
 
 		Predicate filter = createDefaultFilter(cb, contact);
-		filter = AbstractAdoService.and(cb, filter, createUserFilter(cb, cq, contact));
+		filter = BaseAdoService.and(cb, filter, createUserFilter(cb, cq, contact));
 
 		Predicate quarantineDateFilter = buildQuarantineDateFilter(cb, contact, from, to);
 
-		filter = AbstractAdoService.and(cb, filter, quarantineDateFilter);
+		filter = BaseAdoService.and(cb, filter, quarantineDateFilter);
 
-		filter = AbstractAdoService.and(cb, filter, getRegionDistrictDiseasePredicate(region, district, disease, cb, contact, caze));
+		filter = BaseAdoService.and(cb, filter, getRegionDistrictDiseasePredicate(region, district, disease, cb, contact, caze));
 
 		if (filter != null) {
 			cq.where(filter);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/disease/DiseaseConfigurationService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/disease/DiseaseConfigurationService.java
@@ -11,10 +11,11 @@ import javax.persistence.criteria.Root;
 
 import de.symeda.sormas.api.Disease;
 import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.AbstractUserAdoService;
 
 @Stateless
 @LocalBean
-public class DiseaseConfigurationService extends AbstractAdoService<DiseaseConfiguration> {
+public class DiseaseConfigurationService extends AbstractUserAdoService<DiseaseConfiguration> {
 
 	public DiseaseConfigurationService() {
 		super(DiseaseConfiguration.class);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/disease/DiseaseConfigurationService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/disease/DiseaseConfigurationService.java
@@ -10,12 +10,11 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
 import de.symeda.sormas.api.Disease;
-import de.symeda.sormas.backend.common.AbstractAdoService;
-import de.symeda.sormas.backend.common.AbstractUserAdoService;
+import de.symeda.sormas.backend.common.AdoServiceWithUserFilter;
 
 @Stateless
 @LocalBean
-public class DiseaseConfigurationService extends AbstractUserAdoService<DiseaseConfiguration> {
+public class DiseaseConfigurationService extends AdoServiceWithUserFilter<DiseaseConfiguration> {
 
 	public DiseaseConfigurationService() {
 		super(DiseaseConfiguration.class);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/document/DocumentService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/document/DocumentService.java
@@ -27,11 +27,12 @@ import javax.persistence.criteria.Root;
 
 import de.symeda.sormas.api.document.DocumentRelatedEntityType;
 import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.AbstractUserAdoService;
 import de.symeda.sormas.backend.event.Event;
 
 @Stateless
 @LocalBean
-public class DocumentService extends AbstractAdoService<Document> {
+public class DocumentService extends AbstractUserAdoService<Document> {
 
 	public DocumentService() {
 		super(Document.class);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/document/DocumentService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/document/DocumentService.java
@@ -26,13 +26,11 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
 import de.symeda.sormas.api.document.DocumentRelatedEntityType;
-import de.symeda.sormas.backend.common.AbstractAdoService;
-import de.symeda.sormas.backend.common.AbstractUserAdoService;
-import de.symeda.sormas.backend.event.Event;
+import de.symeda.sormas.backend.common.AdoServiceWithUserFilter;
 
 @Stateless
 @LocalBean
-public class DocumentService extends AbstractUserAdoService<Document> {
+public class DocumentService extends AdoServiceWithUserFilter<Document> {
 
 	public DocumentService() {
 		super(Document.class);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/epidata/EpiDataService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/epidata/EpiDataService.java
@@ -28,13 +28,13 @@ import javax.persistence.criteria.JoinType;
 import javax.persistence.criteria.Predicate;
 
 import de.symeda.sormas.api.utils.DataHelper;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
 import de.symeda.sormas.backend.exposure.Exposure;
 
 @Stateless
 @LocalBean
-public class EpiDataService extends AbstractAdoService<EpiData> {
+public class EpiDataService extends BaseAdoService<EpiData> {
 
 	public EpiDataService() {
 		super(EpiData.class);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/epidata/EpiDataService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/epidata/EpiDataService.java
@@ -22,7 +22,6 @@ import java.sql.Timestamp;
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
 import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.From;
 import javax.persistence.criteria.Join;
 import javax.persistence.criteria.JoinType;
@@ -46,13 +45,6 @@ public class EpiDataService extends AbstractAdoService<EpiData> {
 		EpiData epiData = new EpiData();
 		epiData.setUuid(DataHelper.createUuid());
 		return epiData;
-	}
-
-	@SuppressWarnings("rawtypes")
-	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, EpiData> from) {
-		// A user should not directly query for this
-		throw new UnsupportedOperationException();
 	}
 
 	@Override

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/event/EventFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/event/EventFacadeEjb.java
@@ -60,7 +60,7 @@ import de.symeda.sormas.api.event.EventStatus;
 import de.symeda.sormas.api.user.UserRight;
 import de.symeda.sormas.api.utils.SortProperty;
 import de.symeda.sormas.backend.caze.Case;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
 import de.symeda.sormas.backend.contact.Contact;
 import de.symeda.sormas.backend.location.Location;
@@ -205,7 +205,7 @@ public class EventFacadeEjb implements EventFacade {
 
 		if (eventCriteria != null) {
 			Predicate criteriaFilter = eventService.buildCriteriaFilter(eventCriteria, cb, event);
-			filter = AbstractAdoService.and(cb, filter, criteriaFilter);
+			filter = BaseAdoService.and(cb, filter, criteriaFilter);
 		}
 
 		cq.where(filter);
@@ -261,7 +261,7 @@ public class EventFacadeEjb implements EventFacade {
 
 		if (eventCriteria != null) {
 			Predicate criteriaFilter = eventService.buildCriteriaFilter(eventCriteria, cb, event);
-			filter = AbstractAdoService.and(cb, filter, criteriaFilter);
+			filter = BaseAdoService.and(cb, filter, criteriaFilter);
 		}
 
 		cq.where(filter);
@@ -437,7 +437,7 @@ public class EventFacadeEjb implements EventFacade {
 
 		if (eventCriteria != null) {
 			Predicate criteriaFilter = eventService.buildCriteriaFilter(eventCriteria, cb, event);
-			filter = AbstractAdoService.and(cb, filter, criteriaFilter);
+			filter = BaseAdoService.and(cb, filter, criteriaFilter);
 		}
 
 		cq.where(filter);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/event/EventParticipantService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/event/EventParticipantService.java
@@ -36,7 +36,7 @@ import javax.persistence.criteria.Root;
 import de.symeda.sormas.api.event.EventParticipantCriteria;
 import de.symeda.sormas.api.utils.DataHelper;
 import de.symeda.sormas.backend.caze.Case;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.common.AbstractCoreAdoService;
 import de.symeda.sormas.backend.person.Person;
 import de.symeda.sormas.backend.sample.SampleService;
@@ -68,7 +68,7 @@ public class EventParticipantService extends AbstractCoreAdoService<EventPartici
 
 		if (user != null) {
 			Predicate userFilter = createUserFilter(cb, cq, from);
-			filter = AbstractAdoService.and(cb, filter, userFilter);
+			filter = BaseAdoService.and(cb, filter, userFilter);
 		}
 
 		if (date != null) {
@@ -97,7 +97,7 @@ public class EventParticipantService extends AbstractCoreAdoService<EventPartici
 
 		if (user != null) {
 			Predicate userFilter = createUserFilter(cb, cq, from);
-			filter = AbstractAdoService.and(cb, filter, userFilter);
+			filter = BaseAdoService.and(cb, filter, userFilter);
 		}
 
 		cq.where(filter);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/event/EventService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/event/EventService.java
@@ -55,7 +55,7 @@ import de.symeda.sormas.backend.action.Action;
 import de.symeda.sormas.backend.action.ActionService;
 import de.symeda.sormas.backend.caze.Case;
 import de.symeda.sormas.backend.caze.CaseService;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.common.AbstractCoreAdoService;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
 import de.symeda.sormas.backend.common.CoreAdo;
@@ -107,7 +107,7 @@ public class EventService extends AbstractCoreAdoService<Event> {
 			eventUserFilterCriteria.forceRegionJurisdiction(true);
 
 			Predicate userFilter = createUserFilter(cb, cq, from, eventUserFilterCriteria);
-			filter = AbstractAdoService.and(cb, filter, userFilter);
+			filter = BaseAdoService.and(cb, filter, userFilter);
 		}
 
 		if (date != null) {
@@ -137,7 +137,7 @@ public class EventService extends AbstractCoreAdoService<Event> {
 			eventUserFilterCriteria.forceRegionJurisdiction(true);
 
 			Predicate userFilter = createUserFilter(cb, cq, from, eventUserFilterCriteria);
-			filter = AbstractAdoService.and(cb, filter, userFilter);
+			filter = BaseAdoService.and(cb, filter, userFilter);
 		}
 
 		cq.where(filter);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/exposure/ExposureService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/exposure/ExposureService.java
@@ -45,10 +45,4 @@ public class ExposureService extends AbstractAdoService<Exposure> {
 		em.createQuery(cu).executeUpdate();
 	}
 
-	@SuppressWarnings("rawtypes")
-	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Exposure> from) {
-		// A user should not directly query for this
-		throw new UnsupportedOperationException();
-	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/exposure/ExposureService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/exposure/ExposureService.java
@@ -18,17 +18,14 @@ package de.symeda.sormas.backend.exposure;
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
 import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.CriteriaUpdate;
-import javax.persistence.criteria.From;
-import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 
 @Stateless
 @LocalBean
-public class ExposureService extends AbstractAdoService<Exposure> {
+public class ExposureService extends BaseAdoService<Exposure> {
 
 	public ExposureService() {
 		super(Exposure.class);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/facility/FacilityFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/facility/FacilityFacadeEjb.java
@@ -55,7 +55,7 @@ import de.symeda.sormas.api.region.CommunityReferenceDto;
 import de.symeda.sormas.api.region.DistrictReferenceDto;
 import de.symeda.sormas.api.utils.SortProperty;
 import de.symeda.sormas.api.utils.ValidationRuntimeException;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.region.Community;
 import de.symeda.sormas.backend.region.CommunityFacadeEjb;
 import de.symeda.sormas.backend.region.CommunityService;
@@ -156,7 +156,7 @@ public class FacilityFacadeEjb implements FacilityFacade {
 
 		if (regionUuid != null) {
 			Predicate regionFilter = cb.equal(facility.get(Facility.REGION), regionService.getByUuid(regionUuid));
-			filter = AbstractAdoService.and(cb, filter, regionFilter);
+			filter = BaseAdoService.and(cb, filter, regionFilter);
 		}
 
 		if (filter != null) {
@@ -178,7 +178,7 @@ public class FacilityFacadeEjb implements FacilityFacade {
 		Predicate filter = facilityService.createChangeDateFilter(cb, facility, date);
 
 		Predicate regionFilter = cb.isNull(facility.get(Facility.REGION));
-		filter = AbstractAdoService.and(cb, filter, regionFilter);
+		filter = BaseAdoService.and(cb, filter, regionFilter);
 
 		if (filter != null) {
 			cq.where(filter);
@@ -401,7 +401,7 @@ public class FacilityFacadeEjb implements FacilityFacade {
 			cb.notEqual(facility.get(Facility.UUID), FacilityDto.OTHER_FACILITY_UUID),
 			cb.notEqual(facility.get(Facility.UUID), FacilityDto.NONE_FACILITY_UUID));
 		if (filter != null) {
-			filter = AbstractAdoService.and(cb, filter, excludeFilter);
+			filter = BaseAdoService.and(cb, filter, excludeFilter);
 		} else {
 			filter = excludeFilter;
 		}
@@ -473,7 +473,7 @@ public class FacilityFacadeEjb implements FacilityFacade {
 			cb.notEqual(root.get(Facility.UUID), FacilityDto.OTHER_FACILITY_UUID),
 			cb.notEqual(root.get(Facility.UUID), FacilityDto.NONE_FACILITY_UUID));
 		if (filter != null) {
-			filter = AbstractAdoService.and(cb, filter, excludeFilter);
+			filter = BaseAdoService.and(cb, filter, excludeFilter);
 		} else {
 			filter = excludeFilter;
 		}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/feature/FeatureConfigurationService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/feature/FeatureConfigurationService.java
@@ -15,12 +15,11 @@ import javax.persistence.criteria.From;
 import javax.persistence.criteria.JoinType;
 import javax.persistence.criteria.Predicate;
 
-import de.symeda.sormas.backend.common.AbstractUserAdoService;
+import de.symeda.sormas.backend.common.AdoServiceWithUserFilter;
 import org.apache.commons.lang3.ArrayUtils;
 
 import de.symeda.sormas.api.feature.FeatureConfigurationCriteria;
 import de.symeda.sormas.api.feature.FeatureType;
-import de.symeda.sormas.backend.common.AbstractAdoService;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
 import de.symeda.sormas.backend.region.District;
 import de.symeda.sormas.backend.region.Region;
@@ -28,7 +27,7 @@ import de.symeda.sormas.backend.user.User;
 
 @Stateless
 @LocalBean
-public class FeatureConfigurationService extends AbstractUserAdoService<FeatureConfiguration> {
+public class FeatureConfigurationService extends AdoServiceWithUserFilter<FeatureConfiguration> {
 
 	public FeatureConfigurationService() {
 		super(FeatureConfiguration.class);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/feature/FeatureConfigurationService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/feature/FeatureConfigurationService.java
@@ -15,6 +15,7 @@ import javax.persistence.criteria.From;
 import javax.persistence.criteria.JoinType;
 import javax.persistence.criteria.Predicate;
 
+import de.symeda.sormas.backend.common.AbstractUserAdoService;
 import org.apache.commons.lang3.ArrayUtils;
 
 import de.symeda.sormas.api.feature.FeatureConfigurationCriteria;
@@ -27,7 +28,7 @@ import de.symeda.sormas.backend.user.User;
 
 @Stateless
 @LocalBean
-public class FeatureConfigurationService extends AbstractAdoService<FeatureConfiguration> {
+public class FeatureConfigurationService extends AbstractUserAdoService<FeatureConfiguration> {
 
 	public FeatureConfigurationService() {
 		super(FeatureConfiguration.class);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/hospitalization/HospitalizationService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/hospitalization/HospitalizationService.java
@@ -19,17 +19,13 @@ package de.symeda.sormas.backend.hospitalization;
 
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.From;
-import javax.persistence.criteria.Predicate;
 
 import de.symeda.sormas.api.utils.DataHelper;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 
 @Stateless
 @LocalBean
-public class HospitalizationService extends AbstractAdoService<Hospitalization> {
+public class HospitalizationService extends BaseAdoService<Hospitalization> {
 
 	public HospitalizationService() {
 		super(Hospitalization.class);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/hospitalization/HospitalizationService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/hospitalization/HospitalizationService.java
@@ -42,10 +42,4 @@ public class HospitalizationService extends AbstractAdoService<Hospitalization> 
 		return hospitalization;
 	}
 
-	@SuppressWarnings("rawtypes")
-	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Hospitalization> from) {
-		// A user should not directly query for this
-		throw new UnsupportedOperationException();
-	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/hospitalization/PreviousHospitalizationService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/hospitalization/PreviousHospitalizationService.java
@@ -27,7 +27,6 @@ import javax.persistence.criteria.Expression;
 import javax.persistence.criteria.From;
 import javax.persistence.criteria.Join;
 import javax.persistence.criteria.JoinType;
-import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
 import de.symeda.sormas.backend.caze.Case;
@@ -39,13 +38,6 @@ public class PreviousHospitalizationService extends AbstractAdoService<PreviousH
 
 	public PreviousHospitalizationService() {
 		super(PreviousHospitalization.class);
-	}
-
-	@SuppressWarnings("rawtypes")
-	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, PreviousHospitalization> from) {
-		// A user should not directly query for this
-		throw new UnsupportedOperationException();
 	}
 
 	public List<Object[]> getFirstPreviousHospitalizations(List<Long> caseIds) {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/hospitalization/PreviousHospitalizationService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/hospitalization/PreviousHospitalizationService.java
@@ -24,17 +24,16 @@ import javax.ejb.Stateless;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Expression;
-import javax.persistence.criteria.From;
 import javax.persistence.criteria.Join;
 import javax.persistence.criteria.JoinType;
 import javax.persistence.criteria.Root;
 
 import de.symeda.sormas.backend.caze.Case;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 
 @Stateless
 @LocalBean
-public class PreviousHospitalizationService extends AbstractAdoService<PreviousHospitalization> {
+public class PreviousHospitalizationService extends BaseAdoService<PreviousHospitalization> {
 
 	public PreviousHospitalizationService() {
 		super(PreviousHospitalization.class);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/importexport/ExportConfigurationService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/importexport/ExportConfigurationService.java
@@ -2,16 +2,12 @@ package de.symeda.sormas.backend.importexport;
 
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.From;
-import javax.persistence.criteria.Predicate;
 
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 
 @Stateless
 @LocalBean
-public class ExportConfigurationService extends AbstractAdoService<ExportConfiguration> {
+public class ExportConfigurationService extends BaseAdoService<ExportConfiguration> {
 
 	public ExportConfigurationService() {
 		super(ExportConfiguration.class);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/importexport/ExportConfigurationService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/importexport/ExportConfigurationService.java
@@ -17,10 +17,4 @@ public class ExportConfigurationService extends AbstractAdoService<ExportConfigu
 		super(ExportConfiguration.class);
 	}
 
-	@SuppressWarnings("rawtypes")
-	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, ExportConfiguration> from) {
-		// A user should not query for this
-		throw new UnsupportedOperationException();
-	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/PointOfEntryFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/PointOfEntryFacadeEjb.java
@@ -33,7 +33,7 @@ import de.symeda.sormas.api.infrastructure.PointOfEntryReferenceDto;
 import de.symeda.sormas.api.region.DistrictReferenceDto;
 import de.symeda.sormas.api.utils.SortProperty;
 import de.symeda.sormas.api.utils.ValidationRuntimeException;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.facility.Facility;
 import de.symeda.sormas.backend.region.District;
 import de.symeda.sormas.backend.region.DistrictFacadeEjb;
@@ -209,7 +209,7 @@ public class PointOfEntryFacadeEjb implements PointOfEntryFacade {
 			cb.notEqual(pointOfEntry.get(PointOfEntry.UUID), PointOfEntryDto.OTHER_POE_UUID));
 
 		if (filter != null) {
-			filter = AbstractAdoService.and(cb, filter, excludeFilter);
+			filter = BaseAdoService.and(cb, filter, excludeFilter);
 		} else {
 			filter = excludeFilter;
 		}
@@ -277,7 +277,7 @@ public class PointOfEntryFacadeEjb implements PointOfEntryFacade {
 			cb.notEqual(root.get(PointOfEntry.UUID), PointOfEntryDto.OTHER_POE_UUID));
 
 		if (filter != null) {
-			filter = AbstractAdoService.and(cb, filter, excludeFilter);
+			filter = BaseAdoService.and(cb, filter, excludeFilter);
 		} else {
 			filter = excludeFilter;
 		}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/PopulationDataService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/PopulationDataService.java
@@ -10,12 +10,13 @@ import javax.persistence.criteria.Predicate;
 
 import de.symeda.sormas.api.infrastructure.PopulationDataCriteria;
 import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.AbstractUserAdoService;
 import de.symeda.sormas.backend.region.District;
 import de.symeda.sormas.backend.region.Region;
 
 @Stateless
 @LocalBean
-public class PopulationDataService extends AbstractAdoService<PopulationData> {
+public class PopulationDataService extends AbstractUserAdoService<PopulationData> {
 
 	public PopulationDataService() {
 		super(PopulationData.class);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/PopulationDataService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/PopulationDataService.java
@@ -9,14 +9,13 @@ import javax.persistence.criteria.JoinType;
 import javax.persistence.criteria.Predicate;
 
 import de.symeda.sormas.api.infrastructure.PopulationDataCriteria;
-import de.symeda.sormas.backend.common.AbstractAdoService;
-import de.symeda.sormas.backend.common.AbstractUserAdoService;
+import de.symeda.sormas.backend.common.AdoServiceWithUserFilter;
 import de.symeda.sormas.backend.region.District;
 import de.symeda.sormas.backend.region.Region;
 
 @Stateless
 @LocalBean
-public class PopulationDataService extends AbstractUserAdoService<PopulationData> {
+public class PopulationDataService extends AdoServiceWithUserFilter<PopulationData> {
 
 	public PopulationDataService() {
 		super(PopulationData.class);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/labmessage/LabMessageService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/labmessage/LabMessageService.java
@@ -1,10 +1,5 @@
 package de.symeda.sormas.backend.labmessage;
 
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.From;
-import javax.persistence.criteria.Predicate;
-
 import de.symeda.sormas.backend.common.AbstractAdoService;
 
 public class LabMessageService extends AbstractAdoService<LabMessage> {
@@ -13,8 +8,4 @@ public class LabMessageService extends AbstractAdoService<LabMessage> {
 		super(LabMessage.class);
 	}
 
-	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, LabMessage> from) {
-		throw new UnsupportedOperationException();
-	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/labmessage/LabMessageService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/labmessage/LabMessageService.java
@@ -1,8 +1,8 @@
 package de.symeda.sormas.backend.labmessage;
 
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 
-public class LabMessageService extends AbstractAdoService<LabMessage> {
+public class LabMessageService extends BaseAdoService<LabMessage> {
 
 	public LabMessageService() {
 		super(LabMessage.class);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/location/LocationService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/location/LocationService.java
@@ -17,14 +17,10 @@
  *******************************************************************************/
 package de.symeda.sormas.backend.location;
 
+import de.symeda.sormas.backend.common.AbstractAdoService;
+
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.From;
-import javax.persistence.criteria.Predicate;
-
-import de.symeda.sormas.backend.common.AbstractAdoService;
 
 @Stateless
 @LocalBean
@@ -34,10 +30,4 @@ public class LocationService extends AbstractAdoService<Location> {
 		super(Location.class);
 	}
 
-	@SuppressWarnings("rawtypes")
-	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Location> from) {
-		// A user should not directly query for this
-		throw new UnsupportedOperationException();
-	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/location/LocationService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/location/LocationService.java
@@ -17,14 +17,14 @@
  *******************************************************************************/
 package de.symeda.sormas.backend.location;
 
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
 
 @Stateless
 @LocalBean
-public class LocationService extends AbstractAdoService<Location> {
+public class LocationService extends BaseAdoService<Location> {
 
 	public LocationService() {
 		super(Location.class);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/outbreak/OutbreakService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/outbreak/OutbreakService.java
@@ -35,14 +35,14 @@ import javax.persistence.criteria.Root;
 import de.symeda.sormas.api.Disease;
 import de.symeda.sormas.api.outbreak.OutbreakCriteria;
 import de.symeda.sormas.backend.caze.Case;
-import de.symeda.sormas.backend.common.AbstractUserAdoService;
+import de.symeda.sormas.backend.common.AdoServiceWithUserFilter;
 import de.symeda.sormas.backend.region.District;
 import de.symeda.sormas.backend.region.Region;
 import de.symeda.sormas.backend.user.User;
 
 @Stateless
 @LocalBean
-public class OutbreakService extends AbstractUserAdoService<Outbreak> {
+public class OutbreakService extends AdoServiceWithUserFilter<Outbreak> {
 
 	public OutbreakService() {
 		super(Outbreak.class);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/outbreak/OutbreakService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/outbreak/OutbreakService.java
@@ -35,14 +35,14 @@ import javax.persistence.criteria.Root;
 import de.symeda.sormas.api.Disease;
 import de.symeda.sormas.api.outbreak.OutbreakCriteria;
 import de.symeda.sormas.backend.caze.Case;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.AbstractUserAdoService;
 import de.symeda.sormas.backend.region.District;
 import de.symeda.sormas.backend.region.Region;
 import de.symeda.sormas.backend.user.User;
 
 @Stateless
 @LocalBean
-public class OutbreakService extends AbstractAdoService<Outbreak> {
+public class OutbreakService extends AbstractUserAdoService<Outbreak> {
 
 	public OutbreakService() {
 		super(Outbreak.class);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonFacadeEjb.java
@@ -81,7 +81,7 @@ import de.symeda.sormas.backend.caze.Case;
 import de.symeda.sormas.backend.caze.CaseFacadeEjb.CaseFacadeEjbLocal;
 import de.symeda.sormas.backend.caze.CaseService;
 import de.symeda.sormas.backend.caze.CaseUserFilterCriteria;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.common.ConfigFacadeEjb;
 import de.symeda.sormas.backend.contact.Contact;
 import de.symeda.sormas.backend.contact.ContactService;
@@ -229,8 +229,8 @@ public class PersonFacadeEjb implements PersonFacade {
 
 		Predicate filter =
 			caseService.createUserFilter(cb, cq, root, new CaseUserFilterCriteria().excludeCasesFromContacts(excludeCasesFromContacts));
-		filter = AbstractAdoService.and(cb, filter, caseService.createCriteriaFilter(caseCriteria, cb, cq, root, joins));
-		filter = AbstractAdoService.and(cb, filter, cb.equal(person.get(Person.CAUSE_OF_DEATH_DISEASE), root.get(Case.DISEASE)));
+		filter = BaseAdoService.and(cb, filter, caseService.createCriteriaFilter(caseCriteria, cb, cq, root, joins));
+		filter = BaseAdoService.and(cb, filter, cb.equal(person.get(Person.CAUSE_OF_DEATH_DISEASE), root.get(Case.DISEASE)));
 
 		if (filter != null) {
 			cq.where(filter);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonService.java
@@ -43,6 +43,7 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import javax.persistence.criteria.Subquery;
 
+import de.symeda.sormas.backend.common.AbstractUserAdoService;
 import org.apache.commons.lang3.StringUtils;
 
 import de.symeda.sormas.api.Disease;
@@ -53,7 +54,6 @@ import de.symeda.sormas.api.person.PersonSimilarityCriteria;
 import de.symeda.sormas.api.utils.DateHelper;
 import de.symeda.sormas.backend.caze.Case;
 import de.symeda.sormas.backend.caze.CaseService;
-import de.symeda.sormas.backend.common.AbstractAdoService;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
 import de.symeda.sormas.backend.common.ConfigFacadeEjb.ConfigFacadeEjbLocal;
 import de.symeda.sormas.backend.contact.Contact;
@@ -68,7 +68,7 @@ import de.symeda.sormas.utils.CaseJoins;
 
 @Stateless
 @LocalBean
-public class PersonService extends AbstractAdoService<Person> {
+public class PersonService extends AbstractUserAdoService<Person> {
 
 	@EJB
 	private CaseService caseService;
@@ -142,6 +142,11 @@ public class PersonService extends AbstractAdoService<Person> {
 			.flatMap(List<String>::stream)
 			.distinct()
 			.collect(Collectors.toList());
+	}
+
+	@Override
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Person> from) {
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -443,13 +448,6 @@ public class PersonService extends AbstractAdoService<Person> {
 		}
 
 		return filter;
-	}
-
-	@SuppressWarnings("rawtypes")
-	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Person> from) {
-		// getAllUuids and getAllAfter have custom implementations
-		throw new UnsupportedOperationException();
 	}
 
 	@Override

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonService.java
@@ -43,7 +43,7 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import javax.persistence.criteria.Subquery;
 
-import de.symeda.sormas.backend.common.AbstractUserAdoService;
+import de.symeda.sormas.backend.common.AdoServiceWithUserFilter;
 import org.apache.commons.lang3.StringUtils;
 
 import de.symeda.sormas.api.Disease;
@@ -68,7 +68,7 @@ import de.symeda.sormas.utils.CaseJoins;
 
 @Stateless
 @LocalBean
-public class PersonService extends AbstractUserAdoService<Person> {
+public class PersonService extends AdoServiceWithUserFilter<Person> {
 
 	@EJB
 	private CaseService caseService;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/report/AggregateReportFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/report/AggregateReportFacadeEjb.java
@@ -26,7 +26,7 @@ import de.symeda.sormas.api.report.AggregateReportDto;
 import de.symeda.sormas.api.report.AggregateReportFacade;
 import de.symeda.sormas.api.report.AggregatedCaseCountDto;
 import de.symeda.sormas.api.user.UserRight;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.disease.DiseaseConfigurationFacadeEjb.DiseaseConfigurationFacadeEjbLocal;
 import de.symeda.sormas.backend.facility.FacilityFacadeEjb;
 import de.symeda.sormas.backend.facility.FacilityService;
@@ -110,7 +110,7 @@ public class AggregateReportFacadeEjb implements AggregateReportFacade {
 		Predicate filter = service.createUserFilter(cb, cq, root);
 		if (criteria != null) {
 			Predicate criteriaFilter = service.createCriteriaFilter(criteria, cb, cq, root);
-			filter = AbstractAdoService.and(cb, filter, criteriaFilter);
+			filter = BaseAdoService.and(cb, filter, criteriaFilter);
 		}
 
 		if (filter != null) {
@@ -224,7 +224,7 @@ public class AggregateReportFacadeEjb implements AggregateReportFacade {
 		Predicate filter = service.createUserFilter(cb, cq, root);
 		if (criteria != null) {
 			Predicate criteriaFilter = service.createCriteriaFilter(criteria, cb, cq, root);
-			filter = AbstractAdoService.and(cb, filter, criteriaFilter);
+			filter = BaseAdoService.and(cb, filter, criteriaFilter);
 		}
 
 		if (filter != null) {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/report/AggregateReportService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/report/AggregateReportService.java
@@ -15,8 +15,7 @@ import javax.persistence.criteria.Root;
 import de.symeda.sormas.api.report.AggregateReportCriteria;
 import de.symeda.sormas.api.user.JurisdictionLevel;
 import de.symeda.sormas.api.user.UserRole;
-import de.symeda.sormas.backend.common.AbstractAdoService;
-import de.symeda.sormas.backend.common.AbstractUserAdoService;
+import de.symeda.sormas.backend.common.AdoServiceWithUserFilter;
 import de.symeda.sormas.backend.facility.Facility;
 import de.symeda.sormas.backend.infrastructure.PointOfEntry;
 import de.symeda.sormas.backend.region.District;
@@ -25,7 +24,7 @@ import de.symeda.sormas.backend.user.User;
 
 @Stateless
 @LocalBean
-public class AggregateReportService extends AbstractUserAdoService<AggregateReport> {
+public class AggregateReportService extends AdoServiceWithUserFilter<AggregateReport> {
 
 	public AggregateReportService() {
 		super(AggregateReport.class);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/report/AggregateReportService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/report/AggregateReportService.java
@@ -16,6 +16,7 @@ import de.symeda.sormas.api.report.AggregateReportCriteria;
 import de.symeda.sormas.api.user.JurisdictionLevel;
 import de.symeda.sormas.api.user.UserRole;
 import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.AbstractUserAdoService;
 import de.symeda.sormas.backend.facility.Facility;
 import de.symeda.sormas.backend.infrastructure.PointOfEntry;
 import de.symeda.sormas.backend.region.District;
@@ -24,7 +25,7 @@ import de.symeda.sormas.backend.user.User;
 
 @Stateless
 @LocalBean
-public class AggregateReportService extends AbstractAdoService<AggregateReport> {
+public class AggregateReportService extends AbstractUserAdoService<AggregateReport> {
 
 	public AggregateReportService() {
 		super(AggregateReport.class);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/report/WeeklyReportEntryService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/report/WeeklyReportEntryService.java
@@ -27,11 +27,11 @@ import javax.persistence.criteria.JoinType;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.AbstractUserAdoService;
 
 @Stateless
 @LocalBean
-public class WeeklyReportEntryService extends AbstractAdoService<WeeklyReportEntry> {
+public class WeeklyReportEntryService extends AbstractUserAdoService<WeeklyReportEntry> {
 
 	@EJB
 	private WeeklyReportService weeklyReportService;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/report/WeeklyReportEntryService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/report/WeeklyReportEntryService.java
@@ -27,11 +27,11 @@ import javax.persistence.criteria.JoinType;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
-import de.symeda.sormas.backend.common.AbstractUserAdoService;
+import de.symeda.sormas.backend.common.AdoServiceWithUserFilter;
 
 @Stateless
 @LocalBean
-public class WeeklyReportEntryService extends AbstractUserAdoService<WeeklyReportEntry> {
+public class WeeklyReportEntryService extends AdoServiceWithUserFilter<WeeklyReportEntry> {
 
 	@EJB
 	private WeeklyReportService weeklyReportService;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/report/WeeklyReportService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/report/WeeklyReportService.java
@@ -38,7 +38,7 @@ import de.symeda.sormas.api.report.WeeklyReportCriteria;
 import de.symeda.sormas.api.user.JurisdictionLevel;
 import de.symeda.sormas.api.user.UserRole;
 import de.symeda.sormas.api.utils.EpiWeek;
-import de.symeda.sormas.backend.common.AbstractUserAdoService;
+import de.symeda.sormas.backend.common.AdoServiceWithUserFilter;
 import de.symeda.sormas.backend.facility.Facility;
 import de.symeda.sormas.backend.region.DistrictService;
 import de.symeda.sormas.backend.region.Region;
@@ -48,7 +48,7 @@ import de.symeda.sormas.backend.user.UserService;
 
 @Stateless
 @LocalBean
-public class WeeklyReportService extends AbstractUserAdoService<WeeklyReport> {
+public class WeeklyReportService extends AdoServiceWithUserFilter<WeeklyReport> {
 
 	@EJB
 	private RegionService regionService;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/report/WeeklyReportService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/report/WeeklyReportService.java
@@ -38,7 +38,7 @@ import de.symeda.sormas.api.report.WeeklyReportCriteria;
 import de.symeda.sormas.api.user.JurisdictionLevel;
 import de.symeda.sormas.api.user.UserRole;
 import de.symeda.sormas.api.utils.EpiWeek;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.AbstractUserAdoService;
 import de.symeda.sormas.backend.facility.Facility;
 import de.symeda.sormas.backend.region.DistrictService;
 import de.symeda.sormas.backend.region.Region;
@@ -48,7 +48,7 @@ import de.symeda.sormas.backend.user.UserService;
 
 @Stateless
 @LocalBean
-public class WeeklyReportService extends AbstractAdoService<WeeklyReport> {
+public class WeeklyReportService extends AbstractUserAdoService<WeeklyReport> {
 
 	@EJB
 	private RegionService regionService;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/AdditionalTestService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/AdditionalTestService.java
@@ -16,12 +16,12 @@ import javax.persistence.criteria.Root;
 
 import de.symeda.sormas.backend.caze.Case;
 import de.symeda.sormas.backend.common.AbstractAdoService;
-import de.symeda.sormas.backend.common.AbstractUserAdoService;
+import de.symeda.sormas.backend.common.AdoServiceWithUserFilter;
 import de.symeda.sormas.backend.user.User;
 
 @Stateless
 @LocalBean
-public class AdditionalTestService extends AbstractUserAdoService<AdditionalTest> {
+public class AdditionalTestService extends AdoServiceWithUserFilter<AdditionalTest> {
 
 	@EJB
 	private SampleService sampleService;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/AdditionalTestService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/AdditionalTestService.java
@@ -16,11 +16,12 @@ import javax.persistence.criteria.Root;
 
 import de.symeda.sormas.backend.caze.Case;
 import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.AbstractUserAdoService;
 import de.symeda.sormas.backend.user.User;
 
 @Stateless
 @LocalBean
-public class AdditionalTestService extends AbstractAdoService<AdditionalTest> {
+public class AdditionalTestService extends AbstractUserAdoService<AdditionalTest> {
 
 	@EJB
 	private SampleService sampleService;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/AdditionalTestService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/AdditionalTestService.java
@@ -15,7 +15,7 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
 import de.symeda.sormas.backend.caze.Case;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.common.AdoServiceWithUserFilter;
 import de.symeda.sormas.backend.user.User;
 
@@ -42,7 +42,7 @@ public class AdditionalTestService extends AdoServiceWithUserFilter<AdditionalTe
 
 		if (user != null) {
 			Predicate userFilter = createUserFilter(cb, cq, from);
-			filter = AbstractAdoService.and(cb, filter, userFilter);
+			filter = BaseAdoService.and(cb, filter, userFilter);
 		}
 
 		if (date != null) {
@@ -69,7 +69,7 @@ public class AdditionalTestService extends AdoServiceWithUserFilter<AdditionalTe
 
 		if (user != null) {
 			Predicate userFilter = createUserFilter(cb, cq, from);
-			filter = AbstractAdoService.and(cb, filter, userFilter);
+			filter = BaseAdoService.and(cb, filter, userFilter);
 		}
 
 		cq.where(filter);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/PathogenTestService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/PathogenTestService.java
@@ -34,7 +34,7 @@ import javax.persistence.criteria.Root;
 import de.symeda.sormas.api.sample.PathogenTestResultType;
 import de.symeda.sormas.api.utils.DateHelper;
 import de.symeda.sormas.backend.caze.Case;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.common.AbstractCoreAdoService;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
 import de.symeda.sormas.backend.common.CoreAdo;
@@ -61,12 +61,12 @@ public class PathogenTestService extends AbstractCoreAdoService<PathogenTest> {
 
 		if (user != null) {
 			Predicate userFilter = createUserFilter(cb, cq, from);
-			filter = AbstractAdoService.and(cb, filter, userFilter);
+			filter = BaseAdoService.and(cb, filter, userFilter);
 		}
 
 		if (date != null) {
 			Predicate dateFilter = createChangeDateFilter(cb, from, DateHelper.toTimestampUpper(date));
-			filter = AbstractAdoService.and(cb, filter, dateFilter);
+			filter = BaseAdoService.and(cb, filter, dateFilter);
 		}
 
 		cq.where(filter);
@@ -86,7 +86,7 @@ public class PathogenTestService extends AbstractCoreAdoService<PathogenTest> {
 
 		if (user != null) {
 			Predicate userFilter = createUserFilter(cb, cq, from);
-			filter = AbstractAdoService.and(cb, filter, userFilter);
+			filter = BaseAdoService.and(cb, filter, userFilter);
 		}
 
 		cq.where(filter);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/SampleFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/SampleFacadeEjb.java
@@ -75,7 +75,7 @@ import de.symeda.sormas.backend.caze.CaseFacadeEjb;
 import de.symeda.sormas.backend.caze.CaseFacadeEjb.CaseFacadeEjbLocal;
 import de.symeda.sormas.backend.caze.CaseJurisdictionChecker;
 import de.symeda.sormas.backend.caze.CaseService;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
 import de.symeda.sormas.backend.common.messaging.MessageSubject;
 import de.symeda.sormas.api.messaging.MessageType;
@@ -345,7 +345,7 @@ public class SampleFacadeEjb implements SampleFacade {
 
 		if (sampleCriteria != null) {
 			Predicate criteriaFilter = sampleService.buildCriteriaFilter(sampleCriteria, cb, joins);
-			filter = AbstractAdoService.and(cb, filter, criteriaFilter);
+			filter = BaseAdoService.and(cb, filter, criteriaFilter);
 		}
 
 		if (filter != null) {
@@ -607,12 +607,12 @@ public class SampleFacadeEjb implements SampleFacade {
 
 		if (sampleCriteria != null) {
 			Predicate criteriaFilter = sampleService.buildCriteriaFilter(sampleCriteria, cb, joins);
-			filter = AbstractAdoService.and(cb, filter, criteriaFilter);
+			filter = BaseAdoService.and(cb, filter, criteriaFilter);
 		} else if (caseCriteria != null) {
 			CaseJoins<Sample> caseJoins = new CaseJoins<>(joins.getCaze());
 			Predicate criteriaFilter = caseService.createCriteriaFilter(caseCriteria, cb, cq, joins.getCaze(), caseJoins);
-			filter = AbstractAdoService.and(cb, filter, criteriaFilter);
-			filter = AbstractAdoService.and(cb, filter, cb.isFalse(sample.get(Sample.DELETED)));
+			filter = BaseAdoService.and(cb, filter, criteriaFilter);
+			filter = BaseAdoService.and(cb, filter, cb.isFalse(sample.get(Sample.DELETED)));
 		}
 
 		if (filter != null) {
@@ -702,7 +702,7 @@ public class SampleFacadeEjb implements SampleFacade {
 		Predicate filter = sampleService.createUserFilter(cq, cb, joins, sampleCriteria);
 		if (sampleCriteria != null) {
 			Predicate criteriaFilter = sampleService.buildCriteriaFilter(sampleCriteria, cb, joins);
-			filter = AbstractAdoService.and(cb, filter, criteriaFilter);
+			filter = BaseAdoService.and(cb, filter, criteriaFilter);
 		}
 
 		if (filter != null) {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/SampleService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/SampleService.java
@@ -52,7 +52,7 @@ import de.symeda.sormas.api.user.JurisdictionLevel;
 import de.symeda.sormas.api.utils.DataHelper;
 import de.symeda.sormas.backend.caze.Case;
 import de.symeda.sormas.backend.caze.CaseService;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.common.AbstractCoreAdoService;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
 import de.symeda.sormas.backend.common.CoreAdo;
@@ -66,7 +66,6 @@ import de.symeda.sormas.backend.person.Person;
 import de.symeda.sormas.backend.region.District;
 import de.symeda.sormas.backend.region.Region;
 import de.symeda.sormas.backend.user.User;
-import de.symeda.sormas.backend.util.QueryHelper;
 
 @Stateless
 @LocalBean
@@ -127,12 +126,12 @@ public class SampleService extends AbstractCoreAdoService<Sample> {
 
 		if (user != null) {
 			Predicate userFilter = createUserFilter(cb, cq, from);
-			filter = AbstractAdoService.and(cb, filter, userFilter);
+			filter = BaseAdoService.and(cb, filter, userFilter);
 		}
 
 		if (date != null) {
 			Predicate dateFilter = createChangeDateFilter(cb, from, date);
-			filter = AbstractAdoService.and(cb, filter, dateFilter);
+			filter = BaseAdoService.and(cb, filter, dateFilter);
 		}
 
 		cq.where(filter);
@@ -152,7 +151,7 @@ public class SampleService extends AbstractCoreAdoService<Sample> {
 
 		if (user != null) {
 			Predicate userFilter = createUserFilter(cb, cq, from);
-			filter = AbstractAdoService.and(cb, filter, userFilter);
+			filter = BaseAdoService.and(cb, filter, userFilter);
 		}
 
 		cq.where(filter);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasOriginInfoService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasOriginInfoService.java
@@ -22,11 +22,11 @@ import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.From;
 import javax.persistence.criteria.Predicate;
 
-import de.symeda.sormas.backend.common.AbstractUserAdoService;
+import de.symeda.sormas.backend.common.AdoServiceWithUserFilter;
 
 @Stateless
 @LocalBean
-public class SormasToSormasOriginInfoService extends AbstractUserAdoService<SormasToSormasOriginInfo> {
+public class SormasToSormasOriginInfoService extends AdoServiceWithUserFilter<SormasToSormasOriginInfo> {
 
 	public SormasToSormasOriginInfoService() {
 		super(SormasToSormasOriginInfo.class);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasOriginInfoService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasOriginInfoService.java
@@ -22,11 +22,11 @@ import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.From;
 import javax.persistence.criteria.Predicate;
 
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.AbstractUserAdoService;
 
 @Stateless
 @LocalBean
-public class SormasToSormasOriginInfoService extends AbstractAdoService<SormasToSormasOriginInfo> {
+public class SormasToSormasOriginInfoService extends AbstractUserAdoService<SormasToSormasOriginInfo> {
 
 	public SormasToSormasOriginInfoService() {
 		super(SormasToSormasOriginInfo.class);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasShareInfoService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasShareInfoService.java
@@ -27,13 +27,13 @@ import javax.persistence.criteria.Root;
 
 import de.symeda.sormas.api.sormastosormas.SormasToSormasShareInfoCriteria;
 import de.symeda.sormas.backend.caze.Case;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.AbstractUserAdoService;
 import de.symeda.sormas.backend.contact.Contact;
 import de.symeda.sormas.backend.sample.Sample;
 
 @Stateless
 @LocalBean
-public class SormasToSormasShareInfoService extends AbstractAdoService<SormasToSormasShareInfo> {
+public class SormasToSormasShareInfoService extends AbstractUserAdoService<SormasToSormasShareInfo> {
 
 	public SormasToSormasShareInfoService() {
 		super(SormasToSormasShareInfo.class);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasShareInfoService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasShareInfoService.java
@@ -27,13 +27,13 @@ import javax.persistence.criteria.Root;
 
 import de.symeda.sormas.api.sormastosormas.SormasToSormasShareInfoCriteria;
 import de.symeda.sormas.backend.caze.Case;
-import de.symeda.sormas.backend.common.AbstractUserAdoService;
+import de.symeda.sormas.backend.common.AdoServiceWithUserFilter;
 import de.symeda.sormas.backend.contact.Contact;
 import de.symeda.sormas.backend.sample.Sample;
 
 @Stateless
 @LocalBean
-public class SormasToSormasShareInfoService extends AbstractUserAdoService<SormasToSormasShareInfo> {
+public class SormasToSormasShareInfoService extends AdoServiceWithUserFilter<SormasToSormasShareInfo> {
 
 	public SormasToSormasShareInfoService() {
 		super(SormasToSormasShareInfo.class);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/symptoms/SymptomsService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/symptoms/SymptomsService.java
@@ -17,14 +17,14 @@
  *******************************************************************************/
 package de.symeda.sormas.backend.symptoms;
 
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
 
 @Stateless
 @LocalBean
-public class SymptomsService extends AbstractAdoService<Symptoms> {
+public class SymptomsService extends BaseAdoService<Symptoms> {
 
 	public SymptomsService() {
 		super(Symptoms.class);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/symptoms/SymptomsService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/symptoms/SymptomsService.java
@@ -17,14 +17,10 @@
  *******************************************************************************/
 package de.symeda.sormas.backend.symptoms;
 
+import de.symeda.sormas.backend.common.AbstractAdoService;
+
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.From;
-import javax.persistence.criteria.Predicate;
-
-import de.symeda.sormas.backend.common.AbstractAdoService;
 
 @Stateless
 @LocalBean
@@ -34,10 +30,4 @@ public class SymptomsService extends AbstractAdoService<Symptoms> {
 		super(Symptoms.class);
 	}
 
-	@SuppressWarnings("rawtypes")
-	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Symptoms> from) {
-		// A user should not directly query for this
-		throw new UnsupportedOperationException();
-	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/task/TaskFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/task/TaskFacadeEjb.java
@@ -72,7 +72,7 @@ import de.symeda.sormas.backend.caze.CaseFacadeEjb;
 import de.symeda.sormas.backend.caze.CaseFacadeEjb.CaseFacadeEjbLocal;
 import de.symeda.sormas.backend.caze.CaseJurisdictionChecker;
 import de.symeda.sormas.backend.caze.CaseService;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
 import de.symeda.sormas.backend.common.CronService;
 import de.symeda.sormas.backend.common.messaging.MessageSubject;
@@ -350,12 +350,12 @@ public class TaskFacadeEjb implements TaskFacade {
 		if (taskCriteria == null || !taskCriteria.hasContextCriteria()) {
 			filter = taskService.createUserFilter(cb, cq, task);
 		} else {
-			filter = AbstractAdoService.and(cb, filter, taskService.createAssigneeFilter(cb, joins.getAssignee()));
+			filter = BaseAdoService.and(cb, filter, taskService.createAssigneeFilter(cb, joins.getAssignee()));
 		}
 
 		if (taskCriteria != null) {
 			Predicate criteriaFilter = taskService.buildCriteriaFilter(taskCriteria, cb, task, joins);
-			filter = AbstractAdoService.and(cb, filter, criteriaFilter);
+			filter = BaseAdoService.and(cb, filter, criteriaFilter);
 		}
 
 		if (filter != null) {
@@ -413,12 +413,12 @@ public class TaskFacadeEjb implements TaskFacade {
 		if (taskCriteria == null || !taskCriteria.hasContextCriteria()) {
 			filter = taskService.createUserFilter(cb, cq, task);
 		} else {
-			filter = AbstractAdoService.and(cb, filter, taskService.createAssigneeFilter(cb, joins.getAssignee()));
+			filter = BaseAdoService.and(cb, filter, taskService.createAssigneeFilter(cb, joins.getAssignee()));
 		}
 
 		if (taskCriteria != null) {
 			Predicate criteriaFilter = taskService.buildCriteriaFilter(taskCriteria, cb, task, joins);
-			filter = AbstractAdoService.and(cb, filter, criteriaFilter);
+			filter = BaseAdoService.and(cb, filter, criteriaFilter);
 		}
 
 		if (filter != null) {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/task/TaskService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/task/TaskService.java
@@ -45,6 +45,7 @@ import de.symeda.sormas.api.utils.DataHelper;
 import de.symeda.sormas.backend.caze.Case;
 import de.symeda.sormas.backend.caze.CaseService;
 import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.AbstractUserAdoService;
 import de.symeda.sormas.backend.common.TaskCreationException;
 import de.symeda.sormas.backend.contact.Contact;
 import de.symeda.sormas.backend.contact.ContactService;
@@ -58,7 +59,7 @@ import de.symeda.sormas.backend.user.UserService;
 
 @Stateless
 @LocalBean
-public class TaskService extends AbstractAdoService<Task> {
+public class TaskService extends AbstractUserAdoService<Task> {
 
 	@EJB
 	private CaseService caseService;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/task/TaskService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/task/TaskService.java
@@ -44,7 +44,7 @@ import de.symeda.sormas.api.user.UserRole;
 import de.symeda.sormas.api.utils.DataHelper;
 import de.symeda.sormas.backend.caze.Case;
 import de.symeda.sormas.backend.caze.CaseService;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.common.AdoServiceWithUserFilter;
 import de.symeda.sormas.backend.common.TaskCreationException;
 import de.symeda.sormas.backend.contact.Contact;
@@ -84,12 +84,12 @@ public class TaskService extends AdoServiceWithUserFilter<Task> {
 
 		if (user != null) {
 			Predicate userFilter = createUserFilter(cb, cq, from);
-			filter = AbstractAdoService.and(cb, filter, userFilter);
+			filter = BaseAdoService.and(cb, filter, userFilter);
 		}
 
 		if (date != null) {
 			Predicate dateFilter = createChangeDateFilter(cb, from, date);
-			filter = AbstractAdoService.and(cb, filter, dateFilter);
+			filter = BaseAdoService.and(cb, filter, dateFilter);
 		}
 
 		cq.where(filter);
@@ -109,7 +109,7 @@ public class TaskService extends AdoServiceWithUserFilter<Task> {
 
 		if (user != null) {
 			Predicate userFilter = createUserFilter(cb, cq, from);
-			filter = AbstractAdoService.and(cb, filter, userFilter);
+			filter = BaseAdoService.and(cb, filter, userFilter);
 		}
 
 		cq.where(filter);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/task/TaskService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/task/TaskService.java
@@ -45,7 +45,7 @@ import de.symeda.sormas.api.utils.DataHelper;
 import de.symeda.sormas.backend.caze.Case;
 import de.symeda.sormas.backend.caze.CaseService;
 import de.symeda.sormas.backend.common.AbstractAdoService;
-import de.symeda.sormas.backend.common.AbstractUserAdoService;
+import de.symeda.sormas.backend.common.AdoServiceWithUserFilter;
 import de.symeda.sormas.backend.common.TaskCreationException;
 import de.symeda.sormas.backend.contact.Contact;
 import de.symeda.sormas.backend.contact.ContactService;
@@ -59,7 +59,7 @@ import de.symeda.sormas.backend.user.UserService;
 
 @Stateless
 @LocalBean
-public class TaskService extends AbstractUserAdoService<Task> {
+public class TaskService extends AdoServiceWithUserFilter<Task> {
 
 	@EJB
 	private CaseService caseService;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/therapy/PrescriptionFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/therapy/PrescriptionFacadeEjb.java
@@ -32,7 +32,7 @@ import de.symeda.sormas.api.user.UserRight;
 import de.symeda.sormas.backend.caze.Case;
 import de.symeda.sormas.backend.caze.CaseJurisdictionChecker;
 import de.symeda.sormas.backend.caze.CaseService;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.facility.Facility;
 import de.symeda.sormas.backend.infrastructure.PointOfEntry;
 import de.symeda.sormas.backend.person.Person;
@@ -206,7 +206,7 @@ public class PrescriptionFacadeEjb implements PrescriptionFacade {
 		Predicate filter = service.createUserFilter(cb, cq, prescription);
 		CaseJoins<Therapy> caseJoins = new CaseJoins<>(joins.getCaze());
 		Predicate criteriaFilter = caseService.createCriteriaFilter(criteria, cb, cq, joins.getCaze(), caseJoins);
-		filter = AbstractAdoService.and(cb, filter, criteriaFilter);
+		filter = BaseAdoService.and(cb, filter, criteriaFilter);
 		cq.where(filter);
 		cq.orderBy(cb.desc(joins.getCaze().get(Case.UUID)), cb.desc(prescription.get(Prescription.PRESCRIPTION_DATE)));
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/therapy/PrescriptionService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/therapy/PrescriptionService.java
@@ -15,6 +15,7 @@ import javax.persistence.criteria.JoinType;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
+import de.symeda.sormas.backend.common.AbstractUserAdoService;
 import org.apache.commons.lang3.StringUtils;
 
 import de.symeda.sormas.api.therapy.PrescriptionCriteria;
@@ -25,7 +26,7 @@ import de.symeda.sormas.backend.user.User;
 
 @Stateless
 @LocalBean
-public class PrescriptionService extends AbstractAdoService<Prescription> {
+public class PrescriptionService extends AbstractUserAdoService<Prescription> {
 
 	@EJB
 	private CaseService caseService;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/therapy/PrescriptionService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/therapy/PrescriptionService.java
@@ -21,7 +21,7 @@ import org.apache.commons.lang3.StringUtils;
 import de.symeda.sormas.api.therapy.PrescriptionCriteria;
 import de.symeda.sormas.backend.caze.Case;
 import de.symeda.sormas.backend.caze.CaseService;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.user.User;
 
 @Stateless
@@ -64,12 +64,12 @@ public class PrescriptionService extends AdoServiceWithUserFilter<Prescription> 
 
 		if (user != null) {
 			Predicate userFilter = createUserFilter(cb, cq, from);
-			filter = AbstractAdoService.and(cb, filter, userFilter);
+			filter = BaseAdoService.and(cb, filter, userFilter);
 		}
 
 		if (date != null) {
 			Predicate dateFilter = createChangeDateFilter(cb, from, date);
-			filter = AbstractAdoService.and(cb, filter, dateFilter);
+			filter = BaseAdoService.and(cb, filter, dateFilter);
 		}
 
 		cq.where(filter);
@@ -109,7 +109,7 @@ public class PrescriptionService extends AdoServiceWithUserFilter<Prescription> 
 
 		if (user != null) {
 			Predicate userFilter = createUserFilter(cb, cq, from);
-			filter = AbstractAdoService.and(cb, filter, userFilter);
+			filter = BaseAdoService.and(cb, filter, userFilter);
 		}
 
 		cq.where(filter);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/therapy/PrescriptionService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/therapy/PrescriptionService.java
@@ -15,7 +15,7 @@ import javax.persistence.criteria.JoinType;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
-import de.symeda.sormas.backend.common.AbstractUserAdoService;
+import de.symeda.sormas.backend.common.AdoServiceWithUserFilter;
 import org.apache.commons.lang3.StringUtils;
 
 import de.symeda.sormas.api.therapy.PrescriptionCriteria;
@@ -26,7 +26,7 @@ import de.symeda.sormas.backend.user.User;
 
 @Stateless
 @LocalBean
-public class PrescriptionService extends AbstractUserAdoService<Prescription> {
+public class PrescriptionService extends AdoServiceWithUserFilter<Prescription> {
 
 	@EJB
 	private CaseService caseService;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/therapy/TherapyService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/therapy/TherapyService.java
@@ -2,10 +2,6 @@ package de.symeda.sormas.backend.therapy;
 
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.From;
-import javax.persistence.criteria.Predicate;
 
 import de.symeda.sormas.backend.common.AbstractAdoService;
 
@@ -17,10 +13,4 @@ public class TherapyService extends AbstractAdoService<Therapy> {
 		super(Therapy.class);
 	}
 
-	@SuppressWarnings("rawtypes")
-	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Therapy> from) {
-		// A user should not directly query for this
-		throw new UnsupportedOperationException();
-	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/therapy/TherapyService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/therapy/TherapyService.java
@@ -3,11 +3,11 @@ package de.symeda.sormas.backend.therapy;
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
 
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 
 @Stateless
 @LocalBean
-public class TherapyService extends AbstractAdoService<Therapy> {
+public class TherapyService extends BaseAdoService<Therapy> {
 
 	public TherapyService() {
 		super(Therapy.class);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/therapy/TreatmentFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/therapy/TreatmentFacadeEjb.java
@@ -31,7 +31,7 @@ import de.symeda.sormas.api.user.UserRight;
 import de.symeda.sormas.backend.caze.Case;
 import de.symeda.sormas.backend.caze.CaseJurisdictionChecker;
 import de.symeda.sormas.backend.caze.CaseService;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.facility.Facility;
 import de.symeda.sormas.backend.infrastructure.PointOfEntry;
 import de.symeda.sormas.backend.person.Person;
@@ -197,7 +197,7 @@ public class TreatmentFacadeEjb implements TreatmentFacade {
 		Predicate filter = service.createUserFilter(cb, cq, treatment);
 		CaseJoins<Therapy> caseJoins = new CaseJoins<>(joins.getCaze());
 		Predicate criteriaFilter = caseService.createCriteriaFilter(criteria, cb, cq, joins.getCaze(), caseJoins);
-		filter = AbstractAdoService.and(cb, filter, criteriaFilter);
+		filter = BaseAdoService.and(cb, filter, criteriaFilter);
 		cq.where(filter);
 		cq.orderBy(cb.desc(joins.getCaze().get(Case.UUID)), cb.desc(treatment.get(Treatment.TREATMENT_DATE_TIME)));
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/therapy/TreatmentService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/therapy/TreatmentService.java
@@ -15,6 +15,7 @@ import javax.persistence.criteria.JoinType;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
+import de.symeda.sormas.backend.common.AbstractUserAdoService;
 import org.apache.commons.lang3.StringUtils;
 
 import de.symeda.sormas.api.therapy.TreatmentCriteria;
@@ -25,7 +26,7 @@ import de.symeda.sormas.backend.user.User;
 
 @Stateless
 @LocalBean
-public class TreatmentService extends AbstractAdoService<Treatment> {
+public class TreatmentService extends AbstractUserAdoService<Treatment> {
 
 	@EJB
 	private CaseService caseService;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/therapy/TreatmentService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/therapy/TreatmentService.java
@@ -21,7 +21,7 @@ import org.apache.commons.lang3.StringUtils;
 import de.symeda.sormas.api.therapy.TreatmentCriteria;
 import de.symeda.sormas.backend.caze.Case;
 import de.symeda.sormas.backend.caze.CaseService;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.user.User;
 
 @Stateless
@@ -82,12 +82,12 @@ public class TreatmentService extends AdoServiceWithUserFilter<Treatment> {
 
 		if (user != null) {
 			Predicate userFilter = createUserFilter(cb, cq, from);
-			filter = AbstractAdoService.and(cb, filter, userFilter);
+			filter = BaseAdoService.and(cb, filter, userFilter);
 		}
 
 		if (date != null) {
 			Predicate dateFilter = createChangeDateFilter(cb, from, date);
-			filter = AbstractAdoService.and(cb, filter, dateFilter);
+			filter = BaseAdoService.and(cb, filter, dateFilter);
 		}
 
 		cq.where(filter);
@@ -109,7 +109,7 @@ public class TreatmentService extends AdoServiceWithUserFilter<Treatment> {
 
 		if (user != null) {
 			Predicate userFilter = createUserFilter(cb, cq, from);
-			filter = AbstractAdoService.and(cb, filter, userFilter);
+			filter = BaseAdoService.and(cb, filter, userFilter);
 		}
 
 		cq.where(filter);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/therapy/TreatmentService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/therapy/TreatmentService.java
@@ -15,7 +15,7 @@ import javax.persistence.criteria.JoinType;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
-import de.symeda.sormas.backend.common.AbstractUserAdoService;
+import de.symeda.sormas.backend.common.AdoServiceWithUserFilter;
 import org.apache.commons.lang3.StringUtils;
 
 import de.symeda.sormas.api.therapy.TreatmentCriteria;
@@ -26,7 +26,7 @@ import de.symeda.sormas.backend.user.User;
 
 @Stateless
 @LocalBean
-public class TreatmentService extends AbstractUserAdoService<Treatment> {
+public class TreatmentService extends AdoServiceWithUserFilter<Treatment> {
 
 	@EJB
 	private CaseService caseService;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/user/UserRoleConfigService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/user/UserRoleConfigService.java
@@ -34,12 +34,12 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
 import de.symeda.sormas.api.user.UserRole;
-import de.symeda.sormas.backend.common.AbstractAdoService;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
+import de.symeda.sormas.backend.common.AbstractUserAdoService;
 
 @Stateless
 @LocalBean
-public class UserRoleConfigService extends AbstractAdoService<UserRoleConfig> {
+public class UserRoleConfigService extends AbstractUserAdoService<UserRoleConfig> {
 
 	@Resource
 	private SessionContext sessionContext;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/user/UserRoleConfigService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/user/UserRoleConfigService.java
@@ -35,11 +35,11 @@ import javax.persistence.criteria.Root;
 
 import de.symeda.sormas.api.user.UserRole;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
-import de.symeda.sormas.backend.common.AbstractUserAdoService;
+import de.symeda.sormas.backend.common.AdoServiceWithUserFilter;
 
 @Stateless
 @LocalBean
-public class UserRoleConfigService extends AbstractUserAdoService<UserRoleConfig> {
+public class UserRoleConfigService extends AdoServiceWithUserFilter<UserRoleConfig> {
 
 	@Resource
 	private SessionContext sessionContext;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/user/UserService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/user/UserService.java
@@ -47,8 +47,8 @@ import de.symeda.sormas.api.user.UserRight;
 import de.symeda.sormas.api.user.UserRole;
 import de.symeda.sormas.api.utils.DataHelper;
 import de.symeda.sormas.backend.caze.Case;
-import de.symeda.sormas.backend.common.AbstractAdoService;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
+import de.symeda.sormas.backend.common.AbstractUserAdoService;
 import de.symeda.sormas.backend.facility.Facility;
 import de.symeda.sormas.backend.region.District;
 import de.symeda.sormas.backend.region.Region;
@@ -56,7 +56,7 @@ import de.symeda.sormas.backend.util.PasswordHelper;
 
 @Stateless
 @LocalBean
-public class UserService extends AbstractAdoService<User> {
+public class UserService extends AbstractUserAdoService<User> {
 
 	@EJB
 	private UserRoleConfigFacadeEjb.UserRoleConfigFacadeEjbLocal userRoleConfigFacade;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/user/UserService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/user/UserService.java
@@ -48,7 +48,7 @@ import de.symeda.sormas.api.user.UserRole;
 import de.symeda.sormas.api.utils.DataHelper;
 import de.symeda.sormas.backend.caze.Case;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
-import de.symeda.sormas.backend.common.AbstractUserAdoService;
+import de.symeda.sormas.backend.common.AdoServiceWithUserFilter;
 import de.symeda.sormas.backend.facility.Facility;
 import de.symeda.sormas.backend.region.District;
 import de.symeda.sormas.backend.region.Region;
@@ -56,7 +56,7 @@ import de.symeda.sormas.backend.util.PasswordHelper;
 
 @Stateless
 @LocalBean
-public class UserService extends AbstractUserAdoService<User> {
+public class UserService extends AdoServiceWithUserFilter<User> {
 
 	@EJB
 	private UserRoleConfigFacadeEjb.UserRoleConfigFacadeEjbLocal userRoleConfigFacade;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/visit/VisitService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/visit/VisitService.java
@@ -46,7 +46,7 @@ import de.symeda.sormas.api.utils.DateHelper;
 import de.symeda.sormas.api.visit.VisitCriteria;
 import de.symeda.sormas.backend.caze.Case;
 import de.symeda.sormas.backend.caze.CaseService;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
 import de.symeda.sormas.backend.contact.Contact;
 import de.symeda.sormas.backend.contact.ContactService;
@@ -56,7 +56,7 @@ import de.symeda.sormas.backend.user.User;
 
 @Stateless
 @LocalBean
-public class VisitService extends AbstractAdoService<Visit> {
+public class VisitService extends BaseAdoService<Visit> {
 
 	@EJB
 	private ContactService contactService;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/visit/VisitService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/visit/VisitService.java
@@ -252,13 +252,6 @@ public class VisitService extends AbstractAdoService<Visit> {
 		return filter;
 	}
 
-	@SuppressWarnings("rawtypes")
-	@Override
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Visit> from) {
-		// getAllUuids and getAllAfter have custom implementations
-		throw new UnsupportedOperationException();
-	}
-
 	@Override
 	public Predicate createChangeDateFilter(CriteriaBuilder cb, From<?, Visit> visitPath, Timestamp date) {
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/visualization/VisualizationFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/visualization/VisualizationFacadeEjb.java
@@ -68,7 +68,7 @@ import de.symeda.sormas.api.region.RegionReferenceDto;
 import de.symeda.sormas.api.visualization.VisualizationFacade;
 import de.symeda.sormas.backend.caze.Case;
 import de.symeda.sormas.backend.caze.CaseService;
-import de.symeda.sormas.backend.common.AbstractAdoService;
+import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
 import de.symeda.sormas.backend.common.ConfigFacadeEjb.ConfigFacadeEjbLocal;
 import de.symeda.sormas.backend.contact.Contact;
@@ -168,7 +168,7 @@ public class VisualizationFacadeEjb implements VisualizationFacade {
 		Collection<Disease> diseases) {
 		Join<Contact, Case> caze = root.join(Contact.CAZE, JoinType.LEFT);
 
-		return AbstractAdoService.and(
+		return BaseAdoService.and(
 			cb,
 			contactService.createUserFilter(cb, cq, root),
 			contactService.createActiveContactsFilter(cb, root),

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/common/BaseAdoServiceTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/common/BaseAdoServiceTest.java
@@ -17,23 +17,23 @@ import javax.persistence.criteria.Selection;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
-public class AbstractAdoServiceTest {
+public class BaseAdoServiceTest {
 
 	@Test
 	public void testReduce() {
 
 		//all null
-		assertThat(AbstractAdoService.reduce(null), nullValue());
-		assertThat(AbstractAdoService.reduce(null, (Predicate) null), nullValue());
-		assertThat(AbstractAdoService.reduce(null, null, null), nullValue());
+		assertThat(BaseAdoService.reduce(null), nullValue());
+		assertThat(BaseAdoService.reduce(null, (Predicate) null), nullValue());
+		assertThat(BaseAdoService.reduce(null, null, null), nullValue());
 
 		DummyPredicate p0 = new DummyPredicate();
 
 		//one non-null
-		assertThat(AbstractAdoService.reduce(null, p0), sameInstance(p0));
-		assertThat(AbstractAdoService.reduce(null, p0, null), sameInstance(p0));
-		assertThat(AbstractAdoService.reduce(null, null, p0), sameInstance(p0));
-		assertThat(AbstractAdoService.reduce(null, null, null, null, null, p0, null, null, null), sameInstance(p0));
+		assertThat(BaseAdoService.reduce(null, p0), sameInstance(p0));
+		assertThat(BaseAdoService.reduce(null, p0, null), sameInstance(p0));
+		assertThat(BaseAdoService.reduce(null, null, p0), sameInstance(p0));
+		assertThat(BaseAdoService.reduce(null, null, null, null, null, p0, null, null, null), sameInstance(p0));
 
 		DummyPredicate p1 = new DummyPredicate();
 		DummyPredicate p2 = new DummyPredicate();
@@ -49,14 +49,14 @@ public class AbstractAdoServiceTest {
 		};
 
 		//two Arguments
-		assertThat(AbstractAdoService.reduce(op, p0, p1), sameInstance(pr));
+		assertThat(BaseAdoService.reduce(op, p0, p1), sameInstance(pr));
 		assertThat(restrictions, Matchers.contains(p0, p1));
 
-		assertThat(AbstractAdoService.reduce(op, null, null, p0, null, p1, null, null), sameInstance(pr));
+		assertThat(BaseAdoService.reduce(op, null, null, p0, null, p1, null, null), sameInstance(pr));
 		assertThat(restrictions, Matchers.contains(p0, p1));
 
 		//4 Arguments
-		assertThat(AbstractAdoService.reduce(op, null, null, p0, null, p1, null, p2, p3, null), sameInstance(pr));
+		assertThat(BaseAdoService.reduce(op, null, null, p0, null, p1, null, p2, p3, null), sameInstance(pr));
 		assertThat(restrictions, Matchers.contains(p0, p1, p2, p3));
 	}
 


### PR DESCRIPTION
This PR minimizes the need for UnsupportedOperationException 
```
	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Visit> from) {
		// getAllUuids and getAllAfter have custom implementations
		throw new UnsupportedOperationException();
	}
```

This minimizes surprises for developers because a runtime exception is moved to a compile check.

#3906 