### PR TITLE
Change/4431 disbale default user accounts

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/ConfigFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/ConfigFacadeEjb.java
@@ -133,7 +133,7 @@ public class ConfigFacadeEjb implements ConfigFacade {
 	private static final String DASHBOARD_MAP_MARKER_LIMIT = "dashboardMapMarkerLimit";
 	private static final String AUDITOR_ATTRIBUTE_LOGGING = "auditor.attribute.logging";
 
-	private static final String CREATE_DEFAULT_USERS = "createDefaultUsers";
+	private static final String CREATE_DEFAULT_ENTITIES = "createDefaultEntities";
 
 	private final Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -549,8 +549,8 @@ public class ConfigFacadeEjb implements ConfigFacade {
 		return getInt(DASHBOARD_MAP_MARKER_LIMIT, -1);
 	}
 
-	public boolean isCreateDefaultUsers() {
-		return getBoolean(CREATE_DEFAULT_USERS, true);
+	public boolean isCreateDefaultEntities() {
+		return getBoolean(CREATE_DEFAULT_ENTITIES, true);
 	}
 
 	public String getDocgenerationNullReplacement() {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/ConfigFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/ConfigFacadeEjb.java
@@ -550,7 +550,7 @@ public class ConfigFacadeEjb implements ConfigFacade {
 	}
 
 	public boolean isCreateDefaultEntities() {
-		return getBoolean(CREATE_DEFAULT_ENTITIES, true);
+		return getBoolean(CREATE_DEFAULT_ENTITIES, false);
 	}
 
 	public String getDocgenerationNullReplacement() {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/StartupShutdownService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/StartupShutdownService.java
@@ -314,9 +314,9 @@ public class StartupShutdownService {
 			userService.persist(admin);
 			userUpdateEvent.fire(new UserUpdateEvent(admin));
 
-			if (!configFacade.isCreateDefaultUsers()) {
-				// return if getCreateDefaultUsers() is false
-				logger.info("Skipping the creation of default users");
+			if (!configFacade.isCreateDefaultEntities()) {
+				// return if isCreateDefaultEntities() is false
+				logger.info("Skipping the creation of default entities");
 				return;
 			}
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/StartupShutdownService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/StartupShutdownService.java
@@ -197,6 +197,11 @@ public class StartupShutdownService {
 	}
 
 	private void createDefaultInfrastructureData() {
+		if (!configFacade.isCreateDefaultEntities()) {
+			// return if isCreateDefaultEntities() is false
+			logger.info("Skipping the creation of default infrastructure data");
+			return;
+		}
 
 		// Region
 		Region region = null;

--- a/sormas-base/setup/sormas.properties
+++ b/sormas-base/setup/sormas.properties
@@ -205,8 +205,8 @@ sms.auth.secret=
 # default "./."
 #docgeneration.nullReplacement=./.
 
-# Control the creation of the default users
-# createDefaultUsers=true
+# Control the creation of the default entities
+# createDefaultEntities=false
 
 # Turn off Attribute logging in the Auditlog on instances where this is not needed
 # auditor.attribute.logging=true


### PR DESCRIPTION
Closes #4431 

- Addresses this [comment](https://github.com/hzi-braunschweig/SORMAS-Project/issues/4431#issuecomment-785164193) and renames default users to default entities as default district and regions is also not inserted
- disable default generation 