### PR TITLE
[#5355] checkout without token on fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,8 @@
 name: Java CI with Maven
 
 env:
-  java: 11
+  JAVA: 11
+  IS_FORK: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
 
 on:
   push:
@@ -18,23 +19,37 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
+      - name: Checkout repository (with token)
+        # Check if PR results from the repository: if yes, we have access to the secrets.
+        # The token is only needed for privileged actions from within the repo, so no need
+        # to make it available on 3rd party PRs
+        if: ${{ !fromJSON(env.IS_FORK) }}
         uses: actions/checkout@v2
         with:
           token: ${{ secrets.SORMAS_VITAGROUP_TOKEN }}
 
-      - name: Set up JDK ${{ env.java }}
+      - name: Checkout repository (without token)
+        # Check if PR results from a fork: if yes, we cannot access the token.
+        # The token is only needed for privileged actions from within the repo, so no need
+        # to make it available on 3rd party PRs
+        if: ${{ fromJSON(env.IS_FORK) }}
+        uses: actions/checkout@v2
+
+      - name: Set up JDK ${{ env.JAVA }}
         uses: actions/setup-java@v1
         with:
-          java-version: ${{ env.java }}
+          java-version: ${{ env.JAVA }}
 
       - name: Cache Maven packages
+        # Check if PR results from the repository: if yes, it is safe to cache dependencies.
+        # This is to keep us safe from cache poisoning through 3rd party PRs.
+        if: ${{ !fromJSON(env.IS_FORK) }}
         # FIXME(@JonasCir) #3733 remove '**/*.pom' once serverlib pom is renamed
         uses: actions/cache@v2
         with:
           path: ~/.m2
-          key: ${{ runner.os }}-java-${{ env.java }}-m2-${{ hashFiles('**/pom.xml', '**/*.pom') }}
-          restore-keys: ${{ runner.os }}-java-${{ env.java }}-m2
+          key: ${{ runner.os }}-java-${{ env.JAVA }}-m2-${{ hashFiles('**/pom.xml', '**/*.pom') }}
+          restore-keys: ${{ runner.os }}-java-${{ env.JAVA }}-m2
 
       - name: Run mvn verify
         # FIXME(@JonasCir) see https://github.com/hzi-braunschweig/SORMAS-Project/issues/3730#issuecomment-745165678
@@ -42,6 +57,8 @@ jobs:
         run: mvn verify -B -ntp
 
       - name: Commit external visits API spec to development
+        # Privileged action needing a secret token. Since this only runs on development in our own repo
+        # the token will be available through a privileged checkout.
         if: github.event_name == 'push' && github.ref == 'refs/heads/development' && hashFiles('sormas-rest/target/external_visits_API.yaml') != hashFiles('openapi/external_visits_API.yaml')
         # https://stackoverflow.com/questions/59604922/authorize-bash-to-access-github-protected-branch
         run: |


### PR DESCRIPTION
Fixes #5355 

We now check if the PR comes from this repo base or is a fork. Depending on this we checkout differently.

Have a look at the [CI run](https://github.com/hzi-braunschweig/SORMAS-Project/pull/5358/checks?check_run_id=2526572196) from this PR: Token was checked out and cache was used.

In my example PR [run](https://github.com/hzi-braunschweig/SORMAS-Project/pull/5359/checks?check_run_id=2526558475) from a fork, the checkout without token is used and caching is skipped due to security implications. 

