### PR TITLE
refactor ExternalJournal update (#4243)

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseFacadeEjb.java
@@ -39,19 +39,16 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import javax.annotation.Resource;
 import javax.ejb.EJB;
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
-import javax.enterprise.concurrent.ManagedScheduledExecutorService;
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
 import javax.persistence.PersistenceContext;
@@ -138,7 +135,6 @@ import de.symeda.sormas.api.messaging.ManualMessageLogDto;
 import de.symeda.sormas.api.messaging.MessageType;
 import de.symeda.sormas.api.person.ApproximateAgeType;
 import de.symeda.sormas.api.person.CauseOfDeath;
-import de.symeda.sormas.api.person.JournalPersonDto;
 import de.symeda.sormas.api.person.PersonDto;
 import de.symeda.sormas.api.person.PersonReferenceDto;
 import de.symeda.sormas.api.person.PresentCondition;
@@ -396,8 +392,6 @@ public class CaseFacadeEjb implements CaseFacade {
 	private ExternalJournalService externalJournalService;
 	@EJB
 	private DiseaseVariantService diseaseVariantService;
-	@Resource
-	private ManagedScheduledExecutorService executorService;
 
 	@Override
 	public List<CaseDataDto> getAllActiveCasesAfter(Date date) {
@@ -1639,7 +1633,7 @@ public class CaseFacadeEjb implements CaseFacade {
 		validate(dto);
 
 		if (caze != null) {
-			handleExternalJournalPerson(dto);
+			externalJournalService.handleExternalJournalPersonUpdate(dto.getPerson());
 		}
 
 		caze = fillOrBuildEntity(dto, caze, checkChangeDate);
@@ -1662,20 +1656,6 @@ public class CaseFacadeEjb implements CaseFacade {
 
 			onCaseChanged(existingCaseDto, caze);
 		}
-	}
-
-	// 5 second delay added before notifying of update so that current transaction can complete and new data can be retrieved from DB
-	private void handleExternalJournalPerson(CaseDataDto updatedCase) {
-		if (!configFacade.isExternalJournalActive()) {
-			return;
-		}
-		/**
-		 * The .getPersonForJournal(...) here gets the person in the state it is (most likely) known to an external journal.
-		 * Changes of related data is assumed to be not yet persisted in the database.
-		 */
-		JournalPersonDto existingPerson = personFacade.getPersonForJournal(updatedCase.getPerson().getUuid());
-		Runnable notify = () -> externalJournalService.notifyExternalJournalPersonUpdate(existingPerson);
-		executorService.schedule(notify, 5, TimeUnit.SECONDS);
 	}
 
 	private void updateCaseVisitAssociations(CaseDataDto existingCase, Case caze) {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/externaljournal/ExternalJournalService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/externaljournal/ExternalJournalService.java
@@ -237,8 +237,7 @@ public class ExternalJournalService {
 		 * new data can be retrieved from DB
 		 */
 		JournalPersonDto existingPerson = personFacade.getPersonForJournal(person.getUuid());
-		Runnable notify = () -> notifyExternalJournalPersonUpdate(existingPerson);
-		executorService.schedule(notify, 5, TimeUnit.SECONDS);
+		executorService.schedule((Runnable) () -> notifyExternalJournalPersonUpdate(existingPerson), 5, TimeUnit.SECONDS);
 	}
 
 	/**

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/externaljournal/ExternalJournalService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/externaljournal/ExternalJournalService.java
@@ -17,9 +17,11 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import javax.annotation.Resource;
 import javax.ejb.EJB;
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
+import javax.enterprise.concurrent.ManagedScheduledExecutorService;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
@@ -27,7 +29,6 @@ import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import de.symeda.sormas.api.utils.ValidationRuntimeException;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.validator.routines.EmailValidator;
@@ -55,7 +56,9 @@ import de.symeda.sormas.api.externaljournal.patientdiary.PatientDiaryValidationE
 import de.symeda.sormas.api.i18n.I18nProperties;
 import de.symeda.sormas.api.person.JournalPersonDto;
 import de.symeda.sormas.api.person.PersonDto;
+import de.symeda.sormas.api.person.PersonReferenceDto;
 import de.symeda.sormas.api.person.SymptomJournalStatus;
+import de.symeda.sormas.api.utils.ValidationRuntimeException;
 import de.symeda.sormas.backend.common.ConfigFacadeEjb;
 import de.symeda.sormas.backend.person.PersonFacadeEjb;
 import de.symeda.sormas.backend.util.ClientHelper;
@@ -85,6 +88,8 @@ public class ExternalJournalService {
 	private ConfigFacadeEjb.ConfigFacadeEjbLocal configFacade;
 	@EJB
 	private PersonFacadeEjb.PersonFacadeEjbLocal personFacade;
+	@Resource
+	private ManagedScheduledExecutorService executorService;
 
 	/**
 	 * Retrieves a token used for authenticating in the symptom journal.
@@ -220,14 +225,29 @@ public class ExternalJournalService {
 		return shouldNotify;
 	}
 
+	public void handleExternalJournalPersonUpdate(PersonReferenceDto person) {
+		if (!configFacade.isExternalJournalActive()) {
+			return;
+		}
+
+		/**
+		 * The .getPersonForJournal(...) here gets the person in the state it is (most likely) known to an external journal.
+		 * Changes of related data is assumed to be not yet persisted in the database.
+		 * 5 second delay added before notifying of update so that current transaction can complete and
+		 * new data can be retrieved from DB
+		 */
+		JournalPersonDto existingPerson = personFacade.getPersonForJournal(person.getUuid());
+		Runnable notify = () -> notifyExternalJournalPersonUpdate(existingPerson);
+		executorService.schedule(notify, 5, TimeUnit.SECONDS);
+	}
+
 	/**
 	 * Note: This method just checks for changes in the Person data.
 	 * It can not check for Contact related data such as FollowUpUntil dates.
 	 */
 	private boolean shouldNotify(JournalPersonDto existingJournalPerson) {
 		PersonDto detailedExistingPerson = personFacade.getPersonByUuid(existingJournalPerson.getUuid());
-		if (SymptomJournalStatus.ACCEPTED.equals(detailedExistingPerson.getSymptomJournalStatus())
-			|| SymptomJournalStatus.REGISTERED.equals(detailedExistingPerson.getSymptomJournalStatus())) {
+		if (detailedExistingPerson.isEnrolledInExternalJournal()) {
 			JournalPersonDto updatedJournalPerson = personFacade.getPersonForJournal(existingJournalPerson.getUuid());
 			return !existingJournalPerson.equals(updatedJournalPerson);
 		}


### PR DESCRIPTION
Remarks from  https://github.com/hzi-braunschweig/SORMAS-Project/issues/4243#issuecomment-778222278:

- `ExternalJournalService.notifyExternalJournalPersonUpdate` is called from `ExternalJournalService.handleExternalJournalPersonUpdate` only. Wether an external journal is active at all is checked there first (fixed in #4306).
- `ExternalJournalService.shouldNotify` is about detecting changes form updates where initially only the previous state is known. Unfortunately even `PersonDto.isEnrolledInExternalJournal()` may have been subject to change, so fetching the person data is necessary