### PR TITLE
Fix failing tests in sormas-ui on local path with blanks (fixes #4024)

### DIFF
--- a/sormas-ui/src/test/java/de/symeda/sormas/ui/caze/importer/CaseImporterTest.java
+++ b/sormas-ui/src/test/java/de/symeda/sormas/ui/caze/importer/CaseImporterTest.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.function.Consumer;
 
@@ -33,7 +34,7 @@ import de.symeda.sormas.ui.importer.ImportSimilarityResultOption;
 public class CaseImporterTest extends AbstractBeanTest {
 
 	@Test
-	public void testImportAllCases() throws IOException, InvalidColumnException, InterruptedException, CsvValidationException {
+	public void testImportAllCases() throws IOException, InvalidColumnException, InterruptedException, CsvValidationException, URISyntaxException {
 
 		TestDataCreator creator = new TestDataCreator();
 
@@ -42,7 +43,7 @@ public class CaseImporterTest extends AbstractBeanTest {
 			.createUser(rdcf.region.getUuid(), rdcf.district.getUuid(), rdcf.facility.getUuid(), "Surv", "Sup", UserRole.SURVEILLANCE_SUPERVISOR);
 
 		// Successful import of 5 cases
-		File csvFile = new File(getClass().getClassLoader().getResource("sormas_import_test_success.csv").getFile());
+		File csvFile = new File(getClass().getClassLoader().getResource("sormas_import_test_success.csv").toURI());
 		CaseImporter caseImporter = new CaseImporterExtension(csvFile, true, user.toReference());
 		ImportResultStatus importResult = caseImporter.runImport();
 
@@ -50,7 +51,7 @@ public class CaseImporterTest extends AbstractBeanTest {
 		assertEquals(5, getCaseFacade().count(null));
 
 		// Failed import of 5 cases because of errors
-		csvFile = new File(getClass().getClassLoader().getResource("sormas_import_test_errors.csv").getFile());
+		csvFile = new File(getClass().getClassLoader().getResource("sormas_import_test_errors.csv").toURI());
 		caseImporter = new CaseImporterExtension(csvFile, true, user.toReference());
 		importResult = caseImporter.runImport();
 
@@ -60,10 +61,10 @@ public class CaseImporterTest extends AbstractBeanTest {
 		// Failed import
 		boolean exceptionWasThrown = false;
 
-		csvFile = new File(getClass().getClassLoader().getResource("sormas_import_test_failure.csv").getFile());
+		csvFile = new File(getClass().getClassLoader().getResource("sormas_import_test_failure.csv").toURI());
 		caseImporter = new CaseImporterExtension(csvFile, true, user.toReference());
 		try {
-			importResult = caseImporter.runImport();
+			caseImporter.runImport();
 		} catch (InvalidColumnException e) {
 			exceptionWasThrown = true;
 		}
@@ -71,7 +72,7 @@ public class CaseImporterTest extends AbstractBeanTest {
 		assertEquals(5, getCaseFacade().count(null));
 
 		// Similarity: skip
-		csvFile = new File(getClass().getClassLoader().getResource("sormas_import_test_similarities.csv").getFile());
+		csvFile = new File(getClass().getClassLoader().getResource("sormas_import_test_similarities.csv").toURI());
 		caseImporter = new CaseImporterExtension(csvFile, true, user.toReference()) {
 
 			@Override
@@ -86,7 +87,7 @@ public class CaseImporterTest extends AbstractBeanTest {
 		assertEquals("ABC-DEF-GHI-19-5", getCaseFacade().getAllActiveCasesAfter(null).get(0).getEpidNumber());
 
 		// Similarity: pick
-		csvFile = new File(getClass().getClassLoader().getResource("sormas_import_test_similarities.csv").getFile());
+		csvFile = new File(getClass().getClassLoader().getResource("sormas_import_test_similarities.csv").toURI());
 		caseImporter = new CaseImporterExtension(csvFile, true, user.toReference()) {
 
 			@Override
@@ -110,7 +111,7 @@ public class CaseImporterTest extends AbstractBeanTest {
 		assertEquals("ABC-DEF-GHI-19-5", getCaseFacade().getAllActiveCasesAfter(null).get(0).getEpidNumber());
 
 		// Similarity: cancel
-		csvFile = new File(getClass().getClassLoader().getResource("sormas_import_test_similarities.csv").getFile());
+		csvFile = new File(getClass().getClassLoader().getResource("sormas_import_test_similarities.csv").toURI());
 		caseImporter = new CaseImporterExtension(csvFile, true, user.toReference()) {
 
 			@Override
@@ -125,7 +126,7 @@ public class CaseImporterTest extends AbstractBeanTest {
 		assertEquals("ABC-DEF-GHI-19-5", getCaseFacade().getAllActiveCasesAfter(null).get(0).getEpidNumber());
 
 		// Similarity: override
-		csvFile = new File(getClass().getClassLoader().getResource("sormas_import_test_similarities.csv").getFile());
+		csvFile = new File(getClass().getClassLoader().getResource("sormas_import_test_similarities.csv").toURI());
 		caseImporter = new CaseImporterExtension(csvFile, true, user.toReference()) {
 
 			@Override
@@ -149,7 +150,7 @@ public class CaseImporterTest extends AbstractBeanTest {
 		assertEquals("ABC-DEF-GHI-19-10", getCaseFacade().getAllActiveCasesAfter(null).get(0).getEpidNumber());
 
 		// Similarity: create -> fail because of duplicate epid number
-		csvFile = new File(getClass().getClassLoader().getResource("sormas_import_test_similarities.csv").getFile());
+		csvFile = new File(getClass().getClassLoader().getResource("sormas_import_test_similarities.csv").toURI());
 		caseImporter = new CaseImporterExtension(csvFile, true, user.toReference()) {
 
 			@Override
@@ -179,7 +180,7 @@ public class CaseImporterTest extends AbstractBeanTest {
 		assertEquals("ABC-DEF-GHI-19-99", getCaseFacade().getAllActiveCasesAfter(null).get(0).getEpidNumber());
 
 		// Similarity: create -> pass
-		csvFile = new File(getClass().getClassLoader().getResource("sormas_import_test_similarities.csv").getFile());
+		csvFile = new File(getClass().getClassLoader().getResource("sormas_import_test_similarities.csv").toURI());
 		caseImporter = new CaseImporterExtension(csvFile, true, user.toReference()) {
 
 			@Override
@@ -203,7 +204,7 @@ public class CaseImporterTest extends AbstractBeanTest {
 		creator.createRDCF("R2", "D2", "C2", "F2");
 		creator.createRDCF("R3", "D3", "C3", "F3");
 
-		csvFile = new File(getClass().getClassLoader().getResource("sormas_case_import_test_different_infrastructure.csv").getFile());
+		csvFile = new File(getClass().getClassLoader().getResource("sormas_case_import_test_different_infrastructure.csv").toURI());
 		caseImporter = new CaseImporterExtension(csvFile, true, user.toReference());
 		importResult = caseImporter.runImport();
 
@@ -211,7 +212,7 @@ public class CaseImporterTest extends AbstractBeanTest {
 		assertEquals(7, getCaseFacade().count(null));
 
 		// Successful import of 5 cases from a commented CSV file
-		csvFile = new File(getClass().getClassLoader().getResource("sormas_import_test_comment_success.csv").getFile());
+		csvFile = new File(getClass().getClassLoader().getResource("sormas_import_test_comment_success.csv").toURI());
 		caseImporter = new CaseImporterExtension(csvFile, true, user.toReference());
 		importResult = caseImporter.runImport();
 
@@ -220,13 +221,13 @@ public class CaseImporterTest extends AbstractBeanTest {
 	}
 
 	@Test
-	public void testLineListingImport() throws IOException, InvalidColumnException, InterruptedException, CsvValidationException {
+	public void testLineListingImport() throws IOException, InvalidColumnException, InterruptedException, CsvValidationException, URISyntaxException {
 		TestDataCreator.RDCF rdcf = new TestDataCreator().createRDCF("Abia", "Bende", "Bende Ward", "Bende Maternity Home");
 		UserDto user = creator
 			.createUser(rdcf.region.getUuid(), rdcf.district.getUuid(), rdcf.facility.getUuid(), "Surv", "Sup", UserRole.SURVEILLANCE_SUPERVISOR);
 
 		// Successful import of 5 cases
-		File csvFile = new File(getClass().getClassLoader().getResource("sormas_import_test_line_listing.csv").getFile());
+		File csvFile = new File(getClass().getClassLoader().getResource("sormas_import_test_line_listing.csv").toURI());
 		CaseImporter caseImporter = new CaseImporterExtension(csvFile, false, user.toReference());
 		ImportResultStatus importResult = caseImporter.runImport();
 
@@ -234,7 +235,7 @@ public class CaseImporterTest extends AbstractBeanTest {
 		assertEquals(5, getCaseFacade().count(null));
 
 		// Successful import of 5 cases from commented CSV file
-		csvFile = new File(getClass().getClassLoader().getResource("sormas_import_test_comment_line_listing.csv").getFile());
+		csvFile = new File(getClass().getClassLoader().getResource("sormas_import_test_comment_line_listing.csv").toURI());
 		caseImporter = new CaseImporterExtension(csvFile, false, user.toReference());
 		importResult = caseImporter.runImport();
 
@@ -260,7 +261,7 @@ public class CaseImporterTest extends AbstractBeanTest {
 			return new OutputStreamWriter(new OutputStream() {
 
 				@Override
-				public void write(int b) throws IOException {
+				public void write(int b) {
 					// Do nothing
 				}
 			});

--- a/sormas-ui/src/test/java/de/symeda/sormas/ui/contact/importer/ContactImporterTest.java
+++ b/sormas-ui/src/test/java/de/symeda/sormas/ui/contact/importer/ContactImporterTest.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -43,7 +44,7 @@ import de.symeda.sormas.ui.importer.ImportSimilarityResultOption;
 public class ContactImporterTest extends AbstractBeanTest {
 
 	@Test
-	public void testImportCaseContacts() throws IOException, InvalidColumnException, InterruptedException, CsvValidationException {
+	public void testImportCaseContacts() throws IOException, InvalidColumnException, InterruptedException, CsvValidationException, URISyntaxException {
 
 		ContactFacadeEjb contactFacade = getBean(ContactFacadeEjbLocal.class);
 
@@ -61,7 +62,7 @@ public class ContactImporterTest extends AbstractBeanTest {
 			rdcf);
 
 		// Successful import of 5 case contacts
-		File csvFile = new File(getClass().getClassLoader().getResource("sormas_case_contact_import_test_success.csv").getFile());
+		File csvFile = new File(getClass().getClassLoader().getResource("sormas_case_contact_import_test_success.csv").toURI());
 		ContactImporter contactImporter = new ContactImporterExtension(csvFile, false, user.toReference(), caze);
 		ImportResultStatus importResult = contactImporter.runImport();
 
@@ -70,7 +71,7 @@ public class ContactImporterTest extends AbstractBeanTest {
 
 		// Person Similarity: pick
 		List<PersonNameDto> persons = FacadeProvider.getPersonFacade().getMatchingNameDtos(user.toReference(), new PersonSimilarityCriteria());
-		csvFile = new File(getClass().getClassLoader().getResource("sormas_case_contact_import_test_similarities.csv").getFile());
+		csvFile = new File(getClass().getClassLoader().getResource("sormas_case_contact_import_test_similarities.csv").toURI());
 		contactImporter = new ContactImporterExtension(csvFile, false, user.toReference(), caze) {
 
 			@Override
@@ -93,7 +94,7 @@ public class ContactImporterTest extends AbstractBeanTest {
 		assertEquals(6, getPersonFacade().getAllUuids().size());
 
 		// Person Similarity: skip
-		csvFile = new File(getClass().getClassLoader().getResource("sormas_case_contact_import_test_similarities.csv").getFile());
+		csvFile = new File(getClass().getClassLoader().getResource("sormas_case_contact_import_test_similarities.csv").toURI());
 		contactImporter = new ContactImporterExtension(csvFile, false, user.toReference(), caze) {
 
 			@Override
@@ -108,7 +109,7 @@ public class ContactImporterTest extends AbstractBeanTest {
 		assertEquals(6, getPersonFacade().getAllUuids().size());
 
 		// Person Similarity: create
-		csvFile = new File(getClass().getClassLoader().getResource("sormas_case_contact_import_test_similarities.csv").getFile());
+		csvFile = new File(getClass().getClassLoader().getResource("sormas_case_contact_import_test_similarities.csv").toURI());
 		contactImporter = new ContactImporterExtension(csvFile, false, user.toReference(), caze) {
 
 			@Override
@@ -124,7 +125,7 @@ public class ContactImporterTest extends AbstractBeanTest {
 
 		// Test import contacts from a commented CSV file
 		// Successful import of 5 case contacts
-		csvFile = new File(getClass().getClassLoader().getResource("sormas_case_contact_import_test_comment_success.csv").getFile());
+		csvFile = new File(getClass().getClassLoader().getResource("sormas_case_contact_import_test_comment_success.csv").toURI());
 		contactImporter = new ContactImporterExtension(csvFile, false, user.toReference(), caze);
 		importResult = contactImporter.runImport();
 
@@ -133,7 +134,7 @@ public class ContactImporterTest extends AbstractBeanTest {
 	}
 
 	@Test
-	public void testImportContacts() throws IOException, InvalidColumnException, InterruptedException, CsvValidationException {
+	public void testImportContacts() throws IOException, InvalidColumnException, InterruptedException, CsvValidationException, URISyntaxException {
 
 		ContactFacadeEjb contactFacade = getBean(ContactFacadeEjbLocal.class);
 
@@ -144,7 +145,7 @@ public class ContactImporterTest extends AbstractBeanTest {
 		// Try to import 3 contacts. 
 		// 2 of them belong to a case that does not exist.
 		// 1 of those 2 still has enough details to be imported
-		File csvFile = new File(getClass().getClassLoader().getResource("sormas_contact_import_test.csv").getFile());
+		File csvFile = new File(getClass().getClassLoader().getResource("sormas_contact_import_test.csv").toURI());
 		ContactImporter contactImporter = new ContactImporterExtension(csvFile, false, user.toReference(), null);
 		ImportResultStatus importResult = contactImporter.runImport();
 
@@ -162,7 +163,7 @@ public class ContactImporterTest extends AbstractBeanTest {
 			rdcf,
 			"ABCDEF-GHIJKL-MNOPQR");
 
-		csvFile = new File(getClass().getClassLoader().getResource("sormas_contact_import_test.csv").getFile());
+		csvFile = new File(getClass().getClassLoader().getResource("sormas_contact_import_test.csv").toURI());
 		contactImporter = new ContactImporterExtension(csvFile, false, user.toReference(), null);
 		importResult = contactImporter.runImport();
 
@@ -181,7 +182,7 @@ public class ContactImporterTest extends AbstractBeanTest {
 		assertEquals(3, contactFacade.count(contactCriteria));
 
 		// Test import contacts from a commented CSV file
-		csvFile = new File(getClass().getClassLoader().getResource("sormas_contact_import_test_comment.csv").getFile());
+		csvFile = new File(getClass().getClassLoader().getResource("sormas_contact_import_test_comment.csv").toURI());
 		contactImporter = new ContactImporterExtension(csvFile, false, user.toReference(), null);
 		importResult = contactImporter.runImport();
 
@@ -207,7 +208,7 @@ public class ContactImporterTest extends AbstractBeanTest {
 			return new OutputStreamWriter(new OutputStream() {
 
 				@Override
-				public void write(int b) throws IOException {
+				public void write(int b) {
 					// Do nothing
 				}
 			});

--- a/sormas-ui/src/test/java/de/symeda/sormas/ui/dashboard/campaigns/CampaignFormDataImporterTest.java
+++ b/sormas-ui/src/test/java/de/symeda/sormas/ui/dashboard/campaigns/CampaignFormDataImporterTest.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -33,7 +34,7 @@ public class CampaignFormDataImporterTest extends AbstractBeanTest {
 
 	@Test
 	@Ignore("Remove ignore once we have replaced H2 - #2526")
-	public void testImportCampaignFormData() throws IOException, InvalidColumnException, InterruptedException, CsvValidationException {
+	public void testImportCampaignFormData() throws IOException, InvalidColumnException, InterruptedException, CsvValidationException, URISyntaxException {
 
 		final TestDataCreator.RDCF rdcf = creator.createRDCF("Region", "District", "Community", "Facility");
 		UserDto user =
@@ -43,7 +44,7 @@ public class CampaignFormDataImporterTest extends AbstractBeanTest {
 
 		final CampaignFormMetaDto campaignForm = creator.createCampaignForm(campaign);
 
-		File csvFile = new File(getClass().getClassLoader().getResource("campaign/sormas_campaign_data_import_test_success.csv").getFile());
+		File csvFile = new File(getClass().getClassLoader().getResource("campaign/sormas_campaign_data_import_test_success.csv").toURI());
 		CampaignFormDataImporterExtension campaignFormDataImporter = new CampaignFormDataImporterExtension(
 			csvFile,
 			false,
@@ -58,7 +59,7 @@ public class CampaignFormDataImporterTest extends AbstractBeanTest {
 
 	@Test
 	public void testImportCampaignFormDataWithWrongDataType()
-		throws IOException, InvalidColumnException, InterruptedException, CsvValidationException {
+			throws IOException, InvalidColumnException, InterruptedException, CsvValidationException, URISyntaxException {
 
 		final TestDataCreator.RDCF rdcf = creator.createRDCF("Region", "District", "Community", "Facility");
 		UserDto user =
@@ -68,7 +69,7 @@ public class CampaignFormDataImporterTest extends AbstractBeanTest {
 
 		final CampaignFormMetaDto campaignForm = creator.createCampaignForm(campaign);
 
-		File csvFile = new File(getClass().getClassLoader().getResource("campaign/sormas_campaign_data_import_test_wrong_type.csv").getFile());
+		File csvFile = new File(getClass().getClassLoader().getResource("campaign/sormas_campaign_data_import_test_wrong_type.csv").toURI());
 		CampaignFormDataImporterExtension campaignFormDataImporter = new CampaignFormDataImporterExtension(
 			csvFile,
 			false,
@@ -83,7 +84,7 @@ public class CampaignFormDataImporterTest extends AbstractBeanTest {
 
     @Test
 	public void testImportCampaignFormDataWithNonExistingColumn()
-		throws IOException, InvalidColumnException, InterruptedException, CsvValidationException {
+			throws IOException, InvalidColumnException, InterruptedException, CsvValidationException, URISyntaxException {
 
 		final TestDataCreator.RDCF rdcf = creator.createRDCF("Region", "District", "Community", "Facility");
 		UserDto user =
@@ -93,7 +94,7 @@ public class CampaignFormDataImporterTest extends AbstractBeanTest {
 
 		final CampaignFormMetaDto campaignForm = creator.createCampaignForm(campaign);
 
-		File csvFile = new File(getClass().getClassLoader().getResource("campaign/sormas_campaign_data_import_test_nonexisting_column.csv").getFile());
+		File csvFile = new File(getClass().getClassLoader().getResource("campaign/sormas_campaign_data_import_test_nonexisting_column.csv").toURI());
 		CampaignFormDataImporterExtension campaignFormDataImporter = new CampaignFormDataImporterExtension(
 			csvFile,
 			false,
@@ -121,7 +122,7 @@ public class CampaignFormDataImporterTest extends AbstractBeanTest {
 		}
 
 		@Override
-		protected void writeImportError(String[] errorLine, String message) throws IOException {
+		protected void writeImportError(String[] errorLine, String message) {
 			errorMessages.add(message);
 		}
 

--- a/sormas-ui/src/test/java/de/symeda/sormas/ui/event/eventparticipantimporter/EventParticipantImporterTest.java
+++ b/sormas-ui/src/test/java/de/symeda/sormas/ui/event/eventparticipantimporter/EventParticipantImporterTest.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -50,7 +51,7 @@ import de.symeda.sormas.ui.importer.ImportSimilarityResultOption;
 public class EventParticipantImporterTest extends AbstractBeanTest {
 
 	@Test
-	public void testImportEventParticipant() throws IOException, InvalidColumnException, InterruptedException, CsvValidationException {
+	public void testImportEventParticipant() throws IOException, InvalidColumnException, InterruptedException, CsvValidationException, URISyntaxException {
 
 		EventParticipantFacadeEjbLocal eventParticipantFacade = getBean(EventParticipantFacadeEjbLocal.class);
 
@@ -73,7 +74,7 @@ public class EventParticipantImporterTest extends AbstractBeanTest {
 		EventReferenceDto eventRef = event.toReference();
 
 		// Successful import of 5 event participant
-		File csvFile = new File(getClass().getClassLoader().getResource("sormas_eventparticipant_import_test_success.csv").getFile());
+		File csvFile = new File(getClass().getClassLoader().getResource("sormas_eventparticipant_import_test_success.csv").toURI());
 		EventParticipantImporterExtension eventParticipantImporter =
 			new EventParticipantImporterExtension(csvFile, false, user.toReference(), eventRef);
 		ImportResultStatus importResult = eventParticipantImporter.runImport();
@@ -83,7 +84,7 @@ public class EventParticipantImporterTest extends AbstractBeanTest {
 	}
 
 	@Test
-	public void testImportEventParticipantSimilarityPick() throws IOException, InvalidColumnException, InterruptedException, CsvValidationException {
+	public void testImportEventParticipantSimilarityPick() throws IOException, InvalidColumnException, InterruptedException, CsvValidationException, URISyntaxException {
 		EventParticipantFacadeEjbLocal eventParticipantFacade = getBean(EventParticipantFacadeEjbLocal.class);
 
 		RDCF rdcf = creator.createRDCF("Region", "District", "Community", "Facility");
@@ -115,7 +116,7 @@ public class EventParticipantImporterTest extends AbstractBeanTest {
 
 		// Person Similarity: pick
 		List<PersonNameDto> persons = FacadeProvider.getPersonFacade().getMatchingNameDtos(user.toReference(), new PersonSimilarityCriteria());
-		File csvFile = new File(getClass().getClassLoader().getResource("sormas_eventparticipant_import_test_similarities.csv").getFile());
+		File csvFile = new File(getClass().getClassLoader().getResource("sormas_eventparticipant_import_test_similarities.csv").toURI());
 
 		EventParticipantImporterExtension eventParticipantImporter =
 			new EventParticipantImporterExtension(csvFile, false, user.toReference(), eventRef) {
@@ -150,7 +151,7 @@ public class EventParticipantImporterTest extends AbstractBeanTest {
 
 	@Test
 	public void testImportEventParticipantSimilarityPickEventParticipant()
-		throws IOException, InvalidColumnException, InterruptedException, CsvValidationException {
+			throws IOException, InvalidColumnException, InterruptedException, CsvValidationException, URISyntaxException {
 		EventParticipantFacadeEjbLocal eventParticipantFacade = getBean(EventParticipantFacadeEjbLocal.class);
 
 		RDCF rdcf = creator.createRDCF("Region", "District", "Community", "Facility");
@@ -175,7 +176,7 @@ public class EventParticipantImporterTest extends AbstractBeanTest {
 
 		// Person Similarity: pick event participant
 		List<PersonNameDto> persons = FacadeProvider.getPersonFacade().getMatchingNameDtos(user.toReference(), new PersonSimilarityCriteria());
-		File csvFile = new File(getClass().getClassLoader().getResource("sormas_eventparticipant_import_test_similarities.csv").getFile());
+		File csvFile = new File(getClass().getClassLoader().getResource("sormas_eventparticipant_import_test_similarities.csv").toURI());
 
 		EventParticipantImporterExtension eventParticipantImporter =
 			new EventParticipantImporterExtension(csvFile, false, user.toReference(), eventRef) {
@@ -208,7 +209,7 @@ public class EventParticipantImporterTest extends AbstractBeanTest {
 
 	@Test
 	public void testImportEventParticipantSimilarityCreate()
-		throws IOException, InvalidColumnException, InterruptedException, CsvValidationException {
+			throws IOException, InvalidColumnException, InterruptedException, CsvValidationException, URISyntaxException {
 		EventParticipantFacadeEjbLocal eventParticipantFacade = getBean(EventParticipantFacadeEjbLocal.class);
 
 		RDCF rdcf = creator.createRDCF("Region", "District", "Community", "Facility");
@@ -239,7 +240,7 @@ public class EventParticipantImporterTest extends AbstractBeanTest {
 			rdcf);
 
 		// Person Similarity: create
-		File csvFile = new File(getClass().getClassLoader().getResource("sormas_eventparticipant_import_test_similarities.csv").getFile());
+		File csvFile = new File(getClass().getClassLoader().getResource("sormas_eventparticipant_import_test_similarities.csv").toURI());
 
 		EventParticipantImporterExtension eventParticipantImporter =
 			new EventParticipantImporterExtension(csvFile, false, user.toReference(), eventRef) {
@@ -261,7 +262,7 @@ public class EventParticipantImporterTest extends AbstractBeanTest {
 	}
 
 	@Test
-	public void testImportEventParticipantSimilaritySkip() throws IOException, InvalidColumnException, InterruptedException, CsvValidationException {
+	public void testImportEventParticipantSimilaritySkip() throws IOException, InvalidColumnException, InterruptedException, CsvValidationException, URISyntaxException {
 		EventParticipantFacadeEjbLocal eventParticipantFacade = getBean(EventParticipantFacadeEjbLocal.class);
 
 		RDCF rdcf = creator.createRDCF("Region", "District", "Community", "Facility");
@@ -283,7 +284,7 @@ public class EventParticipantImporterTest extends AbstractBeanTest {
 		EventReferenceDto eventRef = event.toReference();
 
 		// Person Similarity: create
-		File csvFile = new File(getClass().getClassLoader().getResource("sormas_eventparticipant_import_test_similarities.csv").getFile());
+		File csvFile = new File(getClass().getClassLoader().getResource("sormas_eventparticipant_import_test_similarities.csv").toURI());
 
 		EventParticipantImporterExtension eventParticipantImporter =
 			new EventParticipantImporterExtension(csvFile, false, user.toReference(), eventRef) {
@@ -301,7 +302,7 @@ public class EventParticipantImporterTest extends AbstractBeanTest {
 	}
 
 	@Test
-	public void testImportEventParticipantComment() throws IOException, InvalidColumnException, InterruptedException, CsvValidationException {
+	public void testImportEventParticipantComment() throws IOException, InvalidColumnException, InterruptedException, CsvValidationException, URISyntaxException {
 		EventParticipantFacadeEjbLocal eventParticipantFacade = getBean(EventParticipantFacadeEjbLocal.class);
 
 		RDCF rdcf = creator.createRDCF("Region", "District", "Community", "Facility");
@@ -323,7 +324,7 @@ public class EventParticipantImporterTest extends AbstractBeanTest {
 		EventReferenceDto eventRef = event.toReference();
 
 		// Successful import of 5 event participant
-		File csvFile = new File(getClass().getClassLoader().getResource("sormas_eventparticipant_import_test_comment_success.csv").getFile());
+		File csvFile = new File(getClass().getClassLoader().getResource("sormas_eventparticipant_import_test_comment_success.csv").toURI());
 		EventParticipantImporterExtension eventParticipantImporter =
 			new EventParticipantImporterExtension(csvFile, false, user.toReference(), eventRef);
 		ImportResultStatus importResult = eventParticipantImporter.runImport();
@@ -346,7 +347,7 @@ public class EventParticipantImporterTest extends AbstractBeanTest {
 			return new OutputStreamWriter(new OutputStream() {
 
 				@Override
-				public void write(int b) throws IOException {
+				public void write(int b) {
 					// Do nothing
 				}
 			});

--- a/sormas-ui/src/test/java/de/symeda/sormas/ui/importer/CountryImporterTest.java
+++ b/sormas-ui/src/test/java/de/symeda/sormas/ui/importer/CountryImporterTest.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.net.URISyntaxException;
 import java.nio.charset.MalformedInputException;
 
 import org.junit.Test;
@@ -31,11 +32,11 @@ import de.symeda.sormas.ui.caze.importer.CountryImporter;
 public class CountryImporterTest extends AbstractBeanTest {
 
 	@Test
-	public void testUmlautsInCountryImport() throws IOException, InvalidColumnException, InterruptedException, CsvValidationException {
+	public void testUmlautsInCountryImport() throws IOException, InvalidColumnException, InterruptedException, CsvValidationException, URISyntaxException {
 		TestDataCreator.RDCF rdcf = new TestDataCreator().createRDCF("Default Region", "Default District", "Default Community", "Default Facility");
 		UserDto user = creator.createUser(rdcf.region.getUuid(), rdcf.district.getUuid(), rdcf.facility.getUuid(), "Default", "User", UserRole.ADMIN);
 
-		File countryCsvFile = new File(getClass().getClassLoader().getResource("sormas_country_import_test.csv").getFile());
+		File countryCsvFile = new File(getClass().getClassLoader().getResource("sormas_country_import_test.csv").toURI());
 		InfrastructureImporter importer = new CountryImporterExtension(countryCsvFile, user.toReference());
 		importer.runImport();
 		getCountryFacade().getByDefaultName("Country with ä", false).get(0);
@@ -43,21 +44,21 @@ public class CountryImporterTest extends AbstractBeanTest {
 
 
 	@Test(expected = MalformedInputException.class)
-	public void testUmlautsInCountryImportNonUTF8() throws IOException, InvalidColumnException, InterruptedException, CsvValidationException {
+	public void testUmlautsInCountryImportNonUTF8() throws IOException, InvalidColumnException, InterruptedException, CsvValidationException, URISyntaxException {
 		TestDataCreator.RDCF rdcf = new TestDataCreator().createRDCF("Default Region", "Default District", "Default Community", "Default Facility");
 		UserDto user = creator.createUser(rdcf.region.getUuid(), rdcf.district.getUuid(), rdcf.facility.getUuid(), "Default", "User", UserRole.ADMIN);
 
-		File countryCsvFile = new File(getClass().getClassLoader().getResource("sormas_country_import_non_utf_test.csv").getFile());
+		File countryCsvFile = new File(getClass().getClassLoader().getResource("sormas_country_import_non_utf_test.csv").toURI());
 		InfrastructureImporter importer = new CountryImporterExtension(countryCsvFile, user.toReference());
 		importer.runImport();
 	}
 
 	@Test
-	public void testDontImportDuplicateCountry() throws IOException, InvalidColumnException, InterruptedException, CsvValidationException {
+	public void testDontImportDuplicateCountry() throws IOException, InvalidColumnException, InterruptedException, CsvValidationException, URISyntaxException {
 		TestDataCreator.RDCF rdcf = new TestDataCreator().createRDCF("Default Region", "Default District", "Default Community", "Default Facility");
 		UserDto user = creator.createUser(rdcf.region.getUuid(), rdcf.district.getUuid(), rdcf.facility.getUuid(), "Default", "User", UserRole.ADMIN);
 
-		File countryCsvFile = new File(getClass().getClassLoader().getResource("sormas_country_import_test.csv").getFile());
+		File countryCsvFile = new File(getClass().getClassLoader().getResource("sormas_country_import_test.csv").toURI());
 		InfrastructureImporter importer = new CountryImporterExtension(countryCsvFile, user.toReference());
 		assertEquals(ImportResultStatus.COMPLETED_WITH_ERRORS, importer.runImport());
 		assertEquals(1, getCountryFacade().count(new CountryCriteria()));

--- a/sormas-ui/src/test/java/de/symeda/sormas/ui/importer/InfrastructureImporterTest.java
+++ b/sormas-ui/src/test/java/de/symeda/sormas/ui/importer/InfrastructureImporterTest.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.net.URISyntaxException;
 
 import de.symeda.sormas.api.region.CountryCriteria;
 import org.junit.Test;
@@ -38,83 +39,83 @@ import de.symeda.sormas.ui.TestDataCreator.RDCF;
 public class InfrastructureImporterTest extends AbstractBeanTest {
 
 	@Test
-	public void testUmlautsInInfrastructureImport() throws IOException, InvalidColumnException, InterruptedException, CsvValidationException {
+	public void testUmlautsInInfrastructureImport() throws IOException, InvalidColumnException, InterruptedException, CsvValidationException, URISyntaxException {
 		RDCF rdcf = new TestDataCreator().createRDCF("Default Region", "Default District", "Default Community", "Default Facility");
 		UserDto user = creator.createUser(rdcf.region.getUuid(), rdcf.district.getUuid(), rdcf.facility.getUuid(), "Default", "User", UserRole.ADMIN);
 
 		// Import region
-		File regionCsvFile = new File(getClass().getClassLoader().getResource("sormas_region_import_test.csv").getFile());
+		File regionCsvFile = new File(getClass().getClassLoader().getResource("sormas_region_import_test.csv").toURI());
 		InfrastructureImporter importer = new InfrastructureImporterExtension(regionCsvFile, user.toReference(), InfrastructureType.REGION);
 		importer.runImport();
 		RegionReferenceDto region = getRegionFacade().getByName("Region with ä", false).get(0);
 
 		// Import district
-		File districtCsvFile = new File(getClass().getClassLoader().getResource("sormas_district_import_test.csv").getFile());
+		File districtCsvFile = new File(getClass().getClassLoader().getResource("sormas_district_import_test.csv").toURI());
 		importer = new InfrastructureImporterExtension(districtCsvFile, user.toReference(), InfrastructureType.DISTRICT);
 		importer.runImport();
 		DistrictReferenceDto district = getDistrictFacade().getByName("District with ß", region, false).get(0);
 
 		// Import community
-		File communityCsvFile = new File(getClass().getClassLoader().getResource("sormas_community_import_test.csv").getFile());
+		File communityCsvFile = new File(getClass().getClassLoader().getResource("sormas_community_import_test.csv").toURI());
 		importer = new InfrastructureImporterExtension(communityCsvFile, user.toReference(), InfrastructureType.COMMUNITY);
 		importer.runImport();
 		CommunityReferenceDto community = getCommunityFacade().getByName("Community with ö", district, false).get(0);
 
 		// Import facility
-		File facilityCsvFile = new File(getClass().getClassLoader().getResource("sormas_facility_import_test.csv").getFile());
+		File facilityCsvFile = new File(getClass().getClassLoader().getResource("sormas_facility_import_test.csv").toURI());
 		importer = new InfrastructureImporterExtension(facilityCsvFile, user.toReference(), InfrastructureType.FACILITY);
 		importer.runImport();
 		getFacilityFacade().getByNameAndType("Facility with ü", district, community, null, false).get(0);
 
 		// Import point of entry from commented CSV file
-		File commentedPoeCsvFile = new File(getClass().getClassLoader().getResource("sormas_poe_import_test_comment.csv").getFile());
+		File commentedPoeCsvFile = new File(getClass().getClassLoader().getResource("sormas_poe_import_test_comment.csv").toURI());
 		importer = new InfrastructureImporterExtension(commentedPoeCsvFile, user.toReference(), InfrastructureType.POINT_OF_ENTRY);
 		importer.runImport();
 		getPointOfEntryFacade().getByName("Airport A", district, false).get(0);
 	}
 
 	@Test
-	public void testDontImportDuplicateInfrastructure() throws IOException, InvalidColumnException, InterruptedException, CsvValidationException {
+	public void testDontImportDuplicateInfrastructure() throws IOException, InvalidColumnException, InterruptedException, CsvValidationException, URISyntaxException {
 		RDCF rdcf = new TestDataCreator().createRDCF("Default Region", "Default District", "Default Community", "Default Facility");
 		UserDto user = creator.createUser(rdcf.region.getUuid(), rdcf.district.getUuid(), rdcf.facility.getUuid(), "Default", "User", UserRole.ADMIN);
 
 		// Import region
-		File regionCsvFile = new File(getClass().getClassLoader().getResource("sormas_region_import_test.csv").getFile());
+		File regionCsvFile = new File(getClass().getClassLoader().getResource("sormas_region_import_test.csv").toURI());
 		InfrastructureImporter importer = new InfrastructureImporterExtension(regionCsvFile, user.toReference(), InfrastructureType.REGION);
 		assertEquals(ImportResultStatus.COMPLETED_WITH_ERRORS, importer.runImport());
 		assertEquals(2, getRegionFacade().count(new RegionCriteria()));
 
 		// Import district
-		File districtCsvFile = new File(getClass().getClassLoader().getResource("sormas_district_import_test.csv").getFile());
+		File districtCsvFile = new File(getClass().getClassLoader().getResource("sormas_district_import_test.csv").toURI());
 		importer = new InfrastructureImporterExtension(districtCsvFile, user.toReference(), InfrastructureType.DISTRICT);
 		assertEquals(ImportResultStatus.COMPLETED_WITH_ERRORS, importer.runImport());
 		assertEquals(2, getDistrictFacade().count(new DistrictCriteria()));
 
 		// Import community
-		File communityCsvFile = new File(getClass().getClassLoader().getResource("sormas_community_import_test.csv").getFile());
+		File communityCsvFile = new File(getClass().getClassLoader().getResource("sormas_community_import_test.csv").toURI());
 		importer = new InfrastructureImporterExtension(communityCsvFile, user.toReference(), InfrastructureType.COMMUNITY);
 		assertEquals(ImportResultStatus.COMPLETED_WITH_ERRORS, importer.runImport());
 		assertEquals(2, getCommunityFacade().count(new CommunityCriteria()));
 
 		// Import facility
-		File facilityCsvFile = new File(getClass().getClassLoader().getResource("sormas_facility_import_test.csv").getFile());
+		File facilityCsvFile = new File(getClass().getClassLoader().getResource("sormas_facility_import_test.csv").toURI());
 		importer = new InfrastructureImporterExtension(facilityCsvFile, user.toReference(), InfrastructureType.FACILITY);
 		assertEquals(ImportResultStatus.COMPLETED_WITH_ERRORS, importer.runImport());
 		assertEquals(3, getFacilityFacade().count(new FacilityCriteria()));
 
 		// Import point of entry
-		File poeCsvFile = new File(getClass().getClassLoader().getResource("sormas_poe_import_test.csv").getFile());
+		File poeCsvFile = new File(getClass().getClassLoader().getResource("sormas_poe_import_test.csv").toURI());
 		importer = new InfrastructureImporterExtension(poeCsvFile, user.toReference(), InfrastructureType.POINT_OF_ENTRY);
 		assertEquals(ImportResultStatus.COMPLETED_WITH_ERRORS, importer.runImport());
 		assertEquals(1, getPointOfEntryFacade().count(new PointOfEntryCriteria()));
 	}
 
 	@Test
-	public void testImportFromFileWithBom() throws InterruptedException, InvalidColumnException, CsvValidationException, IOException {
+	public void testImportFromFileWithBom() throws InterruptedException, InvalidColumnException, CsvValidationException, IOException, URISyntaxException {
 		RDCF rdcf = new TestDataCreator().createRDCF("Default Region", "Default District", "Default Community", "Default Facility");
 		UserDto user = creator.createUser(rdcf.region.getUuid(), rdcf.district.getUuid(), rdcf.facility.getUuid(), "Default", "User", UserRole.ADMIN);
 
-		File districtCsvFile = new File(getClass().getClassLoader().getResource("sormas_district_bom_test.csv").getFile());
+		File districtCsvFile = new File(getClass().getClassLoader().getResource("sormas_district_bom_test.csv").toURI());
 		InfrastructureImporter importer = new InfrastructureImporterExtension(districtCsvFile, user.toReference(), InfrastructureType.DISTRICT);
 		importer.runImport();
 
@@ -132,7 +133,7 @@ public class InfrastructureImporterTest extends AbstractBeanTest {
 			return new OutputStreamWriter(new OutputStream() {
 
 				@Override
-				public void write(int b) throws IOException {
+				public void write(int b) {
 					// Do nothing
 				}
 			});


### PR DESCRIPTION
Fixes test in sormas-ui that fail when run on a local branch with blanks (' ').
The related issue described in #3480 for sormas-backend will be addressed in a separate pull request.

Additional cleanup:
- assignment of importResult in CaseImporterTest, l.66/67, removed, since the value is not used
- IOException removed from method declarations where it is not thrown