### PR TITLE
#4191 - Fixed issues in follow-up until calculation logic

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/caze/CaseLogic.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/caze/CaseLogic.java
@@ -131,45 +131,44 @@ public final class CaseLogic {
 		}
 	}
 
-	public static Date getFollowUpUntilDate(CaseDataDto caze, List<VisitDto> visits, int followUpDuration) {
+	/**
+	 * Calculates the follow-up until date of the case based on its start date (onset contact or report date), the follow-up duration of
+	 * the disease, the current follow-up until date and the date of the last cooperative visit.
+	 *
+	 * @param ignoreOverwrite
+	 *            Returns the expected follow-up until date based on case start date, follow-up duration of the disease and date of the
+	 *            last cooperative visit. Ignores current follow-up until date and whether or not follow-up until has been overwritten.
+	 */
+	public static Date calculateFollowUpUntilDate(CaseDataDto caze, List<VisitDto> visits, int followUpDuration, boolean ignoreOverwrite) {
 
 		Date beginDate = CaseLogic.getStartDate(caze.getSymptoms().getOnsetDate(), caze.getReportDate());
-		Date untilDate = caze.isOverwriteFollowUpUntil() ? caze.getFollowUpUntil() : DateHelper.addDays(beginDate, followUpDuration);
+		Date standardUntilDate = DateHelper.addDays(beginDate, followUpDuration);
+		Date untilDate = !ignoreOverwrite && caze.isOverwriteFollowUpUntil() ? caze.getFollowUpUntil() : standardUntilDate;
 
-		VisitDto lastVisit = null;
-		boolean additionalVisitNeeded;
-		do {
-			additionalVisitNeeded = false;
-			if (visits != null) {
-				for (VisitDto visit : visits) {
-					if (lastVisit != null) {
-						if (lastVisit.getVisitDateTime().before(visit.getVisitDateTime())) {
-							lastVisit = visit;
-						}
-					} else {
-						lastVisit = visit;
-					}
-				}
+		Date lastVisitDate = null;
+		boolean additionalVisitNeeded = true;
+		for (VisitDto visit : visits) {
+			if (lastVisitDate == null || DateHelper.getStartOfDay(visit.getVisitDateTime()).after(DateHelper.getStartOfDay(lastVisitDate))) {
+				lastVisitDate = visit.getVisitDateTime();
 			}
-			if (lastVisit != null) {
-				// if the last visit was not cooperative and happened at the last date of
-				// contact tracing ..
-				if (lastVisit.getVisitStatus() != VisitStatus.COOPERATIVE && lastVisit.getVisitDateTime().compareTo(untilDate) == 0) {
-					// .. we need to do an additional visit
-					additionalVisitNeeded = true;
-					untilDate = DateHelper.addDays(untilDate, 1);
-				}
-				// if the last visit was cooperative and happened at the last date of contact tracing,
-				// revert the follow-up until date back to the original
-				if (!caze.isOverwriteFollowUpUntil()
-					&& lastVisit.getVisitStatus() == VisitStatus.COOPERATIVE
-					&& lastVisit.getVisitDateTime().compareTo(DateHelper.addDays(beginDate, followUpDuration)) == 0) {
-					additionalVisitNeeded = false;
-					untilDate = DateHelper.addDays(beginDate, followUpDuration);
-				}
+			if (additionalVisitNeeded
+				&& !DateHelper.getStartOfDay(visit.getVisitDateTime()).before(DateHelper.getStartOfDay(untilDate))
+				&& visit.getVisitStatus() == VisitStatus.COOPERATIVE) {
+				additionalVisitNeeded = false;
 			}
 		}
-		while (additionalVisitNeeded);
+
+		// Follow-up until needs to be extended to the date after the last visit if there is no cooperative visit after the follow-up until date
+		if (additionalVisitNeeded && lastVisitDate != null) {
+			untilDate = DateHelper.addDays(untilDate, DateHelper.getDaysBetween(untilDate, lastVisitDate));
+		}
+
+		// If the follow-up until date is before the standard follow-up until date for some reason (e.g. because the report date and/or last contact
+		// date were changed), set it to the standard follow-up until date
+		if (DateHelper.getStartOfDay(untilDate).before(standardUntilDate)) {
+			untilDate = standardUntilDate;
+		}
+
 		return untilDate;
 	}
 }

--- a/sormas-api/src/main/java/de/symeda/sormas/api/contact/ContactLogic.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/contact/ContactLogic.java
@@ -38,48 +38,44 @@ public final class ContactLogic {
 		return followUpUntil != null ? followUpUntil : lastContactDate != null ? lastContactDate : reportDate;
 	}
 
-	public static Date getFollowUpUntilDate(ContactDto contact, List<VisitDto> visits, int followUpDuration) {
+	/**
+	 * Calculates the follow-up until date of the contact based on its start date (last contact or report date), the follow-up duration of
+	 * the disease, the current follow-up until date and the date of the last cooperative visit.
+	 * 
+	 * @param ignoreOverwrite
+	 *            Returns the expected follow-up until date based on contact start date, follow-up duration of the disease and date of the
+	 *            last cooperative visit. Ignores current follow-up until date and whether or not follow-up until has been overwritten.
+	 */
+	public static Date calculateFollowUpUntilDate(ContactDto contact, List<VisitDto> visits, int followUpDuration, boolean ignoreOverwrite) {
 
 		Date beginDate = ContactLogic.getStartDate(contact.getLastContactDate(), contact.getReportDateTime());
-		Date untilDate = contact.isOverwriteFollowUpUntil()
-			|| (contact.getFollowUpUntil() != null && contact.getFollowUpUntil().after(DateHelper.addDays(beginDate, followUpDuration)))
-				? contact.getFollowUpUntil()
-				: DateHelper.addDays(beginDate, followUpDuration);
+		Date standardUntilDate = DateHelper.addDays(beginDate, followUpDuration);
+		Date untilDate = !ignoreOverwrite && contact.isOverwriteFollowUpUntil() ? contact.getFollowUpUntil() : standardUntilDate;
 
-		VisitDto lastVisit = null;
-		boolean additionalVisitNeeded;
-		do {
-			additionalVisitNeeded = false;
-			if (visits != null) {
-				for (VisitDto visit : visits) {
-					if (lastVisit != null) {
-						if (lastVisit.getVisitDateTime().before(visit.getVisitDateTime())) {
-							lastVisit = visit;
-						}
-					} else {
-						lastVisit = visit;
-					}
-				}
+		Date lastVisitDate = null;
+		boolean additionalVisitNeeded = true;
+		for (VisitDto visit : visits) {
+			if (lastVisitDate == null || DateHelper.getStartOfDay(visit.getVisitDateTime()).after(DateHelper.getStartOfDay(lastVisitDate))) {
+				lastVisitDate = visit.getVisitDateTime();
 			}
-			if (lastVisit != null) {
-				// if the last visit was not cooperative and happened at the last date of
-				// contact tracing ..
-				if (lastVisit.getVisitStatus() != VisitStatus.COOPERATIVE && DateHelper.isSameDay(lastVisit.getVisitDateTime(), untilDate)) {
-					// .. we need to do an additional visit
-					additionalVisitNeeded = true;
-					untilDate = DateHelper.addDays(untilDate, 1);
-				}
-				// if the last visit was cooperative and happened at the last date of contact tracing,
-				// revert the follow-up until date back to the original
-				if (!contact.isOverwriteFollowUpUntil()
-					&& lastVisit.getVisitStatus() == VisitStatus.COOPERATIVE
-					&& DateHelper.isSameDay(lastVisit.getVisitDateTime(), DateHelper.addDays(beginDate, followUpDuration))) {
-					additionalVisitNeeded = false;
-					untilDate = DateHelper.addDays(beginDate, followUpDuration);
-				}
+			if (additionalVisitNeeded
+				&& !DateHelper.getStartOfDay(visit.getVisitDateTime()).before(DateHelper.getStartOfDay(untilDate))
+				&& visit.getVisitStatus() == VisitStatus.COOPERATIVE) {
+				additionalVisitNeeded = false;
 			}
 		}
-		while (additionalVisitNeeded);
+
+		// Follow-up until needs to be extended to the date after the last visit if there is no cooperative visit after the follow-up until date
+		if (additionalVisitNeeded && lastVisitDate != null) {
+			untilDate = DateHelper.addDays(untilDate, DateHelper.getDaysBetween(untilDate, lastVisitDate));
+		}
+
+		// If the follow-up until date is before the standard follow-up until date for some reason (e.g. because the report date and/or last contact
+		// date were changed), set it to the standard follow-up until date
+		if (DateHelper.getStartOfDay(untilDate).before(standardUntilDate)) {
+			untilDate = standardUntilDate;
+		}
+
 		return untilDate;
 	}
 }

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/contact/ContactServiceTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/contact/ContactServiceTest.java
@@ -4,8 +4,10 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.time.LocalDate;
 import java.util.Date;
@@ -77,26 +79,6 @@ public class ContactServiceTest extends AbstractBeanTest {
 		contacts = getContactService().getAllRelevantContacts(contactPersonEntity, contact1.getDisease(), referenceDate);
 		assertThat(contacts, hasSize(2));
 
-		// Contacts with a follow-up until date before the reference date should not be included
-		contact1.setFollowUpUntil(DateHelper.subtractDays(referenceDate, FollowUpLogic.ALLOWED_DATE_OFFSET + 1));
-		contact1.setOverwriteFollowUpUntil(true);
-		contact2.setFollowUpUntil(DateHelper.subtractDays(referenceDate, FollowUpLogic.ALLOWED_DATE_OFFSET + 1));
-		contact2.setOverwriteFollowUpUntil(true);
-		contact1 = getContactFacade().saveContact(contact1);
-		contact2 = getContactFacade().saveContact(contact2);
-
-		contacts = getContactService().getAllRelevantContacts(contactPersonEntity, contact1.getDisease(), referenceDate);
-		assertThat(contacts, empty());
-
-		// Contacts with a follow-up until date before the reference date but within the offset should be included
-		contact1.setFollowUpUntil(DateHelper.subtractDays(referenceDate, FollowUpLogic.ALLOWED_DATE_OFFSET));
-		contact2.setFollowUpUntil(DateHelper.subtractDays(referenceDate, FollowUpLogic.ALLOWED_DATE_OFFSET));
-		contact1 = getContactFacade().saveContact(contact1);
-		contact2 = getContactFacade().saveContact(contact2);
-
-		contacts = getContactService().getAllRelevantContacts(contactPersonEntity, contact1.getDisease(), referenceDate);
-		assertThat(contacts, hasSize(2));
-
 		// Contacts with a follow-up until date after the reference date should be included
 		contact1.setFollowUpUntil(DateHelper.addDays(referenceDate, FollowUpLogic.ALLOWED_DATE_OFFSET + 1));
 		contact2.setFollowUpUntil(DateHelper.addDays(referenceDate, FollowUpLogic.ALLOWED_DATE_OFFSET + 1));
@@ -155,8 +137,12 @@ public class ContactServiceTest extends AbstractBeanTest {
 		assertEquals(FollowUpStatus.FOLLOW_UP, contact.getFollowUpStatus());
 		assertEquals(LocalDate.now().plusDays(21), DateHelper8.toLocalDate(contact.getFollowUpUntil()));
 
-		VisitDto visit =
-			creator.createVisit(caze.getDisease(), contactPerson.toReference(), DateUtils.addDays(new Date(), 21), VisitStatus.UNAVAILABLE, VisitOrigin.USER);
+		VisitDto visit = creator.createVisit(
+			caze.getDisease(),
+			contactPerson.toReference(),
+			DateUtils.addDays(new Date(), 21),
+			VisitStatus.UNAVAILABLE,
+			VisitOrigin.USER);
 
 		// Follow-up until should be increased by one day
 		contact = getContactFacade().getContactByUuid(contact.getUuid());
@@ -170,6 +156,35 @@ public class ContactServiceTest extends AbstractBeanTest {
 		contact = getContactFacade().getContactByUuid(contact.getUuid());
 		assertEquals(FollowUpStatus.COMPLETED, contact.getFollowUpStatus());
 		assertEquals(LocalDate.now().plusDays(21), DateHelper8.toLocalDate(contact.getFollowUpUntil()));
+
+		// Manually overwrite and increase the follow-up until date
+		contact.setFollowUpUntil(DateUtils.addDays(new Date(), 23));
+		contact.setOverwriteFollowUpUntil(true);
+		contact = getContactFacade().saveContact(contact);
+		assertEquals(FollowUpStatus.FOLLOW_UP, contact.getFollowUpStatus());
+		assertTrue(contact.isOverwriteFollowUpUntil());
+
+		// Add a cooperative visit AFTER the follow-up until date; should set follow-up to completed
+		visit.setVisitStatus(VisitStatus.UNAVAILABLE);
+		visit.setVisitDateTime(contact.getFollowUpUntil());
+		getVisitFacade().saveVisit(visit);
+		contact = getContactFacade().getContactByUuid(contact.getUuid());
+		assertEquals(FollowUpStatus.FOLLOW_UP, contact.getFollowUpStatus());
+		creator.createVisit(
+			caze.getDisease(),
+			contactPerson.toReference(),
+			DateUtils.addDays(new Date(), 24),
+			VisitStatus.COOPERATIVE,
+			VisitOrigin.USER);
+		contact = getContactFacade().getContactByUuid(contact.getUuid());
+		assertEquals(FollowUpStatus.COMPLETED, contact.getFollowUpStatus());
+		assertFalse(contact.isOverwriteFollowUpUntil());
+
+		// Increasing the last contact date should extend follow-up
+		contact.setLastContactDate(DateHelper.addDays(contact.getLastContactDate(), 10));
+		contact = getContactFacade().saveContact(contact);
+		assertEquals(FollowUpStatus.FOLLOW_UP, contact.getFollowUpStatus());
+		assertEquals(LocalDate.now().plusDays(21 + 10), DateHelper8.toLocalDate(contact.getFollowUpUntil()));
 
 		PersonDto person2 = creator.createPerson();
 		ContactDto contact2 = creator.createContact(user.toReference(), person2.toReference());

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/person/PersonFacadeEjbTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/person/PersonFacadeEjbTest.java
@@ -238,9 +238,9 @@ public class PersonFacadeEjbTest extends AbstractBeanTest {
 		creator.createPerson(); // Person without contact
 		final PersonDto person1 = creator.createPerson();
 		final PersonDto person2 = creator.createPerson();
-		final ContactDto contact11 = creator.createContact(user.toReference(), person1.toReference());
-		final ContactDto contact12 = creator.createContact(user.toReference(), person1.toReference());
-		final ContactDto contact2 = creator.createContact(user.toReference(), person2.toReference());
+		final ContactDto contact11 = creator.createContact(user.toReference(), person1.toReference(), DateHelper.subtractDays(new Date(), 41));
+		final ContactDto contact12 = creator.createContact(user.toReference(), person1.toReference(), DateHelper.subtractDays(new Date(), 29));
+		final ContactDto contact2 = creator.createContact(user.toReference(), person2.toReference(), DateHelper.subtractDays(new Date(), 21));
 
 		contact11.setOverwriteFollowUpUntil(true);
 		contact12.setOverwriteFollowUpUntil(true);
@@ -292,8 +292,8 @@ public class PersonFacadeEjbTest extends AbstractBeanTest {
 		person.setBirthdateMM(6);
 		person.setBirthdateDD(1);
 		person.setSymptomJournalStatus(SymptomJournalStatus.REGISTERED);
-		final ContactDto contact1 = creator.createContact(user.toReference(), person.toReference());
-		final ContactDto contact2 = creator.createContact(user.toReference(), person.toReference());
+		final ContactDto contact1 = creator.createContact(user.toReference(), person.toReference(), DateHelper.subtractDays(new Date(), 41));
+		final ContactDto contact2 = creator.createContact(user.toReference(), person.toReference(), DateHelper.subtractDays(new Date(), 29));
 		contact1.setOverwriteFollowUpUntil(true);
 		contact2.setOverwriteFollowUpUntil(true);
 

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/person/PersonFacadeEjbTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/person/PersonFacadeEjbTest.java
@@ -329,11 +329,14 @@ public class PersonFacadeEjbTest extends AbstractBeanTest {
 		final CaseDataDto case12 = creator.createCase(user.toReference(), person1.toReference(), rdcfEntities);
 		final CaseDataDto case2 = creator.createCase(user.toReference(), person2.toReference(), rdcfEntities);
 
+		Date now = new Date();
+		case11.getSymptoms().setOnsetDate(DateHelper.subtractDays(now, 41));
 		case11.setOverwriteFollowUpUntil(true);
+		case12.getSymptoms().setOnsetDate(DateHelper.subtractDays(now, 29));
 		case12.setOverwriteFollowUpUntil(true);
+		case2.getSymptoms().setOnsetDate(DateHelper.subtractDays(now, 21));
 		case2.setOverwriteFollowUpUntil(true);
 
-		Date now = new Date();
 		case11.setFollowUpUntil(DateHelper.subtractDays(now, 20));
 		case12.setFollowUpUntil(DateHelper.subtractDays(now, 8));
 		case2.setFollowUpUntil(now);
@@ -359,15 +362,16 @@ public class PersonFacadeEjbTest extends AbstractBeanTest {
 	public void testGetFollowUpEndDatesContactsAndCases() {
 		RDCFEntities rdcfEntities = creator.createRDCFEntities();
 		UserDto user = creator.createUser(rdcfEntities, UserRole.REST_EXTERNAL_VISITS_USER);
+		Date now = new Date();
 
 		final PersonDto person1 = creator.createPerson();
 		final PersonDto person2 = creator.createPerson();
 		final PersonDto person3 = creator.createPerson();
 		final PersonDto person4 = creator.createPerson();
-		final ContactDto contact1 = creator.createContact(user.toReference(), person1.toReference());
-		final ContactDto contact2 = creator.createContact(user.toReference(), person2.toReference());
+		final ContactDto contact1 = creator.createContact(user.toReference(), person1.toReference(), DateHelper.subtractDays(now, 22));
+		final ContactDto contact2 = creator.createContact(user.toReference(), person2.toReference(), DateHelper.subtractDays(now, 22));
 		final ContactDto contact3 = creator.createContact(user.toReference(), person4.toReference());
-		final ContactDto contact4 = creator.createContact(user.toReference(), person4.toReference());
+		final ContactDto contact4 = creator.createContact(user.toReference(), person4.toReference(), DateHelper.subtractDays(now, 21));
 		final CaseDataDto case1 = creator.createCase(user.toReference(), person1.toReference(), rdcfEntities);
 		final CaseDataDto case2 = creator.createCase(user.toReference(), person2.toReference(), rdcfEntities);
 		final CaseDataDto case3 = creator.createCase(user.toReference(), person2.toReference(), rdcfEntities);
@@ -377,15 +381,19 @@ public class PersonFacadeEjbTest extends AbstractBeanTest {
 		contact1.setOverwriteFollowUpUntil(true);
 		contact2.setOverwriteFollowUpUntil(true);
 		case1.setOverwriteFollowUpUntil(true);
+		case1.getSymptoms().setOnsetDate(DateHelper.subtractDays(now, 23));
 		case2.setOverwriteFollowUpUntil(true);
+		case2.getSymptoms().setOnsetDate(DateHelper.subtractDays(now, 21));
 		case3.setOverwriteFollowUpUntil(true);
+		case3.getSymptoms().setOnsetDate(DateHelper.subtractDays(now, 23));
 		case4.setOverwriteFollowUpUntil(true);
+		case4.getSymptoms().setOnsetDate(DateHelper.subtractDays(now, 21));
 		case5.setOverwriteFollowUpUntil(true);
+		case5.getSymptoms().setOnsetDate(DateHelper.subtractDays(now, 21));
 		contact3.setFollowUpStatus(FollowUpStatus.NO_FOLLOW_UP);
 		contact3.setFollowUpUntil(null);
 		contact4.setFollowUpStatus(FollowUpStatus.FOLLOW_UP);
 
-		Date now = new Date();
 		contact1.setFollowUpUntil(DateHelper.subtractDays(now, 1));
 		case1.setFollowUpUntil(DateHelper.subtractDays(now, 2));
 		contact2.setFollowUpUntil(DateHelper.subtractDays(now, 1));

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/contact/ContactDataForm.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/contact/ContactDataForm.java
@@ -175,7 +175,7 @@ public class ContactDataForm extends AbstractEditForm<ContactDto> {
 	private ComboBox cbDisease;
 	private NullableOptionGroup contactCategory;
 	private boolean quarantineChangedByFollowUpUntilChange = false;
-	private TextField expectedUntilDate;
+	private TextField tfExpectedFollowUpUntilDate;
 
 	public ContactDataForm(Disease disease, ViewMode viewMode, boolean isPseudonymized) {
 		super(
@@ -458,10 +458,16 @@ public class ContactDataForm extends AbstractEditForm<ContactDto> {
 		region.addItems(FacadeProvider.getRegionFacade().getAllActiveByServerCountry());
 
 		CheckBox cbHighPriority = addField(ContactDto.HIGH_PRIORITY, CheckBox.class);
-		expectedUntilDate = new TextField();
-		expectedUntilDate.setCaption(I18nProperties.getCaption(Captions.Contact_expectedFollowUpUntil));
-		getContent().addComponent(expectedUntilDate, EXPECTED_FOLLOW_UP_UNTIL_DATE_LOC);
-		addField(ContactDto.OVERWRITE_FOLLOW_UP_UTIL, CheckBox.class);
+		tfExpectedFollowUpUntilDate = new TextField();
+		tfExpectedFollowUpUntilDate.setCaption(I18nProperties.getCaption(Captions.Contact_expectedFollowUpUntil));
+		getContent().addComponent(tfExpectedFollowUpUntilDate, EXPECTED_FOLLOW_UP_UNTIL_DATE_LOC);
+		CheckBox cbOverwriteFollowUpUntil = addField(ContactDto.OVERWRITE_FOLLOW_UP_UTIL, CheckBox.class);
+		cbOverwriteFollowUpUntil.addValueChangeListener(e -> {
+			if (!(Boolean) e.getProperty().getValue()) {
+				dfFollowUpUntil.discard();
+			}
+		});
+
 		NullableOptionGroup ogImmunosuppressiveTherapyBasicDisease =
 			addField(ContactDto.IMMUNOSUPPRESSIVE_THERAPY_BASIC_DISEASE, NullableOptionGroup.class);
 		addField(ContactDto.IMMUNOSUPPRESSIVE_THERAPY_BASIC_DISEASE_DETAILS, TextField.class);
@@ -986,14 +992,15 @@ public class ContactDataForm extends AbstractEditForm<ContactDto> {
 	public void setValue(ContactDto newFieldValue) throws ReadOnlyException, Converter.ConversionException {
 		super.setValue(newFieldValue);
 
-		expectedUntilDate.setValue(
+		tfExpectedFollowUpUntilDate.setValue(
 			DateHelper.formatLocalDate(
-				ContactLogic.getFollowUpUntilDate(
+				ContactLogic.calculateFollowUpUntilDate(
 					newFieldValue,
 					FacadeProvider.getVisitFacade().getVisitsByContact(newFieldValue.toReference()),
-					FacadeProvider.getDiseaseConfigurationFacade().getFollowUpDuration(newFieldValue.getDisease())),
+					FacadeProvider.getDiseaseConfigurationFacade().getFollowUpDuration(newFieldValue.getDisease()),
+					true),
 				I18nProperties.getUserLanguage()));
-		expectedUntilDate.setReadOnly(true);
+		tfExpectedFollowUpUntilDate.setReadOnly(true);
 
 		// HACK: Binding to the fields will call field listeners that may clear/modify the values of other fields.
 		// this hopefully resets everything to its correct value


### PR DESCRIPTION
* Automatically reset follow-up until to expected follow-up until when "overwrite follow-up until" is unchecked
* Automatically extend follow-up until to expected follow-up until when contact/case start date is changed
* Expected follow-up until date is now always correctly calculated and does not take into account the currently filled in follow-up until date
* Automatically uncheck "Overwrite follow-up until" when the date is automatically changed to a later date than the current follow-up until date

Fixes #4191