### PR TITLE
[#3383] add GitHub Action openAPI canary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,17 @@ jobs:
         # FIXME(@JonasCir) see https://github.com/hzi-braunschweig/SORMAS-Project/issues/3730#issuecomment-745165678
         working-directory: ./sormas-base
         run: mvn verify -B -ntp
+
+      - name: Commit openAPI spec to development
+        if: github.event_name == 'push' && github.ref == 'refs/heads/development'
+        run: |
+            git config user.name github-actions
+            git config user.email github-actions@github.com
+
+            rm -rf openapi
+            mkdir openapi/
+            cp sormas-rest/target/swagger.* sormas-rest/target/external_journal_API.* openapi
+
+            git add openapi
+            git commit -m "[GitHub Actions] Update openAPI spec files"
+            git push

--- a/.github/workflows/openapi_canary.yml
+++ b/.github/workflows/openapi_canary.yml
@@ -1,0 +1,33 @@
+name: OpenAPI Canary
+
+on:
+  schedule:
+    # 2.30 UTC
+    - cron: '30 2 * * *'
+
+jobs:
+  canary:
+    name: Check for changed spec files
+    runs-on: ubuntu-latest
+    container: openapitools/openapi-diff
+
+    steps:
+      - name: Checkout development branch
+        uses: actions/checkout@v2
+        with:
+          path: head
+
+      - name: Checkout master branch
+        uses: actions/checkout@v2
+        with:
+          ref: master
+          path: base
+
+      # --fail-on-incompatible is also possible
+      - name: Run OpenAPI Diff for external journal API
+        run: |
+          java -jar /app/openapi-diff.jar --fail-on-changed base/openapi/external_journal_API.yaml head/openapi/external_journal_API.yaml
+
+      - name: Run OpenAPI Diff for complete API
+        run: |
+          java -jar /app/openapi-diff.jar --fail-on-changed base/openapi/swagger.yaml head/openapi/swagger.yaml


### PR DESCRIPTION
@FredrikSchaeferVitagroup Here are my changes :)
Logistic-wise I think it is better to ship this with your PR (base of this PR is your branch)

1. A new CI action is introduced which runs only on development after the tests are successful: It commits the build swagger files automatically to development. This gives us a reliable single source of truth regarding the openAPI files
2. A canary workflow is introduces which checks once per day if there are any changes between development and master. This will start to work after the next release when develop becomes the new master b/c then the files from (1) are also present on master and a diff can happen. See [here](https://github.com/healthIMIS/SORMAS-Project/runs/2324753779?check_suite_focus=true) for an example failure.
The action is based on the openAPI diff [tool](https://github.com/OpenAPITools/openapi-diff)

Status badges can be shared with customers
![badge](https://user-images.githubusercontent.com/20031875/114417764-28725e80-9bb2-11eb-95f7-57f12591866d.png)
