### PR TITLE
#4084 improve eventparticipant contact queries

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/event/EventParticipantFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/event/EventParticipantFacadeEjb.java
@@ -41,6 +41,7 @@ import javax.persistence.criteria.JoinType;
 import javax.persistence.criteria.Order;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
+import javax.persistence.criteria.Subquery;
 import javax.validation.constraints.NotNull;
 
 import de.symeda.sormas.api.Language;
@@ -583,27 +584,31 @@ public class EventParticipantFacadeEjb implements EventParticipantFacade {
 		IterableHelper.executeBatched(eventParticipantUuids, ModelConstants.PARAMETER_LIMIT, e -> {
 			CriteriaBuilder cb = em.getCriteriaBuilder();
 			CriteriaQuery<Object[]> contactCount = cb.createQuery(Object[].class);
-			Root<Contact> contact = contactCount.from(Contact.class);
-			Join<Contact, Person> person = contact.join(Contact.PERSON);
-			Join<Person, EventParticipant> eventParticipant = person.join(Person.EVENT_PARTICIPANTS);
 
-			contactCount.where(
-				eventParticipant.get(EventParticipant.UUID).in(eventParticipantUuids),
-				cb.isFalse(eventParticipant.get(EventParticipant.DELETED)),
-				cb.isFalse(contact.get(Contact.DELETED)));
+			Root<EventParticipant> epRoot = contactCount.from(EventParticipant.class);
+			Root<Contact> contactRoot = contactCount.from(Contact.class);
+
+			Predicate participantPersonEqualsContactPerson = cb.equal(epRoot.get(EventParticipant.PERSON), contactRoot.get(Contact.PERSON));
+			Predicate notDeleted = cb.isFalse(epRoot.get(EventParticipant.DELETED));
+			Predicate contactNotDeleted = cb.isFalse(contactRoot.get(Contact.DELETED));
+			Predicate isInEvent = epRoot.get(EventParticipant.UUID).in(eventParticipantUuids);
+
 			if (Boolean.TRUE.equals(eventParticipantCriteria.getOnlyCountContactsWithSourceCaseInEvent())) {
-				contactCount.where(
-					contactCount.getRestriction(),
-					contact.join(Contact.CAZE)
-						.get(Case.UUID)
-						.in(
-							eventParticipant.join(EventParticipant.EVENT)
-								.join(Event.EVENT_PERSONS)
-								.join(EventParticipant.RESULTING_CASE)
-								.get(Case.UUID)));
+				Subquery<EventParticipant> sourceCaseSubquery = contactCount.subquery(EventParticipant.class);
+				Root<EventParticipant> epr2 = sourceCaseSubquery.from(EventParticipant.class);
+				sourceCaseSubquery.select(epr2);
+				sourceCaseSubquery.where(
+					cb.equal(epr2.get(EventParticipant.RESULTING_CASE), contactRoot.get(Contact.CAZE)),
+					cb.equal(epr2.get(EventParticipant.EVENT), epRoot.get(EventParticipant.EVENT)));
+
+				contactCount.multiselect(
+					epRoot.get(EventParticipant.UUID),
+					cb.sum(cb.selectCase().when(cb.exists(sourceCaseSubquery), 1).otherwise(0).as(Long.class)));
+			} else {
+				contactCount.multiselect(epRoot.get(EventParticipant.UUID), cb.count(epRoot));
 			}
-			contactCount.multiselect(eventParticipant.get(EventParticipant.UUID), cb.countDistinct(contact.get(Contact.UUID)));
-			contactCount.groupBy(eventParticipant.get(EventParticipant.UUID));
+			contactCount.where(participantPersonEqualsContactPerson, notDeleted, contactNotDeleted, isInEvent);
+			contactCount.groupBy(epRoot.get(EventParticipant.UUID));
 
 			List<Object[]> resultList = em.createQuery(contactCount).getResultList();
 			resultList.forEach(r -> contactCountMap.put((String) r[0], (Long) r[1]));

--- a/sormas-backend/src/main/resources/META-INF/persistence.xml
+++ b/sormas-backend/src/main/resources/META-INF/persistence.xml
@@ -70,7 +70,7 @@
 		 <properties>
          	<property name="hibernate.dialect" value="de.symeda.sormas.backend.ExtendedPostgreSQL94Dialect"/>
          	<property name="hibernate.transaction.jta.platform" value="org.hibernate.service.jta.platform.internal.SunOneJtaPlatform"/>
-			<property name="hibernate.show_sql" value="true" />
+			<property name="hibernate.show_sql" value="false" />
 			<property name="hibernate.format_sql" value="false" />
          	<!-- don't validate on release, otherwise the automatic db update won't work
          	<property name="hibernate.hbm2ddl.auto" value="validate"/>

--- a/sormas-backend/src/main/resources/META-INF/persistence.xml
+++ b/sormas-backend/src/main/resources/META-INF/persistence.xml
@@ -70,7 +70,7 @@
 		 <properties>
          	<property name="hibernate.dialect" value="de.symeda.sormas.backend.ExtendedPostgreSQL94Dialect"/>
          	<property name="hibernate.transaction.jta.platform" value="org.hibernate.service.jta.platform.internal.SunOneJtaPlatform"/>
-			<property name="hibernate.show_sql" value="false" />
+			<property name="hibernate.show_sql" value="true" />
 			<property name="hibernate.format_sql" value="false" />
          	<!-- don't validate on release, otherwise the automatic db update won't work
          	<property name="hibernate.hbm2ddl.auto" value="validate"/>


### PR DESCRIPTION
In the eventparticipant list of an event, the contact-count is calculated (depending on filters: with or without source case in event).

This PR implements improved queries which should perform much better on large databases (see #4084 for details)