### PR TITLE
#5506 - Unclear error message when saving visit will exceed max. char…

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/CommitDiscardWrapperComponent.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/CommitDiscardWrapperComponent.java
@@ -463,6 +463,16 @@ public class CommitDiscardWrapperComponent<C extends Component> extends Vertical
 		return null;
 	}
 
+	private String findHtmlMessageDetails(InvalidValueException exception) {
+		for (InvalidValueException cause : exception.getCauses()) {
+			String message = findHtmlMessage(cause);
+			if (message != null)
+				return message;
+		}
+
+		return null;
+	}
+
 	public void commitAndHandle() {
 		try {
 			commit();
@@ -499,6 +509,11 @@ public class CommitDiscardWrapperComponent<C extends Component> extends Vertical
 						htmlMsg.append("</ul>");
 					} else if (firstCause != null) {
 						htmlMsg.append(findHtmlMessage(firstCause));
+						String additionalInfo = findHtmlMessageDetails(firstCause);
+						if (!additionalInfo.isEmpty()) {
+							htmlMsg.append(" : ");
+							htmlMsg.append(findHtmlMessageDetails(firstCause));
+						}
 					}
 
 				}


### PR DESCRIPTION
… size of symptomcomments column


Fixes #5506
Till this fix, error message has only `Comments` text in error message. With this fix, detailed error message has been added. It will be available for all further messages which contains only problematic input field but not the description itself.
![image](https://user-images.githubusercontent.com/6985315/119361268-27097b00-bcb4-11eb-8dad-6481ee437484.png)
