### PR TITLE
[#5625] refactor s2s encryption service

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/crypt/CmsCreator.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/crypt/CmsCreator.java
@@ -7,6 +7,7 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
+import java.util.Collections;
 
 import org.bouncycastle.asn1.ASN1EncodableVector;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
@@ -124,7 +125,7 @@ public class CmsCreator {
 		}
 
 		if (validateSignature) {
-			CmsReader.verify(cmsSignedData, Arrays.asList(signerCertificate));
+			CmsReader.verify(cmsSignedData, Collections.singletonList(signerCertificate));
 			logger.info("Created signature is valid");
 		}
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasEncryptionService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasEncryptionService.java
@@ -80,7 +80,7 @@ public class SormasToSormasEncryptionService {
 		DECRYPTION
 	}
 
-	private byte[] handle(Mode mode, byte[] data, String otherId)
+	private byte[] cipher(Mode mode, byte[] data, String otherId)
 		throws SormasToSormasException, CMSException, CertificateException, KeyStoreException, IOException, NoSuchAlgorithmException,
 		UnrecoverableKeyException {
 		String ownId = getOrganizationId();
@@ -103,7 +103,7 @@ public class SormasToSormasEncryptionService {
 
 	public byte[] signAndEncrypt(byte[] data, String recipientId) throws SormasToSormasException {
 		try {
-			return handle(Mode.ENCRYPTION, data, recipientId);
+			return cipher(Mode.ENCRYPTION, data, recipientId);
 		} catch (Exception e) {
 			LOGGER.error("Could not sign and encrypt data", e);
 			throw new SormasToSormasException(I18nProperties.getString(Strings.errorSormasToSormasEncrypt));
@@ -112,7 +112,7 @@ public class SormasToSormasEncryptionService {
 
 	public byte[] decryptAndVerify(byte[] data, String senderId) throws SormasToSormasException {
 		try {
-			return handle(Mode.DECRYPTION, data, senderId);
+			return cipher(Mode.DECRYPTION, data, senderId);
 		} catch (Exception e) {
 			LOGGER.error("Could not decrypt and verify data", e);
 			throw new SormasToSormasException(I18nProperties.getString(Strings.errorSormasToSormasDecrypt));

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasEncryptionService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasEncryptionService.java
@@ -96,8 +96,9 @@ public class SormasToSormasEncryptionService {
 			return CmsCreator.signAndEncrypt(data, ownCert, ownKey, otherCert, true);
 		case DECRYPTION:
 			return CmsReader.decryptAndVerify(data, Lists.newArrayList(otherCert), ownCert, ownKey);
+		default:
+			throw new IllegalArgumentException("Unknown mode " + mode);
 		}
-		return null;
 	}
 
 	public byte[] signAndEncrypt(byte[] data, String recipientId) throws SormasToSormasException {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasEncryptionService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasEncryptionService.java
@@ -22,6 +22,7 @@ import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
+import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 
@@ -30,6 +31,7 @@ import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
 import javax.inject.Inject;
 
+import org.bouncycastle.cms.CMSException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,58 +55,63 @@ public class SormasToSormasEncryptionService {
 	@EJB
 	protected ServerAccessDataService serverAccessDataService;
 
-	public byte[] encrypt(byte[] data, String instanceID) throws SormasToSormasException {
+	private KeyStore getKeystore() throws CertificateException, KeyStoreException, IOException, NoSuchAlgorithmException {
+		return loadStore(sormasToSormasConfig.getKeystoreName(), sormasToSormasConfig.getKeystorePass());
+	}
+
+	private KeyStore getTruststore() throws CertificateException, KeyStoreException, IOException, NoSuchAlgorithmException {
+		return loadStore(sormasToSormasConfig.getTruststoreName(), sormasToSormasConfig.getTruststorePass());
+	}
+
+	private KeyStore loadStore(String name, String password) throws KeyStoreException, IOException, NoSuchAlgorithmException, CertificateException {
+		String filePath = sormasToSormasConfig.getPath();
+		Path storePath = Paths.get(filePath, name);
+		KeyStore store = KeyStore.getInstance("pkcs12");
+		store.load(new FileInputStream(storePath.toFile()), password.toCharArray());
+		return store;
+	}
+
+	private enum Mode {
+		Encryption,
+		Decryption
+	}
+
+	private byte[] handle(Mode mode, byte[] data, String otherId)
+		throws SormasToSormasException, CMSException, CertificateException, KeyStoreException, IOException, NoSuchAlgorithmException,
+		UnrecoverableKeyException {
+		String ownId = getOrganizationId();
+		KeyStore keystore = getKeystore();
+		KeyStore truststore = getTruststore();
+		X509Certificate ownCert = (X509Certificate) keystore.getCertificate(ownId);
+		// todo private key should have own password
+		PrivateKey ownKey = (PrivateKey) keystore.getKey(ownId, sormasToSormasConfig.getKeystorePass().toCharArray());
+		X509Certificate otherCert = (X509Certificate) truststore.getCertificate(otherId);
+
+		switch (mode) {
+		case Encryption:
+			return CmsCreator.signAndEncrypt(data, ownCert, ownKey, otherCert, true);
+		case Decryption:
+			return CmsReader.decryptAndVerify(data, Lists.newArrayList(otherCert), ownCert, ownKey);
+		}
+		return null;
+	}
+
+	public byte[] signAndEncrypt(byte[] data, String recipientId) throws SormasToSormasException {
 		try {
-			String filePath = sormasToSormasConfig.getPath();
-			String keystoreName = sormasToSormasConfig.getKeystoreName();
-			Path keystorePath = Paths.get(filePath, keystoreName);
-			String keystorePass = sormasToSormasConfig.getKeystorePass();
-
-			KeyStore keystore = getKeyStore(keystorePath, keystorePass);
-			String organizationId = getOrganizationId();
-
-			X509Certificate signerCertificate = (X509Certificate) keystore.getCertificate(organizationId);
-			PrivateKey privateKey = (PrivateKey) keystore.getKey(organizationId, keystorePass.toCharArray());
-
-			Path truststorePath = Paths.get(filePath, sormasToSormasConfig.getTruststoreName());
-			KeyStore truststore = getKeyStore(truststorePath, sormasToSormasConfig.getTruststorePass());
-			X509Certificate recipientCertificate = (X509Certificate) truststore.getCertificate(instanceID);
-
-			return CmsCreator.signAndEncrypt(data, signerCertificate, privateKey, recipientCertificate, true);
+			return handle(Mode.Encryption, data, recipientId);
 		} catch (Exception e) {
-			LOGGER.error("Couldn't encrypt data", e);
+			LOGGER.error("Could not sign and encrypt data", e);
 			throw new SormasToSormasException(I18nProperties.getString(Strings.errorSormasToSormasEncrypt));
 		}
 	}
 
-	public byte[] decrypt(byte[] data, String instanceID) throws SormasToSormasException {
+	public byte[] decryptAndVerify(byte[] data, String senderId) throws SormasToSormasException {
 		try {
-			String filePath = sormasToSormasConfig.getPath();
-
-			Path keystorePath = Paths.get(filePath, sormasToSormasConfig.getKeystoreName());
-			String keystorePass = sormasToSormasConfig.getKeystorePass();
-			KeyStore keystore = getKeyStore(keystorePath, keystorePass);
-
-			String organizationId = getOrganizationId();
-			X509Certificate recipientCertificate = (X509Certificate) keystore.getCertificate(organizationId);
-			PrivateKey recipientPrivateKey = (PrivateKey) keystore.getKey(organizationId, keystorePass.toCharArray());
-
-			Path truststorePath = Paths.get(filePath, sormasToSormasConfig.getTruststoreName());
-			KeyStore truststore = getKeyStore(truststorePath, sormasToSormasConfig.getTruststorePass());
-			X509Certificate singatureCert = (X509Certificate) truststore.getCertificate(instanceID);
-
-			return CmsReader.decryptAndVerify(data, Lists.newArrayList(singatureCert), recipientCertificate, recipientPrivateKey);
+			return handle(Mode.Decryption, data, senderId);
 		} catch (Exception e) {
-			LOGGER.error("Couldn't decrypt data", e);
+			LOGGER.error("Could not decrypt and verify data", e);
 			throw new SormasToSormasException(I18nProperties.getString(Strings.errorSormasToSormasDecrypt));
 		}
-	}
-
-	private KeyStore getKeyStore(Path keystorePath, String keystorePass)
-		throws KeyStoreException, IOException, NoSuchAlgorithmException, CertificateException {
-		KeyStore keystore = KeyStore.getInstance("pkcs12");
-		keystore.load(new FileInputStream(keystorePath.toFile()), keystorePass.toCharArray());
-		return keystore;
 	}
 
 	private String getOrganizationId() throws SormasToSormasException {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasFacadeHelper.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasFacadeHelper.java
@@ -77,7 +77,7 @@ public class SormasToSormasFacadeHelper {
 
 		Response response;
 		try {
-			byte[] encryptedEntities = encryptionService.encrypt(objectMapper.writeValueAsBytes(entities), targetServerAccessData.getId());
+			byte[] encryptedEntities = encryptionService.signAndEncrypt(objectMapper.writeValueAsBytes(entities), targetServerAccessData.getId());
 			response = restCall.call(
 				targetServerAccessData.getHostName(),
 				"Basic " + new String(Base64.getEncoder().encode(userCredentials.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8),
@@ -123,7 +123,7 @@ public class SormasToSormasFacadeHelper {
 
 	public <T> T[] decryptSharedData(SormasToSormasEncryptedDataDto encryptedData, Class<T[]> dataType) throws SormasToSormasException {
 		try {
-			byte[] decryptedData = encryptionService.decrypt(encryptedData.getData(), encryptedData.getOrganizationId());
+			byte[] decryptedData = encryptionService.decryptAndVerify(encryptedData.getData(), encryptedData.getOrganizationId());
 
 			return objectMapper.readValue(decryptedData, dataType);
 		} catch (IOException e) {

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasFacadeTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasFacadeTest.java
@@ -161,7 +161,7 @@ public class SormasToSormasFacadeTest extends AbstractBeanTest {
 		mockDefaultServerAccess();
 
 		byte[] data = objectMapper.writeValueAsBytes(Collections.singletonList(shareData));
-		byte[] encryptedData = getSormasToSormasEncryptionService().encrypt(data, SECOND_SERVER_ACCESS_CN);
+		byte[] encryptedData = getSormasToSormasEncryptionService().signAndEncrypt(data, SECOND_SERVER_ACCESS_CN);
 
 		mockSecondServerAccess();
 
@@ -171,7 +171,7 @@ public class SormasToSormasFacadeTest extends AbstractBeanTest {
 	protected <T> T[] decryptSharesData(byte[] data, Class<T[]> dataType) throws SormasToSormasException, IOException {
 		mockSecondServerAccess();
 
-		byte[] decryptData = getSormasToSormasEncryptionService().decrypt(data, DEFAULT_SERVER_ACCESS_CN);
+		byte[] decryptData = getSormasToSormasEncryptionService().decryptAndVerify(data, DEFAULT_SERVER_ACCESS_CN);
 		T[] parsedData = objectMapper.readValue(decryptData, dataType);
 
 		mockDefaultServerAccess();


### PR DESCRIPTION
Fixes #5625 
- `encrypt` renamed to `signAndEncrypt`
- `decrypt` renamedt o `decryptAndVerify`
- remove duplicate code from the crypto functions and move it to dedicated functions

No functionality was changed  