### PR TITLE
Avoid creating ScheduledExecutorService

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseFacadeEjb.java
@@ -39,19 +39,19 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import javax.annotation.Resource;
 import javax.ejb.EJB;
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
+import javax.enterprise.concurrent.ManagedScheduledExecutorService;
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
 import javax.persistence.PersistenceContext;
@@ -395,6 +395,8 @@ public class CaseFacadeEjb implements CaseFacade {
 	private ExternalJournalService externalJournalService;
 	@EJB
 	private DiseaseVariantService diseaseVariantService;
+	@Resource
+	private ManagedScheduledExecutorService executorService;
 
 	@Override
 	public List<CaseDataDto> getAllActiveCasesAfter(Date date) {
@@ -1666,8 +1668,6 @@ public class CaseFacadeEjb implements CaseFacade {
 		if (!configFacade.isExternalJournalActive()) {
 			return;
 		}
-
-		final ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
 		/**
 		 * The .getPersonForJournal(...) here gets the person in the state it is (most likely) known to an external journal.
 		 * Changes of related data is assumed to be not yet persisted in the database.

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/contact/ContactFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/contact/ContactFacadeEjb.java
@@ -32,19 +32,19 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import javax.annotation.Resource;
 import javax.annotation.security.RolesAllowed;
 import javax.ejb.EJB;
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
+import javax.enterprise.concurrent.ManagedScheduledExecutorService;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.Query;
@@ -223,6 +223,8 @@ public class ContactFacadeEjb implements ContactFacade {
 	private PersonFacadeEjb.PersonFacadeEjbLocal personFacade;
 	@EJB
 	private VaccinationInfoFacadeEjbLocal vaccinationInfoFacade;
+	@Resource
+	private ManagedScheduledExecutorService executorService;
 
 	@Override
 	public List<String> getAllActiveUuids() {
@@ -348,7 +350,6 @@ public class ContactFacadeEjb implements ContactFacade {
 			return;
 		}
 
-		final ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
 		/**
 		 * The .getPersonForJournal(...) here gets the person in the state it is (most likely) known to an external journal.
 		 * Changes of related data is assumed to be not yet persisted in the database.

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonFacadeEjb.java
@@ -27,15 +27,15 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import javax.annotation.Resource;
 import javax.ejb.EJB;
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
+import javax.enterprise.concurrent.ManagedScheduledExecutorService;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.criteria.CriteriaBuilder;
@@ -61,8 +61,8 @@ import de.symeda.sormas.api.caze.CaseDataDto;
 import de.symeda.sormas.api.caze.CaseOutcome;
 import de.symeda.sormas.api.contact.FollowUpStatus;
 import de.symeda.sormas.api.contact.FollowUpStatusDto;
-import de.symeda.sormas.api.i18n.Captions;
 import de.symeda.sormas.api.feature.FeatureType;
+import de.symeda.sormas.api.i18n.Captions;
 import de.symeda.sormas.api.i18n.I18nProperties;
 import de.symeda.sormas.api.i18n.Validations;
 import de.symeda.sormas.api.location.LocationDto;
@@ -155,6 +155,8 @@ public class PersonFacadeEjb implements PersonFacade {
 	private CountryService countryService;
 	@EJB
 	private FeatureConfigurationFacadeEjbLocal featureConfigurationFacade;
+	@Resource
+	private ManagedScheduledExecutorService executorService;
 
 	@Override
 	public List<String> getAllUuids() {
@@ -339,7 +341,6 @@ public class PersonFacadeEjb implements PersonFacade {
 
 		}
 		// 5 second delay added before notifying of update so that current transaction can complete and new data can be retrieved from DB
-		final ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
 		/**
 		 * The .getPersonForJournal(...) here gets the person in the state it is (most likely) known to an external journal.
 		 * Changes of related data is assumed to be not yet persisted in the database.

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/MockProducer.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/MockProducer.java
@@ -28,6 +28,7 @@ import java.util.Properties;
 
 import javax.ejb.SessionContext;
 import javax.ejb.TimerService;
+import javax.enterprise.concurrent.ManagedScheduledExecutorService;
 import javax.enterprise.inject.Produces;
 import javax.enterprise.inject.Specializes;
 import javax.jms.ConnectionFactory;
@@ -55,6 +56,7 @@ public class MockProducer {
 	public static final Properties properties = new Properties();
 	private static final UserTransaction userTransaction = mock(UserTransaction.class);
 	private static final SormasToSormasRestClient SORMAS_TO_SORMAS_REST_CLIENT = mock(SormasToSormasRestClient.class);
+	private static final ManagedScheduledExecutorService managedScheduledExecutorService = mock(ManagedScheduledExecutorService.class);
 
 	// Receiving e-mail server is mocked: org. jvnet. mock_javamail. mailbox
 	private static Session mailSession;
@@ -81,7 +83,15 @@ public class MockProducer {
 
 	public static void resetMocks() {
 
-		reset(sessionContext, principal, topic, connectionFactory, timerService, userTransaction, SORMAS_TO_SORMAS_REST_CLIENT);
+		reset(
+			sessionContext,
+			principal,
+			topic,
+			connectionFactory,
+			timerService,
+			userTransaction,
+			SORMAS_TO_SORMAS_REST_CLIENT,
+			managedScheduledExecutorService);
 		wireMocks();
 	}
 
@@ -142,5 +152,10 @@ public class MockProducer {
 		public SormasToSormasRestClient sormasToSormasClient() {
 			return SORMAS_TO_SORMAS_REST_CLIENT;
 		}
+	}
+
+	@Produces
+	public static ManagedScheduledExecutorService getManagedScheduledExecutorService() {
+		return managedScheduledExecutorService;
 	}
 }

--- a/sormas-ui/src/test/java/de/symeda/sormas/ui/MockProducer.java
+++ b/sormas-ui/src/test/java/de/symeda/sormas/ui/MockProducer.java
@@ -29,11 +29,14 @@ import java.util.Properties;
 
 import javax.ejb.SessionContext;
 import javax.ejb.TimerService;
+import javax.enterprise.concurrent.ManagedScheduledExecutorService;
 import javax.enterprise.inject.Produces;
 import javax.jms.ConnectionFactory;
 import javax.jms.Topic;
 import javax.mail.Session;
 import javax.transaction.UserTransaction;
+
+import org.apache.james.mime4j.field.address.Mailbox;
 
 import de.symeda.sormas.api.FacadeProvider;
 import de.symeda.sormas.api.utils.InfoProvider;
@@ -54,6 +57,7 @@ public class MockProducer {
 	private static TimerService timerService = mock(TimerService.class);
 	private static Properties properties = new Properties();
 	private static UserTransaction userTransaction = mock(UserTransaction.class);
+	private static ManagedScheduledExecutorService managedScheduledExecutorService = mock(ManagedScheduledExecutorService.class);
 
 	private static FacadeProvider facadeProvider = new FacadeProviderMock();
 
@@ -90,7 +94,7 @@ public class MockProducer {
 
 	public static void resetMocks() {
 
-		reset(sessionContext, principal, topic, connectionFactory, timerService, userTransaction);
+		reset(sessionContext, principal, topic, connectionFactory, timerService, userTransaction, managedScheduledExecutorService);
 		wireMocks();
 	}
 
@@ -137,5 +141,10 @@ public class MockProducer {
 	@Produces
 	public static Principal getPrincipal() {
 		return principal;
+	}
+
+	@Produces
+	public static ManagedScheduledExecutorService getManagedScheduledExecutorService() {
+		return managedScheduledExecutorService;
 	}
 }


### PR DESCRIPTION
PR that replaces the usage of `Executors.newSingleThreadScheduledExecutor()` with `ManagedScheduledExecutorService` resource provided by container. It avoids [creation of uncontrolled threads](https://www.adam-bien.com/roller/abien/entry/can_i_start_threads_in).

#4243