### PR TITLE
[#5006] add mkdocs github pages

### DIFF
--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -1,0 +1,37 @@
+name: Publish GitHub Pages
+on:
+  pull_request:
+    branches:
+      - development
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Deploy page
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v1
+      - name: Copy files
+        run: |
+          cp README.md docs/index.md
+          # remove wrong path prefix
+          sed -i -e 's/docs\///g' docs/index.md
+
+          mkdir docs/sormas-rest/
+          cp sormas-rest/README.md docs/sormas-rest/
+
+          mkdir docs/sormas-cargoserver/
+          cp sormas-cargoserver/README.md docs/sormas-cargoserver/
+
+          mkdir docs/sormas-keycloak-service-provider/
+          cp sormas-keycloak-service-provider/README.md docs/sormas-keycloak-service-provider/
+
+          mkdir -p docs/sormas-base/doc/
+          cp sormas-base/doc/keycloak.md docs/sormas-base/doc/
+      - name: Deploy docs
+        uses: mhausenblas/mkdocs-deploy-gh-pages@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -9,7 +9,7 @@ jobs:
     name: Deploy page
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout master
+      - name: Checkout development
         uses: actions/checkout@v1
       - name: Copy files
         run: |

--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -1,11 +1,8 @@
 name: Publish GitHub Pages
 on:
-  pull_request:
-    branches:
-      - development
   push:
     branches:
-      - master
+      - development
 
 jobs:
   build:
@@ -31,6 +28,7 @@ jobs:
 
           mkdir -p docs/sormas-base/doc/
           cp sormas-base/doc/keycloak.md docs/sormas-base/doc/
+
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@master
         env:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <a href="https://sormas.org/">
     <img
       alt="SORMAS - Surveillance, Outbreak Response Management and Analysis System"
-      src="logo.png"
+      src="https://raw.githubusercontent.com/hzi-braunschweig/SORMAS-Project/development/logo.png"
       height="200"
     />
   </a>
@@ -30,7 +30,8 @@ If you want to contribute to the code, please strictly adhere to the [*Developme
 Please also make sure that you've read the [*Development Contributing Guidelines*](docs/CONTRIBUTING.md#development-contributing-guidelines) before you start to develop, and either follow or regularly check our Twitter account <a href="https://twitter.com/SORMASDev" target="_blank">@SORMASDev</a> to stay up to date with our schedule, new releases, guideline changes and other announcements.
 
 ### How Can I Report a Bug or Request a Feature?
-If you want to report a **security issue**, please read and follow our [*Security Policies*](docs/SECURITY.md). For bugs without security implications, change and feature requests, please [create a new issue](https://github.com/hzi-braunschweig/SORMAS-Project/issues/new/choose) and read the [*Submitting an Issue*](docs/CONTRIBUTING.md#submitting-an-issue) guide for more detailed instructions. We appreciate your help!
+If you want to report a **security issue**, please read and follow our [*Security Policies*](docs/SECURITY.md). For bugs without security implications, change and feature requests, please [create a new issue](https://github.com/hzi-braunschweig/SORMAS-Project/issues/new/choose) and
+read the [*Submitting an Issue*](docs/CONTRIBUTING.md#submitting-an-issue) guide for more detailed instructions. We appreciate your help!
 
 ### Which Browsers and Android Versions Are Supported?
 SORMAS officially supports and is tested on **Chromium-based browsers** (like Google Chrome) and **Mozilla Firefox**, and all Android versions starting from **Android 7.0** (Nougat). In principle, SORMAS should be usable with all web browsers that are supported by Vaadin 8 (Chrome, Firefox, Safari, Edge, Internet Explorer 11; see <https://vaadin.com/faq>).
@@ -38,7 +39,8 @@ SORMAS officially supports and is tested on **Chromium-based browsers** (like Go
 Making use of the SORMAS web application through a mobile device web browser is possible and acceptable also in countries that are subject to the General Data Protection Regulation (GDPR) as enforced by the European Union. However, in such countries that are subject to the GDPR, the Android application (.apk file) for SORMAS should not be used on mobile devices until further notice.
 
 ### Is there a ReST API documentation?
-Yes! Please download the [latest release](https://github.com/hzi-braunschweig/SORMAS-Project/releases/latest) and copy the content of /deploy/openapi/sormas-rest.yaml to an editor that generates a visual API documentation (e.g. <https://editor.swagger.io/>). A runtime Swagger documentation of the External Visits Resource (used by external symptom journals such as CLIMEDO or PIA) is available at ``<<host>>/sormas-rest/openapi.json`` or ``<<host>>/sormas-rest/openapi.yaml``
+Yes! Please download the [latest release](https://github.com/hzi-braunschweig/SORMAS-Project/releases/latest) and copy the content of /deploy/openapi/sormas-rest.yaml to an editor that generates a visual API documentation(e.g. <https://editor.swagger.io/>).
+A runtime Swagger documentation of the External Visits Resource (used by external symptom journals such as CLIMEDO or PIA) is available at ``<<host>>/sormas-rest/openapi.json`` or ``<<host>>/sormas-rest/openapi.yaml``
 
 <p align="center"><img src="https://user-images.githubusercontent.com/23701005/74659600-ebb8fc00-5194-11ea-836b-a7ca9d682301.png"/></p>
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -61,6 +61,8 @@ If you're interested in participating in the development of SORMAS, you can use 
 
 * [Setting up your local environment](DEVELOPMENT_ENVIRONMENT.md)
 * [Adding license headers](ADDING_LICENSE.md)
+* [How to add a new disease?](https://github.com/hzi-braunschweig/SORMAS-Project/wiki/Adding-a-New-Disease)
+* [How to add a new field?](https://github.com/hzi-braunschweig/SORMAS-Project/wiki/Adding-a-New-Field-to-an-Entity)
 
 ### Development Contributing Guidelines
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -61,8 +61,6 @@ If you're interested in participating in the development of SORMAS, you can use 
 
 * [Setting up your local environment](DEVELOPMENT_ENVIRONMENT.md)
 * [Adding license headers](ADDING_LICENSE.md)
-* [How to add a new disease?](GUIDE_ADD_NEW_DISEASE.md)
-* [How to add a new field?](GUIDE_ADD_NEW_FIELD.md)
 
 ### Development Contributing Guidelines
 

--- a/docs/SERVER_SETUP.md
+++ b/docs/SERVER_SETUP.md
@@ -125,10 +125,10 @@ Keycloak can be set up in two ways:
 * SORMAS Server is installed
 * PostgreSQL is installed
 * Docker is installed
-* Open and edit [keycloak-setup.sh](sormas-base/setup/keycloak/keycloak-setup.sh) with your system's actual values *(on Windows use Git Bash)*.
+* Open and edit `sormas-base/setup/keycloak/keycloak-setup.sh` with your system's actual values *(on Windows use Git Bash)*.
 
 **Setup**
-* Run [keycloak-setup.sh](sormas-base/setup/keycloak/keycloak-setup.sh)
+* Run `sormas-base/setup/keycloak/keycloak-setup.sh`
 * Update `sormas.properties` file in the SORMAS domain with the property `authentication.provider=KEYCLOAK`
 
 
@@ -145,8 +145,8 @@ Setting Keycloak up as a standalone installation [Server Installation and Config
 * Set up an Admin User
 * Copy the `themes` folder content to `${KEYCLOAK_HOME}/themes` [Deploying Themes](https://www.keycloak.org/docs/11.0/server_development/#deploying-themes)
 * Deploy the `sormas-keycloak-service-provider` [Using Keycloak Deployer](https://www.keycloak.org/docs/11.0/server_development/#using-the-keycloak-deployer)
-* Update the [SORMAS.json](sormas-base/setup/keycloak/SORMAS.json) file by replacing the following placeholders: `${SORMAS_SERVER_URL}`, `${KEYCLOAK_SORMAS_UI_SECRET}`, `${KEYCLOAK_SORMAS_BACKEND_SECRET}`, `${KEYCLOAK_SORMAS_REST_SECRET}`
-* Create the SORMAS Realm by importing [SORMAS.json](sormas-base/setup/keycloak/SORMAS.json) see [Create a New Realm](https://www.keycloak.org/docs/11.0/server_admin/#_create-realm)
+* Update the `sormas-base/setup/keycloak/SORMAS.json` file by replacing the following placeholders: `${SORMAS_SERVER_URL}`, `${KEYCLOAK_SORMAS_UI_SECRET}`, `${KEYCLOAK_SORMAS_BACKEND_SECRET}`, `${KEYCLOAK_SORMAS_REST_SECRET}`
+* Create the SORMAS Realm by importing `sormas-base/setup/keycloak/SORMAS.json` see [Create a New Realm](https://www.keycloak.org/docs/11.0/server_admin/#_create-realm)
 * Update the `sormas-*` clients by generating new secrets for them
 * Update the realm's email settings to allow sending emails to users
 
@@ -384,8 +384,7 @@ chmod +x r-setup.sh
 ## SORMAS to SORMAS Certificate Setup
 
 To be able to communicate with other SORMAS instances, there are some additional steps which need to be taken, in order to set
-up the certificate and the truststore. Please see the [related guide](GUIDE_SORMAS2SORMAS_CERTIFICATE.md) for detailed instructions regarding
-SORMAS to SORMAS setup.
+up the certificate and the truststore.
 <br/>
 
 ## Troubleshooting

--- a/docs/SERVER_SETUP.md
+++ b/docs/SERVER_SETUP.md
@@ -384,7 +384,7 @@ chmod +x r-setup.sh
 ## SORMAS to SORMAS Certificate Setup
 
 To be able to communicate with other SORMAS instances, there are some additional steps which need to be taken, in order to set
-up the certificate and the truststore.
+up the certificate and the truststore. Please see the [related guide](https://github.com/hzi-braunschweig/SORMAS-Project/wiki/Creating-a-SORMAS2SORMAS-Certificate) for detailed instructions regarding SORMAS to SORMAS setup.
 <br/>
 
 ## Troubleshooting

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,9 +21,9 @@ nav:
   - Offical Website: "https://sormas.org"
   - Home: index.md
   - Contributing: CONTRIBUTING.md
-  - Demo: DEMO_APP.md
+  - Demo App: DEMO_APP.md
   - REST: sormas-rest/README.md
-  - Development: DEVELOPMENT_ENVIRONMENT.md
+  - Development Environment: DEVELOPMENT_ENVIRONMENT.md
   - Cargo Server: sormas-cargoserver/README.md
   - Keycloak: sormas-base/doc/keycloak.md
   - Keycloak Service Provider: sormas-keycloak-service-provider/README.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,38 @@
+site_name: SORMAS Project
+repo_name: 'hzi-braunschweig/SORMAS-Project'
+repo_url: 'https://github.com/hzi-braunschweig/SORMAS-Project'
+
+theme:
+  name: material
+  features:
+    - tabs
+extra:
+  version: 0.10
+  palette:
+    primary: 'cyan'
+  social:
+    - icon: 'fontawesome/brands/github-alt'
+      link: 'https://github.com/hzi-braunschweig/SORMAS-Project'
+plugins:
+  - search:
+      separator: '[\s]+'
+
+nav:
+  - Offical Website: "https://sormas.org"
+  - Home: index.md
+  - Contributing: CONTRIBUTING.md
+  - Demo: DEMO_APP.md
+  - REST: sormas-rest/README.md
+  - Development: DEVELOPMENT_ENVIRONMENT.md
+  - Cargo Server: sormas-cargoserver/README.md
+  - Keycloak: sormas-base/doc/keycloak.md
+  - Keycloak Service Provider: sormas-keycloak-service-provider/README.md
+  - I18n: I18N.md
+  - Security: SECURITY.md
+  - Custimization: SERVER_CUSTOMIZATION.md
+  - Development Setup: SERVER_DEV_SETUP.md
+  - Setup: SERVER_SETUP.md
+  - Update: SERVER_UPDATE.md
+  - Diseases: SOP_DISEASES.md
+  - Licensing: ADDING_LICENSE.md
+  - Acknowledgements: 3RD_PARTY_ACK.md

--- a/sormas-base/doc/keycloak.md
+++ b/sormas-base/doc/keycloak.md
@@ -12,7 +12,7 @@ To set up Keycloak check the guide here [Keycloak Setup](../../SERVER_SETUP.md#k
 ## SORMAS Realm
 
 The SORMAS Realm in Keycloak contains all the configuration which are specific to the SORMAS Project.
-All the configuration is part of the [SORMAS.json](../setup/keycloak/SORMAS.json) file.
+All the configuration is part of the `setup/keycloak/SORMAS.json` file.
 
 ### Configuration summary
 

--- a/sormas-keycloak-service-provider/README.md
+++ b/sormas-keycloak-service-provider/README.md
@@ -11,7 +11,7 @@ Since SORMAS and Keycloak are using different hashing techniques, the `SormasPas
 SORMAS technique by importing the `sormas-api` dependency where the technique is defined.
 
 ### SORMAS Hashing Technique
-*For more info about the SORMAS hashing technique see [PasswordHelper](../sormas-api/src/main/java/de/symeda/sormas/api/utils/PasswordHelper.java).*
+*For more info about the SORMAS hashing technique see `sormas-api/src/main/java/de/symeda/sormas/api/utils/PasswordHelper.java`*
 
 In Keycloak this algorithm will be identifiable by the id `sormas-sha256`.
 


### PR DESCRIPTION
Closes #5006 

preview [here](https://healthimis.github.io/SORMAS-Project/)

The following is changed:

1. Add an GitHub action which populates GitHub pages with the latest documents from `development` (we could change this to `master` if desired).
2. `GUIDE_ADD_NEW_DISEASE.md` and `GUIDE_ADD_NEW_FIELDS.md` were removed, therefore I removed the referencing links in `CONTRIBUTING.md`. If these two files were removed by accident, I can add them again in this PR.
3. A couple of links referenced non Markdown or HTML files, which causes problems with GitHub Preview + Pages, so I removed them
4.  `GUIDE_SORMAS2SORMAS_CERTIFICATE.md` was removed but was still referenced from `SERVER_SETUP.md`, so I removed the link as well. I feel this file should be included again as S2S is a complex feature and we should have some docs on it in the repo.
5. The `nav` key in `mkdcos.yml`  is currently arbitrary and up to discussion. It also supports a tree like structure so we could, have development chapter and a setup chapter and so on. Happy to adjust to taste and comments! :)