### PR TITLE
[#4721] ensure extended classification to be not null

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/disease/DiseaseConfiguration.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/disease/DiseaseConfiguration.java
@@ -44,6 +44,17 @@ public class DiseaseConfiguration extends AbstractDomainObject {
 
 	public void setDisease(Disease disease) {
 		this.disease = disease;
+		if (disease != Disease.CORONAVIRUS && disease != Disease.MEASLES) {
+			this.extendedClassification = false;
+		} else {
+			this.extendedClassification = true;
+		}
+
+		if (disease != Disease.CORONAVIRUS) {
+			this.extendedClassificationMulti = false;
+		} else {
+			this.extendedClassificationMulti = true;
+		}
 	}
 
 	@Column

--- a/sormas-backend/src/main/resources/sql/sormas_schema.sql
+++ b/sormas-backend/src/main/resources/sql/sormas_schema.sql
@@ -6824,16 +6824,16 @@ ALTER TABLE cases
 INSERT INTO schema_version (version_number, comment) VALUES (344, 'Add a "sampling reason" field in the sample #4555');
 
 -- 2021-03-03 Introduce disease properties to switch between basic and extended classification #4218
-ALTER TABLE diseaseconfiguration ADD COLUMN extendedClassification boolean DEFAULT false;
-ALTER TABLE diseaseconfiguration ADD COLUMN extendedClassificationMulti boolean DEFAULT false;
+ALTER TABLE diseaseconfiguration ADD COLUMN extendedClassification boolean NOT NULL DEFAULT false;
+ALTER TABLE diseaseconfiguration ADD COLUMN extendedClassificationMulti boolean NOT NULL DEFAULT false;
 
 ALTER TABLE diseaseconfiguration_history ADD COLUMN extendedClassification boolean;
 ALTER TABLE diseaseconfiguration_history ADD COLUMN extendedClassificationMulti boolean;
 
 UPDATE diseaseconfiguration SET extendedClassification = false WHERE disease not in ('CORONAVIRUS', 'MEASLES');
 UPDATE diseaseconfiguration SET extendedClassificationMulti = false WHERE disease not in ('CORONAVIRUS');
-UPDATE diseaseconfiguration SET extendedClassification = TRUE WHERE disease in ('CORONAVIRUS', 'MEASLES');
-UPDATE diseaseconfiguration SET extendedClassificationMulti = TRUE WHERE disease in ('CORONAVIRUS');
+UPDATE diseaseconfiguration SET extendedClassification = true WHERE disease in ('CORONAVIRUS', 'MEASLES');
+UPDATE diseaseconfiguration SET extendedClassificationMulti = true WHERE disease in ('CORONAVIRUS');
 
 INSERT INTO schema_version (version_number, comment) VALUES (345, 'Introduce disease properties to switch between basic and extended classification #4218');
 


### PR DESCRIPTION
Closes #4721
The problem was that after the DB setup `createMissingDiseaseConfigurations` was called which caused a no args constructor of `DiseaseConfiguration` being invoked. This again caused (somehow) the `extendedclassification` and `extendedclassificationmulti` fields to be null again in the DB after persisting them (I expected them to be false after the constructor but whatever :laughing: ).

This fix ensures that both fields are always set in accordance with the logic that @sergiupacurariu provided for the DB changes in the first place.