### PR TITLE
#4936 fix lat/long order and add EPSG4326_WKT String to sormas.properties

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/ConfigFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/ConfigFacade.java
@@ -97,6 +97,8 @@ public interface ConfigFacade {
 
 	String getGeocodingLatitudeJsonPath();
 
+	String getGeocodingEPSG4326_WKTstring();
+
 	SymptomJournalConfig getSymptomJournalConfig();
 
 	PatientDiaryConfig getPatientDiaryConfig();

--- a/sormas-api/src/main/java/de/symeda/sormas/api/ConfigFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/ConfigFacade.java
@@ -97,7 +97,7 @@ public interface ConfigFacade {
 
 	String getGeocodingLatitudeJsonPath();
 
-	String getGeocodingEPSG4326_WKTstring();
+	String getGeocodingEPSG4326_WKT();
 
 	SymptomJournalConfig getSymptomJournalConfig();
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/ConfigFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/ConfigFacadeEjb.java
@@ -117,6 +117,7 @@ public class ConfigFacadeEjb implements ConfigFacade {
 	private static final String GEOCODING_SERVICE_URL_TEMPLATE = "geocodingServiceUrlTemplate";
 	private static final String GEOCODING_LONGITUDE_JSON_PATH = "geocodingLongitudeJsonPath";
 	private static final String GEOCODING_LATITUDE_JSON_PATH = "geocodingLatitudeJsonPath";
+	private static final String GEOCODING_EPSG4326_WKT_STRING = "geocodingEPSG326_WKTstring";
 
 	private static final String SORMAS2SORMAS_FILES_PATH = "sormas2sormas.path";
 	private static final String SORMAS2SORMAS_SERVER_ACCESS_DATA_FILE_NAME = "sormas2sormas.serverAccessDataFileName";
@@ -135,7 +136,6 @@ public class ConfigFacadeEjb implements ConfigFacade {
 
 	private static final String CREATE_DEFAULT_ENTITIES = "createDefaultEntities";
 	private static final String SKIP_DEFAULT_PASSWORD_CHECK = "skipDefaultPasswordCheck";
-
 
 	private static final String STEP_SIZE_FOR_CSV_EXPORT = "stepSizeForCsvExport";
 
@@ -405,6 +405,13 @@ public class ConfigFacadeEjb implements ConfigFacade {
 	@Override
 	public String getGeocodingLatitudeJsonPath() {
 		return getProperty(GEOCODING_LATITUDE_JSON_PATH, null);
+	}
+
+	@Override
+	public String getGeocodingEPSG4326_WKTstring() {
+		return getProperty(
+			GEOCODING_EPSG4326_WKT_STRING,
+			"GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AXIS[\"Long\",EAST],AXIS[\"Lat\",NORTH],AUTHORITY[\"EPSG\",\"4326\"]]");
 	}
 
 	@Override

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/ConfigFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/ConfigFacadeEjb.java
@@ -117,7 +117,7 @@ public class ConfigFacadeEjb implements ConfigFacade {
 	private static final String GEOCODING_SERVICE_URL_TEMPLATE = "geocodingServiceUrlTemplate";
 	private static final String GEOCODING_LONGITUDE_JSON_PATH = "geocodingLongitudeJsonPath";
 	private static final String GEOCODING_LATITUDE_JSON_PATH = "geocodingLatitudeJsonPath";
-	private static final String GEOCODING_EPSG4326_WKT_STRING = "geocodingEPSG326_WKTstring";
+	private static final String GEOCODING_EPSG4326_WKT = "geocodingEPSG4326_WKT";
 
 	private static final String SORMAS2SORMAS_FILES_PATH = "sormas2sormas.path";
 	private static final String SORMAS2SORMAS_SERVER_ACCESS_DATA_FILE_NAME = "sormas2sormas.serverAccessDataFileName";
@@ -408,9 +408,9 @@ public class ConfigFacadeEjb implements ConfigFacade {
 	}
 
 	@Override
-	public String getGeocodingEPSG4326_WKTstring() {
+	public String getGeocodingEPSG4326_WKT() {
 		return getProperty(
-			GEOCODING_EPSG4326_WKT_STRING,
+			GEOCODING_EPSG4326_WKT,
 			"GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AXIS[\"Long\",EAST],AXIS[\"Lat\",NORTH],AUTHORITY[\"EPSG\",\"4326\"]]");
 	}
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/region/GeoShapeHelper.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/region/GeoShapeHelper.java
@@ -42,9 +42,6 @@ import de.symeda.sormas.api.region.GeoLatLon;
 
 public class GeoShapeHelper {
 
-	private static final String EPSG4326 =
-		"GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AXIS[\"Long\",EAST],AXIS[\"Lat\",NORTH],AUTHORITY[\"EPSG\",\"4326\"]]";
-
 	private static final Logger logger = LoggerFactory.getLogger(GeoShapeHelper.class);
 
 	/**
@@ -84,13 +81,13 @@ public class GeoShapeHelper {
 	 * @throws FactoryException
 	 *             Throws if the requested math transformer could not be build.
 	 */
-	public static MathTransform getLatLonMathTransform(ContentFeatureSource featureSource) throws FactoryException {
+	public static MathTransform getLatLonMathTransform(ContentFeatureSource featureSource, String WKT_String) throws FactoryException {
 		// The CRS of the source file. There are tons of different schemas
 		CoordinateReferenceSystem sourceCRS = featureSource.getSchema().getCoordinateReferenceSystem();
 
 		// The coordinates system you want to reproject the data to
 		// EPSG:4326 is the coordinate reference system GPS uses. Now you know :)
-		CoordinateReferenceSystem targetCRS = CRS.parseWKT(EPSG4326);
+		CoordinateReferenceSystem targetCRS = CRS.parseWKT(WKT_String);
 
 		return CRS.findMathTransform(sourceCRS, targetCRS, true);
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/region/GeoShapeHelper.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/region/GeoShapeHelper.java
@@ -81,13 +81,13 @@ public class GeoShapeHelper {
 	 * @throws FactoryException
 	 *             Throws if the requested math transformer could not be build.
 	 */
-	public static MathTransform getLatLonMathTransform(ContentFeatureSource featureSource, String WKT_String) throws FactoryException {
+	public static MathTransform getLatLonMathTransform(ContentFeatureSource featureSource, String wkt) throws FactoryException {
 		// The CRS of the source file. There are tons of different schemas
 		CoordinateReferenceSystem sourceCRS = featureSource.getSchema().getCoordinateReferenceSystem();
 
 		// The coordinates system you want to reproject the data to
 		// EPSG:4326 is the coordinate reference system GPS uses. Now you know :)
-		CoordinateReferenceSystem targetCRS = CRS.parseWKT(WKT_String);
+		CoordinateReferenceSystem targetCRS = CRS.parseWKT(wkt);
 
 		return CRS.findMathTransform(sourceCRS, targetCRS, true);
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/region/GeoShapeHelper.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/region/GeoShapeHelper.java
@@ -1,17 +1,14 @@
 /*
  * SORMAS® - Surveillance Outbreak Response Management & Analysis System
  * Copyright © 2016-2021 Helmholtz-Zentrum für Infektionsforschung GmbH (HZI)
- *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
@@ -46,7 +43,7 @@ import de.symeda.sormas.api.region.GeoLatLon;
 public class GeoShapeHelper {
 
 	private static final String EPSG4326 =
-		"GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AXIS[\"Lat\",NORTH],AXIS[\"Long\",EAST],AUTHORITY[\"EPSG\",\"4326\"]]";
+		"GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AXIS[\"Long\",EAST],AXIS[\"Lat\",NORTH],AUTHORITY[\"EPSG\",\"4326\"]]";
 
 	private static final Logger logger = LoggerFactory.getLogger(GeoShapeHelper.class);
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/region/GeoShapeProviderEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/region/GeoShapeProviderEjb.java
@@ -134,7 +134,7 @@ public class GeoShapeProviderEjb implements GeoShapeProvider {
 		}
 
 		Point polygonCenter = regionMultiPolygons.get(region).getCentroid();
-		return new GeoLatLon(polygonCenter.getX(), polygonCenter.getY());
+		return new GeoLatLon(polygonCenter.getY(), polygonCenter.getX());
 	}
 
 	@Override
@@ -164,22 +164,23 @@ public class GeoShapeProviderEjb implements GeoShapeProvider {
 		}
 
 		Point polygonCenter = districtMultiPolygons.get(district).getCentroid();
-		return new GeoLatLon(polygonCenter.getX(), polygonCenter.getY());
+		return new GeoLatLon(polygonCenter.getY(), polygonCenter.getX());
 	}
 
 	@PostConstruct
 	private void loadData() {
 		String countryName = configFacade.getCountryName();
+		String WKT_String = configFacade.getGeocodingEPSG4326_WKTstring();
 		if (countryName.isEmpty()) {
 			logger.warn("Shape files couldn't be loaded, because no country name is defined in sormas.properties.");
 		} else {
-			loadRegionData(countryName);
-			loadDistrictData(countryName);
+			loadRegionData(countryName, WKT_String);
+			loadDistrictData(countryName, WKT_String);
 		}
 		buildCountryShape();
 	}
 
-	private void loadRegionData(String countryName) {
+	private void loadRegionData(String countryName, String WKT_String) {
 
 		regionShapes.clear();
 		regionMultiPolygons.clear();
@@ -192,7 +193,7 @@ public class GeoShapeProviderEjb implements GeoShapeProvider {
 				return;
 			}
 
-			MathTransform transform = GeoShapeHelper.getLatLonMathTransform(featureSource);
+			MathTransform transform = GeoShapeHelper.getLatLonMathTransform(featureSource, WKT_String);
 			SimpleFeatureIterator iterator = featureSource.getFeatures().features();
 
 			while (iterator.hasNext()) {
@@ -236,7 +237,7 @@ public class GeoShapeProviderEjb implements GeoShapeProvider {
 		updateCenterOfAllRegions();
 	}
 
-	private void loadDistrictData(String countryName) {
+	private void loadDistrictData(String countryName, String WKT_String) {
 
 		districtShapes.clear();
 		districtMultiPolygons.clear();
@@ -249,7 +250,7 @@ public class GeoShapeProviderEjb implements GeoShapeProvider {
 				return;
 			}
 
-			MathTransform transform = GeoShapeHelper.getLatLonMathTransform(featureSource);
+			MathTransform transform = GeoShapeHelper.getLatLonMathTransform(featureSource, WKT_String);
 			SimpleFeatureIterator iterator = featureSource.getFeatures().features();
 
 			while (iterator.hasNext()) {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/region/GeoShapeProviderEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/region/GeoShapeProviderEjb.java
@@ -1,17 +1,14 @@
 /*
  * SORMAS® - Surveillance Outbreak Response Management & Analysis System
  * Copyright © 2016-2021 Helmholtz-Zentrum für Infektionsforschung GmbH (HZI)
- *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
@@ -116,8 +113,8 @@ public class GeoShapeProviderEjb implements GeoShapeProvider {
 			double lat = 0, lon = 0;
 			int count = 0;
 			for (MultiPolygon polygon : regionMultiPolygons.values()) {
-				lat += polygon.getCentroid().getX();
-				lon += polygon.getCentroid().getY();
+				lon += polygon.getCentroid().getX();
+				lat += polygon.getCentroid().getY();
 				count++;
 			}
 
@@ -283,8 +280,7 @@ public class GeoShapeProviderEjb implements GeoShapeProvider {
 						if (districtExtID == null) {
 							return false;
 						}
-						return districtExtID.contains(shapeDistrictId)
-							|| shapeDistrictId.contains(districtExtID);
+						return districtExtID.contains(shapeDistrictId) || shapeDistrictId.contains(districtExtID);
 					}).reduce((r1, r2) -> {
 						// take the result that best fits
 						// in germany, the external IDs in SORMAS usually contain a leading '110'

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/region/GeoShapeProviderEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/region/GeoShapeProviderEjb.java
@@ -170,17 +170,17 @@ public class GeoShapeProviderEjb implements GeoShapeProvider {
 	@PostConstruct
 	private void loadData() {
 		String countryName = configFacade.getCountryName();
-		String WKT_String = configFacade.getGeocodingEPSG4326_WKTstring();
+		String wkt = configFacade.getGeocodingEPSG4326_WKT();
 		if (countryName.isEmpty()) {
 			logger.warn("Shape files couldn't be loaded, because no country name is defined in sormas.properties.");
 		} else {
-			loadRegionData(countryName, WKT_String);
-			loadDistrictData(countryName, WKT_String);
+			loadRegionData(countryName, wkt);
+			loadDistrictData(countryName, wkt);
 		}
 		buildCountryShape();
 	}
 
-	private void loadRegionData(String countryName, String WKT_String) {
+	private void loadRegionData(String countryName, String wkt) {
 
 		regionShapes.clear();
 		regionMultiPolygons.clear();
@@ -193,7 +193,7 @@ public class GeoShapeProviderEjb implements GeoShapeProvider {
 				return;
 			}
 
-			MathTransform transform = GeoShapeHelper.getLatLonMathTransform(featureSource, WKT_String);
+			MathTransform transform = GeoShapeHelper.getLatLonMathTransform(featureSource, wkt);
 			SimpleFeatureIterator iterator = featureSource.getFeatures().features();
 
 			while (iterator.hasNext()) {
@@ -237,7 +237,7 @@ public class GeoShapeProviderEjb implements GeoShapeProvider {
 		updateCenterOfAllRegions();
 	}
 
-	private void loadDistrictData(String countryName, String WKT_String) {
+	private void loadDistrictData(String countryName, String wkt) {
 
 		districtShapes.clear();
 		districtMultiPolygons.clear();
@@ -250,7 +250,7 @@ public class GeoShapeProviderEjb implements GeoShapeProvider {
 				return;
 			}
 
-			MathTransform transform = GeoShapeHelper.getLatLonMathTransform(featureSource, WKT_String);
+			MathTransform transform = GeoShapeHelper.getLatLonMathTransform(featureSource, wkt);
 			SimpleFeatureIterator iterator = featureSource.getFeatures().features();
 
 			while (iterator.hasNext()) {

--- a/sormas-base/setup/sormas.properties
+++ b/sormas-base/setup/sormas.properties
@@ -146,6 +146,10 @@ sms.auth.secret=
 #geocodingLongitudeJsonPath=$.features[0].geometry.coordinates[0]
 #geocodingLatitudeJsonPath=$.features[0].geometry.coordinates[1]
 
+# EPSG4326 WKT String used to interpret GEO-Coordinate data (e.g. Axis order)
+# default: GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AXIS[\"Long\",EAST],AXIS[\"Lat\",NORTH],AUTHORITY[\"EPSG\",\"4326\"]]
+# geocodingEPSG326_WKTstring=
+
 # Website that is displayed inside an iFrame to create a PIA user account for a contact person; leave this commented
 # if you don't want to use this feature
 #interface.pia.url=

--- a/sormas-base/setup/sormas.properties
+++ b/sormas-base/setup/sormas.properties
@@ -148,7 +148,7 @@ sms.auth.secret=
 
 # EPSG4326 WKT String used to interpret GEO-Coordinate data (e.g. Axis order)
 # default: GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AXIS[\"Long\",EAST],AXIS[\"Lat\",NORTH],AUTHORITY[\"EPSG\",\"4326\"]]
-# geocodingEPSG326_WKTstring=
+# geocodingEPSG4326_WKT=
 
 # Website that is displayed inside an iFrame to create a PIA user account for a contact person; leave this commented
 # if you don't want to use this feature


### PR DESCRIPTION
Fixes #4936 

The whole epsg4326_wkt string is now also configurable, to give users more flexibility when using custom shapefile sources