### PR TITLE
#4052 Fix bug where contact officer could not expand map and chart

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/dashboard/contacts/ContactsDashboardView.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/dashboard/contacts/ContactsDashboardView.java
@@ -379,7 +379,9 @@ public class ContactsDashboardView extends AbstractDashboardView {
 				rowsLayout.setHeightUndefined();
 			}
 			caseStatisticsLayout.setVisible(!expanded);
-			networkDiagramRowLayout.setVisible(!expanded);
+			if (networkDiagramRowLayout != null) {
+				networkDiagramRowLayout.setVisible(!expanded);
+			}
 			contactsStatisticsLayout.setVisible(!expanded);
 		});
 
@@ -418,7 +420,9 @@ public class ContactsDashboardView extends AbstractDashboardView {
 				rowsLayout.setHeightUndefined();
 			}
 			caseStatisticsLayout.setVisible(!expanded);
-			networkDiagramRowLayout.setVisible(!expanded);
+			if (networkDiagramRowLayout != null) {
+				networkDiagramRowLayout.setVisible(!expanded);
+			}
 			contactsStatisticsLayout.setVisible(!expanded);
 		});
 


### PR DESCRIPTION
Closes #4052 

the Problem was that the related methods tried to change visibility of `networkDiagramRowLayout`, which only exists if you have special user rights (which contact officers miss).