### PR TITLE
#4053 Add bottom-padding to tables so that scrollbars wont cover content

### DIFF
--- a/sormas-ui/src/main/webapp/VAADIN/themes/sormas/components/table.scss
+++ b/sormas-ui/src/main/webapp/VAADIN/themes/sormas/components/table.scss
@@ -17,7 +17,7 @@ $v-table-border-width: 1px;
     .v-table-body {
       border: none;
     }
-    
+
     .v-table-row, .v-table-row-odd {
     
       > td, > th {
@@ -82,5 +82,9 @@ $v-table-border-width: 1px;
         }
       }      
     }
+  }
+
+  .v-table-table{
+    padding-bottom: 15px;
   }
 }


### PR DESCRIPTION
Adds 15px bottom padding to tables so this doesn't happen:

![image](https://user-images.githubusercontent.com/4655486/113261180-70020c00-92cf-11eb-8be6-12826f8e5081.png)

(Relevant e.g. for exposure tables)