### PR TITLE
Fix import template and CSV export encoding (fixes #4045)

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/utils/CsvStreamUtils.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/utils/CsvStreamUtils.java
@@ -19,6 +19,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -51,9 +52,27 @@ public class CsvStreamUtils {
 		final Predicate redMethodFilter,
 		ConfigFacade configFacade,
 		OutputStream out) {
+		writeCsvContentToStream(
+			csvRowClass,
+			exportRowsSupplier,
+			propertyIdCaptionSupplier,
+			exportConfiguration,
+			redMethodFilter,
+			configFacade,
+			out,
+			StandardCharsets.UTF_8);
+	}
 
-		try (
-			CSVWriter writer = CSVUtils.createCSVWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8.name()), configFacade.getCsvSeparator())) {
+	public static <T> void writeCsvContentToStream(
+		Class<T> csvRowClass,
+		SupplierBiFunction<Integer, Integer, List<T>> exportRowsSupplier,
+		SupplierBiFunction<String, Class<?>, String> propertyIdCaptionSupplier,
+		ExportConfigurationDto exportConfiguration,
+		final Predicate redMethodFilter,
+		ConfigFacade configFacade,
+		OutputStream out,
+		Charset charset) {
+		try (CSVWriter writer = CSVUtils.createCSVWriter(new OutputStreamWriter(out, charset.name()), configFacade.getCsvSeparator())) {
 
 			// 1. fields in order of declaration - not using Introspector here, because it gives properties in alphabetical order
 			List<Method> readMethods =
@@ -124,7 +143,7 @@ public class CsvStreamUtils {
 							fieldValues[i] = DataHelper.valueToString(value);
 						}
 						writer.writeNext(fieldValues);
-					} ;
+					}
 				} catch (InvocationTargetException | IllegalAccessException | IllegalArgumentException e) {
 					throw new RuntimeException(e);
 				}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/importexport/ImportFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/importexport/ImportFacadeEjb.java
@@ -37,8 +37,9 @@ import static de.symeda.sormas.api.caze.CaseDataDto.REGION;
 import static de.symeda.sormas.api.caze.CaseDataDto.REPORT_DATE;
 import static de.symeda.sormas.api.caze.CaseDataDto.SYMPTOMS;
 
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -619,7 +620,9 @@ public class ImportFacadeEjb implements ImportFacade {
 	 * @throws IOException
 	 */
 	private void writeTemplate(Path templatePath, List<ImportColumn> importColumns, boolean includeEntityNames) throws IOException {
-		try (CSVWriter writer = CSVUtils.createCSVWriter(new FileWriter(templatePath.toString()), configFacade.getCsvSeparator())) {
+		try (CSVWriter writer = CSVUtils.createCSVWriter(
+			new OutputStreamWriter(new FileOutputStream(templatePath.toString()), StandardCharsets.UTF_8.newEncoder()),
+			configFacade.getCsvSeparator())) {
 			if (includeEntityNames) {
 				writer.writeNext(importColumns.stream().map(ImportColumn::getEntityName).toArray(String[]::new));
 			}


### PR DESCRIPTION
Import templates are generated in UTF-8 encoding server side:

```
$ ls | xargs file 
sormas_import_area_template.csv:             ASCII text
sormas_import_case_contact_template.csv:     UTF-8 Unicode text, with very long lines
sormas_import_case_template.csv:             UTF-8 Unicode text, with very long lines
sormas_import_community_template.csv:        ASCII text
sormas_import_contact_template.csv:          UTF-8 Unicode text, with very long lines
sormas_import_country_template.csv:          ASCII text
sormas_import_district_template.csv:         ASCII text
sormas_import_eventparticipant_template.csv: UTF-8 Unicode text, with very long lines
sormas_import_facility_template.csv:         UTF-8 Unicode text, with very long lines
sormas_import_line_listing_template.csv:     UTF-8 Unicode text, with very long lines
sormas_import_point_of_entry_template.csv:   UTF-8 Unicode text
sormas_import_population_data_template.csv:  ASCII text, with very long lines
sormas_import_region_template.csv:           ASCII text
```
where `file` determines `ASCII` for files without special characters:
```
$ ls | xargs file | grep ASCII | sed 's/^\([^:]*\):.*$/\1/' | xargs grep '[^a-zA-Z0-9;"_#. /:-]'
```
returns nothing (grep all ASCII files for any character other than those listed).

Downloads are encoded according to the client OS.

Downloads from a Windows client:
```
$ file sormas_*
sormas_cases_2021-01-16.csv:     ISO-8859 text, with very long lines
sormas_import_case_template.csv: ISO-8859 text, with very long lines
```

Downloads from a Linux client:
```
$ file sormas_*
sormas_cases_2021-01-16.csv:     UTF-8 Unicode text, with very long lines
sormas_import_case_template.csv: UTF-8 Unicode text, with very long lines
```

All downloads display cleanly both in Excel (Windows) and LibreOffice Calc (Linux) without previous modification.

![image](https://user-images.githubusercontent.com/5616564/104899883-acce9000-597b-11eb-805f-585e7f911673.png)
![image](https://user-images.githubusercontent.com/5616564/104899923-bb1cac00-597b-11eb-9fd6-cac5c86c3525.png)


Additional cleanup:
- removed extra semicolon in CsvStreamUtils, l.146
- simplified expression in DownloadUtil, l.585