### PR TITLE
#5423-Update the automation framework reporting

### DIFF
--- a/sormas-e2e-tests/README.md
+++ b/sormas-e2e-tests/README.md
@@ -96,7 +96,7 @@ This file a build configuration script defines a project and its tasks.
 
 ````gradle
 
-gradle clean test -Dcucumber.tags="@Login" -Denvironment=performance
+gradle clean startTests -Dcucumber.tags="@Login" -Denvironment=performance
 
 ````
 

--- a/sormas-e2e-tests/README.md
+++ b/sormas-e2e-tests/README.md
@@ -38,7 +38,7 @@ issues that might block successful web development.
     ```
 
 * Install Gradle
-* Install Allure
+* Install Allure(To check this run `allure serve` from Intellij command line)
 * Install IntelliJ IDEA please follow the steps [here](https://www.jetbrains.com/idea/)
 * Launch IntelliJ IDEA and click on `Import project`
 
@@ -102,12 +102,15 @@ gradle clean startTests -Dcucumber.tags="@Login" -Denvironment=performance
 
 ## Reporting
 
-Allure is a test report tool provides a nice visual representation of executed
+- Allure is a test report tool provides a nice visual representation of executed
 tests. Reporting requires [test execution](#test-execution) to generate some
 test report data.
-Open `allureReport` folder in a project and click on `index.html` (to review
-the project structure please go [here](#folder-structure-conventions)). A new
+- Open `allureReport` folder in a project and click on `index.html`. A new
 generated report should be opened in the default browser.
+- After running the tests you will be able to find the allure report in the root
+of the project, in the allureReports folder. 
+- You can add @issue=ticketNumber
+to link GitHub bugs/tickets
 
 > Allure test report example:
 

--- a/sormas-e2e-tests/README.md
+++ b/sormas-e2e-tests/README.md
@@ -102,14 +102,14 @@ gradle clean startTests -Dcucumber.tags="@Login" -Denvironment=performance
 
 ## Reporting
 
-- Allure is a test report tool provides a nice visual representation of executed
+* Allure is a test report tool provides a nice visual representation of executed
 tests. Reporting requires [test execution](#test-execution) to generate some
 test report data.
-- Open `allureReport` folder in a project and click on `index.html`. A new
+* Open `allureReport` folder in a project and click on `index.html`. A new
 generated report should be opened in the default browser.
-- After running the tests you will be able to find the allure report in the root
-of the project, in the allureReports folder. 
-- You can add @issue=ticketNumber
+* After running the tests you will be able to find the allure report in the root
+of the project, in the allureReports folder.
+* You can add @issue=ticketNumber
 to link GitHub bugs/tickets
 
 > Allure test report example:

--- a/sormas-e2e-tests/build.gradle
+++ b/sormas-e2e-tests/build.gradle
@@ -1,81 +1,136 @@
 import com.github.sherter.googlejavaformatgradleplugin.GoogleJavaFormat
 
 plugins {
-    id 'com.github.sherter.google-java-format' version '0.9'
-    id "com.diffplug.spotless" version "5.12.4"
+	id 'com.github.sherter.google-java-format' version '0.9'
+	id "com.diffplug.spotless" version "5.12.4"
 }
 
 apply plugin: 'java'
 
 repositories {
-    jcenter()
-    mavenCentral()
+	mavenCentral()
 }
 
 dependencies {
-    implementation("io.qameta.allure:allure-cucumber4-jvm:$allureCucumber4JvmVersion")
-    testImplementation("io.qameta.allure:allure-gradle:$allureGradle")
-    testImplementation("io.qameta.allure:allure-java-commons:$allureJavaCommonsVersion")
-    testImplementation("io.qameta.allure:allure-rest-assured:$allureRestAssureVersion")
-    testImplementation("ru.yandex.qatools.allure:allure-java-adaptor-api:$allureVersion")
+	implementation("io.qameta.allure:allure-cucumber4-jvm:$allureCucumber4JvmVersion")
+	testImplementation("io.qameta.allure:allure-java-commons:$allureJavaCommonsVersion")
+	testImplementation("io.qameta.allure:allure-rest-assured:$allureRestAssureVersion")
+	testImplementation("ru.yandex.qatools.allure:allure-java-adaptor-api:$allureVersion")
 
-    implementation("io.github.prashant-ramcharan:courgette-jvm:$ioGithubPrashantRamcharan") {
-        exclude group: 'org.testng', module: 'testng'
-        exclude group: 'org.yaml', module: 'testng'
-    }
-    implementation("io.github.bonigarcia:webdrivermanager:$webdrivermanager")
-    implementation("org.seleniumhq.selenium:selenium-java:$seleniumhqVersion") {
-        exclude group: 'com.google.guava', module: 'guava'
-    }
-    implementation("org.awaitility:awaitility:$orgAwaitility")
-    testImplementation("org.awaitility:awaitility:$orgAwaitility")
+	implementation("io.github.prashant-ramcharan:courgette-jvm:$ioGithubPrashantRamcharan") {
+		exclude group: 'org.testng', module: 'testng'
+		exclude group: 'org.yaml', module: 'testng'
+	}
+	implementation("io.github.bonigarcia:webdrivermanager:$webdrivermanager")
+	implementation("org.seleniumhq.selenium:selenium-java:$seleniumhqVersion") {
+		exclude group: 'com.google.guava', module: 'guava'
+	}
+	implementation("org.awaitility:awaitility:$orgAwaitility")
+	testImplementation("org.awaitility:awaitility:$orgAwaitility")
 
-    testImplementation("com.google.truth.extensions:truth-java8-extension:$truthVersion") {
-        exclude group: 'com.google.guava', module: 'guava'
-    }
-    implementation("com.google.truth.extensions:truth-java8-extension:$truthVersion") {
-        exclude group: 'com.google.guava', module: 'guava'
-    }
+	testImplementation("com.google.truth.extensions:truth-java8-extension:$truthVersion") {
+		exclude group: 'com.google.guava', module: 'guava'
+	}
+	implementation("com.google.truth.extensions:truth-java8-extension:$truthVersion") {
+		exclude group: 'com.google.guava', module: 'guava'
+	}
 
-    implementation("org.projectlombok:lombok:$lombokVersion")
-    annotationProcessor("org.projectlombok:lombok:$lombokVersion")
-    testAnnotationProcessor("org.projectlombok:lombok:$lombokVersion")
+	implementation("org.projectlombok:lombok:$lombokVersion")
+	annotationProcessor("org.projectlombok:lombok:$lombokVersion")
+	testAnnotationProcessor("org.projectlombok:lombok:$lombokVersion")
 
-    implementation("com.google.guava:guava:$guavaVersion")
-    implementation("io.qameta.allure:allure-gradle:$allureGradle")
+	implementation("com.google.guava:guava:$guavaVersion")
 
-    implementation("com.google.inject:guice:$guiceVersion")
-    implementation("io.cucumber:cucumber-guice:$cucumberVersion")
+	implementation("com.google.inject:guice:$guiceVersion")
+	implementation("io.cucumber:cucumber-guice:$cucumberVersion")
 
-    implementation("org.slf4j:slf4j-api:$orgSlf4J")
-    implementation("org.slf4j:slf4j-log4j12:$orgSlf4J")
+	implementation("org.slf4j:slf4j-api:$orgSlf4J")
+	implementation("org.slf4j:slf4j-log4j12:$orgSlf4J")
 
-    implementation("ch.qos.logback:logback-classic:$logBackVersion")
-    implementation("ch.qos.logback:logback-core:$logBackVersion")
+	implementation("ch.qos.logback:logback-classic:$logBackVersion")
+	implementation("ch.qos.logback:logback-core:$logBackVersion")
 
-    implementation("com.github.javafaker:javafaker:$javaFakerVersion") { exclude module: 'org.yaml' }
+	implementation("com.github.javafaker:javafaker:$javaFakerVersion") { exclude module: 'org.yaml' }
 
-    testImplementation group: 'org.assertj', name: 'assertj-core', version: assertjCore
+	testImplementation group: 'org.assertj', name: 'assertj-core', version: assertjCore
 }
 
 task format(type: GoogleJavaFormat) {
-    source 'src/main'
-    source 'src/test'
-    include '**/*.java'
+	source 'src/main'
+	source 'src/test'
+	include '**/*.java'
 }
 
 tasks.withType(Test) {
-    maxParallelForks = (int) (Runtime.runtime.availableProcessors().intdiv(2) ?: 1)
-    systemProperties = System.getProperties()
-    systemProperties.remove("java.endorsed.dirs") // needs to be removed from Java 9
+	maxParallelForks = (int) (Runtime.runtime.availableProcessors().intdiv(2) ?: 1)
+	systemProperties = System.getProperties()
+	systemProperties.remove("java.endorsed.dirs") // needs to be removed from Java 9
+}
+
+task createReportFolderIfNotExist() {
+	// Create a File object representing the folder 'A/B'
+	def folder = new File('allureReports')
+
+	// If it doesn't exist
+	if (!folder.exists()) {
+		// Create all folders up-to and including B
+		folder.mkdirs()
+	}
+}
+
+tasks.register('startTests') {
+	doLast {
+		println 'Starting the test cases'
+	}
+}
+
+task copyGeneratedReport(type: Copy) {
+	dependsOn 'createReportFolderIfNotExist'
+
+	from file("$buildDir/reports/allure-report")
+	into file("allureReports")
+}
+
+task copyToGeneratedReport(type: Copy) {
+	from file("allureReports/history")
+	into file("$buildDir/allure-results/history")
+}
+
+task copyCategoriesJson(type: Copy) {
+	from file("src/test/resources/allurefiles/categories.json")
+	into file("$buildDir/allure-results")
+}
+task copyEnvironmentProperties(type: Copy) {
+	dependsOn 'copyCategoriesJson'
+
+	from file("$buildDir/resources/test/allurefiles/environment.properties")
+	into file("$buildDir/allure-results")
+}
+
+task createAllureReport(type: Exec) {
+	workingDir System.getProperty("user.dir")
+	def workingDirectory = System.getProperty("user.dir")
+	def isWindows = System.getProperty('os.name').toLowerCase(Locale.ROOT).contains('windows')
+	if (isWindows) {
+		commandLine 'cmd', "${workingDirectory}/allure-2.13.10/bin/allure.bat", 'allure.bat', 'generate', '-c', "${workingDirectory}/build/allure-results", '-c', '-o', "${workingDirectory}/allureReports"
+	} else {
+		commandLine "allure", 'generate', "${workingDirectory}/build/allure-results", '-c', '-o', "${workingDirectory}/allureReports"
+	}
 }
 
 test {
-    maxParallelForks = (int) (Runtime.runtime.availableProcessors().intdiv(2) ?: 1)
-    println("maxParallelForks : " + maxParallelForks)
-    testLogging.showStandardStreams = true
+	maxParallelForks = (int) (Runtime.runtime.availableProcessors().intdiv(2) ?: 1)
+	println("maxParallelForks : " + maxParallelForks)
+	testLogging.showStandardStreams = true
 
-    // Pass all properties
-    systemProperties = System.getProperties() as Map<String, ?>
-    systemProperties.remove("java.endorsed.dirs")
+	// Pass all properties
+	systemProperties = System.getProperties() as Map<String, ?>
+	systemProperties.remove("java.endorsed.dirs")
 }
+
+compileJava.dependsOn format
+startTests.finalizedBy copyToGeneratedReport
+copyToGeneratedReport.finalizedBy test
+test.finalizedBy copyEnvironmentProperties
+copyEnvironmentProperties.finalizedBy createAllureReport
+createAllureReport.finalizedBy copyGeneratedReport

--- a/sormas-e2e-tests/scripts/runGivenTimes.sh
+++ b/sormas-e2e-tests/scripts/runGivenTimes.sh
@@ -26,5 +26,5 @@ for ((i = 1; i <= $1; ++i)); do
   rm -rf ./allure-results
   ./gradlew clean
   echo "Run: $i "
-  ./gradlew test -Dcucumber.tags="@Login" -Dheadless=true -Dcourgette.threads=9
+  ./gradlew startTests -Dcucumber.tags="@Login" -Dheadless=true -Dcourgette.threads=9
 done

--- a/sormas-e2e-tests/src/main/java/org/sormas/e2etests/common/CommonInjectorSource.java
+++ b/sormas-e2e-tests/src/main/java/org/sormas/e2etests/common/CommonInjectorSource.java
@@ -20,9 +20,9 @@ package org.sormas.e2etests.common;
 
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-import org.sormas.e2etests.ui.DriverModule;
 import cucumber.api.guice.CucumberModules;
 import cucumber.runtime.java.guice.InjectorSource;
+import org.sormas.e2etests.ui.DriverModule;
 
 public class CommonInjectorSource implements InjectorSource {
   @Override

--- a/sormas-e2e-tests/src/main/java/org/sormas/e2etests/common/CommonModule.java
+++ b/sormas-e2e-tests/src/main/java/org/sormas/e2etests/common/CommonModule.java
@@ -22,10 +22,9 @@ import com.github.javafaker.Faker;
 import com.google.inject.Exposed;
 import com.google.inject.PrivateModule;
 import com.google.inject.Provides;
-import org.sormas.e2etests.ui.DriverManager;
-
 import java.util.Locale;
 import javax.inject.Singleton;
+import org.sormas.e2etests.ui.DriverManager;
 
 public class CommonModule extends PrivateModule {
 

--- a/sormas-e2e-tests/src/main/java/org/sormas/e2etests/services/CaseService.java
+++ b/sormas-e2e-tests/src/main/java/org/sormas/e2etests/services/CaseService.java
@@ -20,10 +20,9 @@ package org.sormas.e2etests.services;
 
 import com.github.javafaker.Faker;
 import com.google.inject.Inject;
-import org.sormas.e2etests.pojo.Case;
-
 import java.time.LocalDate;
 import java.util.UUID;
+import org.sormas.e2etests.pojo.Case;
 
 public class CaseService {
   private final Faker faker;

--- a/sormas-e2e-tests/src/main/java/org/sormas/e2etests/ui/DriverMetaData.java
+++ b/sormas-e2e-tests/src/main/java/org/sormas/e2etests/ui/DriverMetaData.java
@@ -19,10 +19,10 @@
 package org.sormas.e2etests.ui;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.sormas.e2etests.enums.OperatingSystems;
 import java.net.URI;
 import lombok.Builder;
 import lombok.Value;
+import org.sormas.e2etests.enums.OperatingSystems;
 
 @Builder(toBuilder = true, builderClassName = "Builder")
 @JsonDeserialize(builder = DriverMetaData.Builder.class)

--- a/sormas-e2e-tests/src/main/java/org/sormas/e2etests/ui/DriverModule.java
+++ b/sormas-e2e-tests/src/main/java/org/sormas/e2etests/ui/DriverModule.java
@@ -24,11 +24,11 @@ import com.google.inject.Exposed;
 import com.google.inject.PrivateModule;
 import com.google.inject.Provider;
 import com.google.inject.Provides;
-import org.sormas.e2etests.enums.OperatingSystems;
 import javax.inject.Named;
 import lombok.SneakyThrows;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.remote.DesiredCapabilities;
+import org.sormas.e2etests.enums.OperatingSystems;
 
 public class DriverModule extends PrivateModule {
 

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/helpers/AssertHelpers.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/helpers/AssertHelpers.java
@@ -23,7 +23,6 @@ import static org.awaitility.Awaitility.await;
 import static org.awaitility.pollinterval.FibonacciPollInterval.fibonacci;
 import static recorders.StepsLogger.PROCESS_ID_STRING;
 
-import org.sormas.e2etests.steps.BaseSteps;
 import java.io.File;
 import java.time.Duration;
 import java.util.Arrays;
@@ -36,6 +35,7 @@ import org.awaitility.core.ConditionTimeoutException;
 import org.awaitility.core.ThrowingRunnable;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.sormas.e2etests.steps.BaseSteps;
 
 @Slf4j
 public class AssertHelpers {

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/helpers/WebDriverHelpers.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/helpers/WebDriverHelpers.java
@@ -22,8 +22,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 
 import com.google.common.truth.Truth;
-import org.sormas.e2etests.common.TimerLite;
-import org.sormas.e2etests.steps.BaseSteps;
 import java.time.Duration;
 import java.util.function.Predicate;
 import javax.inject.Inject;
@@ -33,6 +31,8 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.NotFoundException;
 import org.openqa.selenium.WebElement;
+import org.sormas.e2etests.common.TimerLite;
+import org.sormas.e2etests.steps.BaseSteps;
 
 @Slf4j
 public class WebDriverHelpers {

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/BaseSteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/BaseSteps.java
@@ -19,7 +19,6 @@
 package org.sormas.e2etests.steps;
 
 import com.google.inject.Inject;
-import org.sormas.e2etests.ui.DriverManager;
 import cucumber.api.Scenario;
 import cucumber.api.java.After;
 import cucumber.api.java.Before;
@@ -28,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.sormas.e2etests.ui.DriverManager;
 import recorders.StepsLogger;
 
 @Slf4j

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/application/LoginSteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/application/LoginSteps.java
@@ -19,11 +19,11 @@
 package org.sormas.e2etests.steps.application;
 
 import com.google.inject.Inject;
+import cucumber.api.java8.En;
+import javax.inject.Named;
 import org.sormas.e2etests.helpers.WebDriverHelpers;
 import org.sormas.e2etests.pages.application.LoginPage;
 import org.sormas.e2etests.pages.application.MainPage;
-import cucumber.api.java8.En;
-import javax.inject.Named;
 
 public class LoginSteps implements En {
 

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/application/NavBarSteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/application/NavBarSteps.java
@@ -18,10 +18,10 @@
 
 package org.sormas.e2etests.steps.application;
 
-import org.sormas.e2etests.helpers.WebDriverHelpers;
-import org.sormas.e2etests.pages.application.NavBarPage;
 import cucumber.api.java8.En;
 import javax.inject.Inject;
+import org.sormas.e2etests.helpers.WebDriverHelpers;
+import org.sormas.e2etests.pages.application.NavBarPage;
 
 public class NavBarSteps implements En {
 

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/application/cases/CaseDirectorySteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/application/cases/CaseDirectorySteps.java
@@ -21,9 +21,9 @@ package org.sormas.e2etests.steps.application.cases;
 import static org.sormas.e2etests.pages.application.cases.CaseDirectoryPage.NEW_CASE_BUTTON;
 import static org.sormas.e2etests.pages.application.cases.CreateNewCasePage.DATE_OF_REPORT_INPUT;
 
-import org.sormas.e2etests.helpers.WebDriverHelpers;
 import cucumber.api.java8.En;
 import javax.inject.Inject;
+import org.sormas.e2etests.helpers.WebDriverHelpers;
 
 public class CaseDirectorySteps implements En {
 

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/application/cases/CreateNewCaseSteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/application/cases/CreateNewCaseSteps.java
@@ -21,17 +21,16 @@ package org.sormas.e2etests.steps.application.cases;
 import static org.sormas.e2etests.pages.application.cases.CreateNewCasePage.*;
 import static org.sormas.e2etests.pages.application.cases.EditCasePage.CASE_SAVED_MESSAGE;
 
-import org.sormas.e2etests.helpers.WebDriverHelpers;
-import org.sormas.e2etests.pages.application.cases.EditCasePage;
-import org.sormas.e2etests.pojo.Case;
-import org.sormas.e2etests.services.CaseService;
 import cucumber.api.java8.En;
-
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.TextStyle;
 import java.util.Locale;
 import javax.inject.Inject;
+import org.sormas.e2etests.helpers.WebDriverHelpers;
+import org.sormas.e2etests.pages.application.cases.EditCasePage;
+import org.sormas.e2etests.pojo.Case;
+import org.sormas.e2etests.services.CaseService;
 
 public class CreateNewCaseSteps implements En {
 

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/application/cases/EditCasePersonSteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/application/cases/EditCasePersonSteps.java
@@ -21,13 +21,13 @@ package org.sormas.e2etests.steps.application.cases;
 import static org.sormas.e2etests.pages.application.cases.EditCasePage.CASE_PERSON_TAB;
 import static org.sormas.e2etests.pages.application.cases.EditCasePersonPage.*;
 
-import org.sormas.e2etests.helpers.WebDriverHelpers;
-import org.sormas.e2etests.pojo.Case;
 import cucumber.api.java8.En;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import javax.inject.Inject;
 import org.assertj.core.api.SoftAssertions;
+import org.sormas.e2etests.helpers.WebDriverHelpers;
+import org.sormas.e2etests.pojo.Case;
 
 public class EditCasePersonSteps implements En {
 

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/application/cases/EditCaseSteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/application/cases/EditCaseSteps.java
@@ -21,13 +21,12 @@ package org.sormas.e2etests.steps.application.cases;
 import static org.sormas.e2etests.pages.application.cases.EditCasePage.*;
 
 import com.google.common.truth.Truth;
-import org.sormas.e2etests.helpers.WebDriverHelpers;
-import org.sormas.e2etests.pojo.Case;
 import cucumber.api.java8.En;
-
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import javax.inject.Inject;
+import org.sormas.e2etests.helpers.WebDriverHelpers;
+import org.sormas.e2etests.pojo.Case;
 
 public class EditCaseSteps implements En {
 

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/application/contacts/ContactDirectorySteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/application/contacts/ContactDirectorySteps.java
@@ -21,9 +21,9 @@ package org.sormas.e2etests.steps.application.contacts;
 import static org.sormas.e2etests.pages.application.contacts.ContactDirectoryPage.NEW_CONTACT_BUTTON;
 import static org.sormas.e2etests.pages.application.contacts.CreateNewContactPage.FIRST_NAME_OF_CONTACT_PERSON_INPUT;
 
-import org.sormas.e2etests.helpers.WebDriverHelpers;
 import cucumber.api.java8.En;
 import javax.inject.Inject;
+import org.sormas.e2etests.helpers.WebDriverHelpers;
 
 public class ContactDirectorySteps implements En {
 

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/application/contacts/CreateNewContactSteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/application/contacts/CreateNewContactSteps.java
@@ -22,9 +22,9 @@ import static org.sormas.e2etests.pages.application.contacts.CreateNewContactPag
 import static org.sormas.e2etests.pages.application.contacts.EditContactPage.UUID;
 
 import com.github.javafaker.Faker;
-import org.sormas.e2etests.helpers.WebDriverHelpers;
 import cucumber.api.java8.En;
 import javax.inject.Inject;
+import org.sormas.e2etests.helpers.WebDriverHelpers;
 
 public class CreateNewContactSteps implements En {
 

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/application/events/CreateNewEventSteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/application/events/CreateNewEventSteps.java
@@ -22,9 +22,9 @@ import static org.sormas.e2etests.pages.application.events.CreateNewEventPage.*;
 import static org.sormas.e2etests.pages.application.events.EventParticipantsPage.ADD_PARTICIPANT_BUTTON;
 
 import com.github.javafaker.Faker;
-import org.sormas.e2etests.helpers.WebDriverHelpers;
 import cucumber.api.java8.En;
 import javax.inject.Inject;
+import org.sormas.e2etests.helpers.WebDriverHelpers;
 
 public class CreateNewEventSteps implements En {
 

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/application/events/EventDirectorySteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/application/events/EventDirectorySteps.java
@@ -20,10 +20,10 @@ package org.sormas.e2etests.steps.application.events;
 
 import static org.sormas.e2etests.pages.application.events.CreateNewEventPage.TITLE_INPUT;
 
-import org.sormas.e2etests.helpers.WebDriverHelpers;
-import org.sormas.e2etests.pages.application.events.EventDirectoryPage;
 import cucumber.api.java8.En;
 import javax.inject.Inject;
+import org.sormas.e2etests.helpers.WebDriverHelpers;
+import org.sormas.e2etests.pages.application.events.EventDirectoryPage;
 
 public class EventDirectorySteps implements En {
 

--- a/sormas-e2e-tests/src/test/resources/allure.properties
+++ b/sormas-e2e-tests/src/test/resources/allure.properties
@@ -15,25 +15,5 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
-
-org.gradle.daemon=true
-org.gradle.parallel=true
-allureCucumber4JvmVersion=2.10.0
-allureJavaCommonsVersion=2.6.0
-allureRestAssureVersion=2.10.0
-allureVersion=1.5.4
-cucumberVersion=4.2.5
-guavaVersion=30.1.1-jre
-guiceVersion=4.2.2
-ioGithubPrashantRamcharan=3.3.0
-javaFakerVersion=0.17.2
-logBackVersion=1.2.3
-lombokVersion=1.18.10
-orgSeleniumhqSelenium=3.11.0
-orgSlf4J=1.7.28
-seleniumhqVersion=4.0.0-beta-3
-truthVersion=1.1.2
-formatVersion=0.9
-orgAwaitility=4.0.3
-webdrivermanager=4.4.1
-assertjCore=3.19.0
+allure.link.issue.pattern=https://github.com/hzi-braunschweig/SORMAS-Project/issues/{}
+allure.results.directory=build/allure-results

--- a/sormas-e2e-tests/src/test/resources/allurefiles/categories.json
+++ b/sormas-e2e-tests/src/test/resources/allurefiles/categories.json
@@ -1,0 +1,36 @@
+[
+  {
+    "name": "Infrastructure problems",
+    "messageRegex": ".*bye-bye.*",
+    "matchedStatuses": [
+      "broken",
+      "failed"
+    ]
+  },
+  {
+    "name": "Outdated tests",
+    "traceRegex": ".*FileNotFoundException.*",
+    "matchedStatuses": [
+      "broken"
+    ]
+  },
+  {
+    "name": "Product defects",
+    "matchedStatuses": [
+      "failed"
+    ]
+  },
+  {
+    "name": "Unknown issues",
+    "matchedStatuses": [
+      "broken"
+    ]
+  },
+  {
+    "name": "Logged Github tickets",
+    "traceRegex": ".*AssumptionViolatedException.*",
+    "matchedStatuses": [
+      "skipped"
+    ]
+  }
+]

--- a/sormas-e2e-tests/src/test/resources/allurefiles/environment.properties
+++ b/sormas-e2e-tests/src/test/resources/allurefiles/environment.properties
@@ -16,24 +16,5 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-org.gradle.daemon=true
-org.gradle.parallel=true
-allureCucumber4JvmVersion=2.10.0
-allureJavaCommonsVersion=2.6.0
-allureRestAssureVersion=2.10.0
-allureVersion=1.5.4
-cucumberVersion=4.2.5
-guavaVersion=30.1.1-jre
-guiceVersion=4.2.2
-ioGithubPrashantRamcharan=3.3.0
-javaFakerVersion=0.17.2
-logBackVersion=1.2.3
-lombokVersion=1.18.10
-orgSeleniumhqSelenium=3.11.0
-orgSlf4J=1.7.28
-seleniumhqVersion=4.0.0-beta-3
-truthVersion=1.1.2
-formatVersion=0.9
-orgAwaitility=4.0.3
-webdrivermanager=4.4.1
-assertjCore=3.19.0
+Browser=Chrome
+Environment=Test-Performance

--- a/sormas-e2e-tests/src/test/resources/features/sanity/Login.feature
+++ b/sormas-e2e-tests/src/test/resources/features/sanity/Login.feature
@@ -1,16 +1,17 @@
 @Sanity @Login
 Feature: Login with different type of users
 
+  @issue=5402
   Scenario Outline: Login with <userType> user
     Given I navigate to SORMAS login page
      When I fill the username with <username>
       And I fill the password with <password>
       And I click on the Log In button
      Then I am logged in with name <userType>
-  
-    Examples: 
-      | userType                  | username | password     | 
-      | National User             | NatUser  | NatUser38118 | 
-      | Contact Supervisor        | ContSup  | ContSup38118 | 
-      | Laboratory Officer        | LabOff   | LabOff38118  | 
+
+    Examples:
+      | userType                  | username | password     |
+      | National User             | NatUser  | NatUser38118 |
+      | Contact Supervisor        | ContSup  | ContSup38118 |
+      | Laboratory Officer        | LabOff   | LabOff38118  |
       | Point of Entry Supervisor | PoeSup   | PoeSup38118  |


### PR DESCRIPTION
Description ->

After this feature we are able to have the allure reports without using the `allure serve` command, and we can have very nice history.

## Changes

1. Now you need to start the tests by using the command : `./gradlew startTests -Dcucumber.tags="@Login"`
2. After running the tests you will be able to find the allure report in the root of the project, in the `allureReports` folder
3. From now we can add `@issue=ticketNumber` to link Github bugs/tickets 👇 
![Allure_Report](https://user-images.githubusercontent.com/9676903/118092602-fb91b100-b3d4-11eb-9443-418fec96e8b1.png)
