### PR TITLE
fix text comparison in failing tests under Windows (#4224)

### DIFF
--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/docgeneration/EventDocumentFacadeEjbTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/docgeneration/EventDocumentFacadeEjbTest.java
@@ -1,5 +1,6 @@
 package de.symeda.sormas.backend.docgeneration;
 
+import static de.symeda.sormas.backend.docgeneration.TemplateTestUtil.cleanLineSeparators;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -127,14 +128,14 @@ public class EventDocumentFacadeEjbTest extends AbstractDocGenerationTest {
 			String testcaseBasename = FilenameUtils.getBaseName(testCaseHtml.getName());
 
 			String htmlText = eventDocumentFacade.getGeneratedDocument(testcaseBasename + ".html", eventDto.toReference(), new Properties());
+			String actual = cleanLineSeparators(
+				htmlText.replaceAll("<p>Event-ID: <b>[A-Z0-9-]*</b></p>", "<p>Event-ID: <b>STN3WX-5JTGYV-IU2LRM-4UHCSOEE</b></p>"));
 
 			StringWriter writer = new StringWriter();
 			IOUtils.copy(getClass().getResourceAsStream("/docgeneration/eventHandout/" + testcaseBasename + ".cmp"), writer, "UTF-8");
 
-			String expected = writer.toString().replaceAll("\\r\\n?", "\n");
-			assertEquals(
-				expected,
-				htmlText.replaceAll("<p>Event-ID: <b>[A-Z0-9-]*</b></p>", "<p>Event-ID: <b>STN3WX-5JTGYV-IU2LRM-4UHCSOEE</b></p>"));
+			String expected = cleanLineSeparators(writer.toString());
+			assertEquals(expected, actual);
 			System.out.println("Testcase completed: " + testcaseBasename);
 		}
 	}

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/docgeneration/QuarantineOrderFacadeEjbTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/docgeneration/QuarantineOrderFacadeEjbTest.java
@@ -15,6 +15,7 @@
 
 package de.symeda.sormas.backend.docgeneration;
 
+import static de.symeda.sormas.backend.docgeneration.TemplateTestUtil.cleanLineSeparators;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -217,7 +218,7 @@ public class QuarantineOrderFacadeEjbTest extends AbstractDocGenerationTest {
 
 		XWPFDocument xwpfDocument = new XWPFDocument(generatedDocument);
 		XWPFWordExtractor xwpfWordExtractor = new XWPFWordExtractor(xwpfDocument);
-		String docxText = xwpfWordExtractor.getText();
+		String docxText = cleanLineSeparators(xwpfWordExtractor.getText());
 		xwpfWordExtractor.close();
 
 		StringWriter writer = new StringWriter();
@@ -227,7 +228,7 @@ public class QuarantineOrderFacadeEjbTest extends AbstractDocGenerationTest {
 			writer,
 			"UTF-8");
 
-		String expected = writer.toString().replaceAll("\\r\\n?", "\n");
+		String expected = cleanLineSeparators(writer.toString());
 		assertEquals(expected, docxText);
 	}
 

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/docgeneration/TemplateEngineTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/docgeneration/TemplateEngineTest.java
@@ -15,6 +15,7 @@
 
 package de.symeda.sormas.backend.docgeneration;
 
+import static de.symeda.sormas.backend.docgeneration.TemplateTestUtil.cleanLineSeparators;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -102,7 +103,7 @@ public class TemplateEngineTest {
 					Properties properties = new Properties();
 					properties.load(new FileInputStream(new File(testcaseProperties.toURI())));
 					deserializeObjects(properties);
-					String testCaseText = testCaseRunner.getGeneratedText(testCase, properties);
+					String testCaseText = cleanLineSeparators(testCaseRunner.getGeneratedText(testCase, properties));
 
 					String expected = getComparisonText(new File(testcaseCmpText.toURI()));
 					assertEquals(testcaseBasename + ": generated text does not match.", expected, testCaseText);
@@ -198,6 +199,6 @@ public class TemplateEngineTest {
 	private String getComparisonText(File testcaseCmpText) throws IOException {
 		StringWriter writer = new StringWriter();
 		IOUtils.copy(new FileInputStream(testcaseCmpText), writer, "UTF-8");
-		return writer.toString().replaceAll("\\r\\n?", "\n");
+		return cleanLineSeparators(writer.toString());
 	}
 }

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/docgeneration/TemplateTestUtil.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/docgeneration/TemplateTestUtil.java
@@ -47,4 +47,8 @@ public class TemplateTestUtil {
 		String json = new ObjectMapper().writeValueAsString(object);
 		System.out.println("(" + canonicalClassName + ") " + json);
 	}
+
+	public static String cleanLineSeparators(String text) {
+		return text.replaceAll("\\r\\n?", "\n");
+	}
 }


### PR DESCRIPTION
Clean line separators `\r\n` before text comparison.