### PR TITLE
#4193 fields should not be public

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/symptoms/SymptomsDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/symptoms/SymptomsDto.java
@@ -2107,7 +2107,7 @@ public class SymptomsDto extends PseudonymizableDto {
 		OTHER })
 	@Complication
 	@HideForCountries
-	public SymptomState otherComplications;
+	private SymptomState otherComplications;
 
 	@Diseases({
 		AFP,
@@ -2133,7 +2133,7 @@ public class SymptomsDto extends PseudonymizableDto {
 	@Complication
 	@HideForCountries
 	@SensitiveData
-	public String otherComplicationsText;
+	private String otherComplicationsText;
 
 	@Diseases({
 		AFP,

--- a/sormas-api/src/main/java/de/symeda/sormas/api/symptoms/SymptomsHelper.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/symptoms/SymptomsHelper.java
@@ -496,7 +496,7 @@ public final class SymptomsHelper {
 		appendYesSymptom(string, symptomsDto.getHighOrLowBloodPressure(), SymptomsDto.HIGH_OR_LOW_BLOOD_PRESSURE);
 		appendYesSymptom(string, symptomsDto.getUrinaryRetention(), SymptomsDto.URINARY_RETENTION);
 
-		appendNotNullValue(string, symptomsDto.otherComplicationsText, SymptomsDto.OTHER_COMPLICATIONS_TEXT);
+		appendNotNullValue(string, symptomsDto.getOtherComplicationsText(), SymptomsDto.OTHER_COMPLICATIONS_TEXT);
 
 		// symptomsComments;
 


### PR DESCRIPTION
Signed-off-by: Axel Nennker <axel.nennker@telekom.de>

I think #4193 occurs because the two fields are public.
This PR makes them private and changes the access to a field by replacing the direct access by the getter
