### PR TITLE
#4214 Add "Date of outcome" to Detailed Export for Cases

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/caze/CaseExportDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/caze/CaseExportDto.java
@@ -719,7 +719,6 @@ public class CaseExportDto implements Serializable {
 			CaseExportType.CASE_MANAGEMENT })
 	@ExportProperty(CaseDataDto.OUTCOME_DATE)
 	@ExportGroup(ExportGroupType.ADDITIONAL)
-	@HideForCountriesExcept(countries = CountryHelper.COUNTRY_CODE_SWITZERLAND)
 	public Date getOutcomeDate() {
 		return outcomeDate;
 	}


### PR DESCRIPTION
Closes https://github.com/hzi-braunschweig/SORMAS-Project/issues/4214

Outcome date is used for all countries in the case but it was exported only for Switzerland