### PR TITLE
[#4193] include samples of contacts and event participants

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/PathogenTestService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/PathogenTestService.java
@@ -38,6 +38,8 @@ import de.symeda.sormas.backend.common.AbstractCoreAdoService;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
 import de.symeda.sormas.backend.common.CoreAdo;
 import de.symeda.sormas.backend.common.CriteriaBuilderHelper;
+import de.symeda.sormas.backend.contact.Contact;
+import de.symeda.sormas.backend.event.EventParticipant;
 import de.symeda.sormas.backend.user.User;
 
 @Stateless
@@ -216,14 +218,19 @@ public class PathogenTestService extends AbstractCoreAdoService<PathogenTest> {
 	}
 
 	/**
-	 * Creates a filter that excludes all pathogen tests that are either {@link CoreAdo#deleted} or associated with
-	 * samples whose case is {@link Case#archived}.
+	 * Creates a filter that excludes all pathogen tests that are {@link CoreAdo#deleted} or associated with
+	 * cases that are {@link Case#archived}, contacts that are {@link Contact#deleted}. or event participants that are
+	 * {@link EventParticipant#deleted}
 	 */
 	public Predicate createActiveTestsFilter(CriteriaBuilder cb, Root<PathogenTest> root) {
 
 		Join<PathogenTest, Sample> sample = root.join(PathogenTest.SAMPLE, JoinType.LEFT);
 		Join<Sample, Case> caze = sample.join(Sample.ASSOCIATED_CASE, JoinType.LEFT);
-		return cb.and(cb.isFalse(caze.get(Case.ARCHIVED)), cb.isFalse(root.get(PathogenTest.DELETED)));
+		Join<Sample, Contact> contact = sample.join(Sample.ASSOCIATED_CONTACT, JoinType.LEFT);
+		Join<Sample, EventParticipant> event = sample.join(Sample.ASSOCIATED_EVENT_PARTICIPANT, JoinType.LEFT);
+		Predicate pred =
+			cb.or(cb.isFalse(caze.get(Case.ARCHIVED)), cb.isFalse(contact.get(Contact.DELETED)), cb.isFalse(event.get(EventParticipant.DELETED)));
+		return cb.and(pred, cb.isFalse(sample.get(Sample.DELETED)));
 	}
 
 	/**

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/SampleService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/SampleService.java
@@ -504,13 +504,18 @@ public class SampleService extends AbstractCoreAdoService<Sample> {
 	}
 
 	/**
-	 * Creates a filter that excludes all samples that are either {@link CoreAdo#deleted} or associated with
-	 * cases that are {@link Case#archived}.
+	 * Creates a filter that excludes all samples that are {@link CoreAdo#deleted} or associated with
+	 * cases that are {@link Case#archived}, contacts that are {@link Contact#deleted}. or event participants that are
+	 * {@link EventParticipant#deleted}
 	 */
 	public Predicate createActiveSamplesFilter(CriteriaBuilder cb, Root<Sample> root) {
 
 		Join<Sample, Case> caze = root.join(Sample.ASSOCIATED_CASE, JoinType.LEFT);
-		return cb.and(cb.isFalse(caze.get(Case.ARCHIVED)), cb.isFalse(root.get(Case.DELETED)));
+		Join<Sample, Contact> contact = root.join(Sample.ASSOCIATED_CONTACT, JoinType.LEFT);
+		Join<Sample, EventParticipant> event = root.join(Sample.ASSOCIATED_EVENT_PARTICIPANT, JoinType.LEFT);
+		Predicate pred =
+			cb.or(cb.isFalse(caze.get(Case.ARCHIVED)), cb.isFalse(contact.get(Contact.DELETED)), cb.isFalse(event.get(EventParticipant.DELETED)));
+		return cb.and(pred, cb.isFalse(root.get(Sample.DELETED)));
 	}
 
 	/**

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/sample/SampleFacadeEjbPseudonymizationTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/sample/SampleFacadeEjbPseudonymizationTest.java
@@ -298,10 +298,10 @@ public class SampleFacadeEjbPseudonymizationTest extends AbstractBeanTest {
 
 		// case samples not yet implemented
 		Optional<SampleDto> active3 = activeSamples.stream().filter(t -> t.getUuid().equals(sample3.getUuid())).findFirst();
-		assertThat(active3.isPresent(), is(false));
+		assertThat(active3.isPresent(), is(true));
 
 		Optional<SampleDto> active4 = activeSamples.stream().filter(t -> t.getUuid().equals(sample4.getUuid())).findFirst();
-		assertThat(active4.isPresent(), is(false));
+		assertThat(active4.isPresent(), is(true));
 	}
 
 	@Test


### PR DESCRIPTION
Closes #4193 

Samples of contacts and event participants are now considered as active samples if they are not deleted.
Does this have implications for the App @MateStrysewske ? 