### PR TITLE
[#5635] rename SharedDataProcesser to ReceivedDataProcessor

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/AbstractSormasToSormasInterface.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/AbstractSormasToSormasInterface.java
@@ -111,21 +111,21 @@ public abstract class AbstractSormasToSormasInterface<T extends AbstractDomainOb
 
 	@Override
 	public void saveSharedEntities(SormasToSormasEncryptedDataDto encryptedData) throws SormasToSormasException, SormasToSormasValidationException {
-		S[] sharedEntities = sormasToSormasFacadeHelper.decryptSharedData(encryptedData, getShareDataClass());
+		S[] receivedEntities = sormasToSormasFacadeHelper.decryptSharedData(encryptedData, getShareDataClass());
 
 		Map<String, ValidationErrors> validationErrors = new HashMap<>();
-		List<P> dataToSave = new ArrayList<>(sharedEntities.length);
+		List<P> dataToSave = new ArrayList<>(receivedEntities.length);
 
-		for (S data : sharedEntities) {
+		for (S receivedEntity : receivedEntities) {
 			try {
-				U entity = data.getEntity();
+				U entity = receivedEntity.getEntity();
 
 				ValidationErrors caseErrors = validateSharedEntity(entity);
 
 				if (caseErrors.hasError()) {
 					validationErrors.put(buildEntityValidationGroupName(entity), caseErrors);
 				} else {
-					P processedData = getSharedDataProcessor().processSharedData(data, null);
+					P processedData = getReceivedDataProcessor().processReceivedData(receivedEntity, null);
 
 					processedData.getEntity().setSormasToSormasOriginInfo(processedData.getOriginInfo());
 
@@ -174,22 +174,23 @@ public abstract class AbstractSormasToSormasInterface<T extends AbstractDomainOb
 
 	@Override
 	public void saveReturnedEntity(SormasToSormasEncryptedDataDto sharedData) throws SormasToSormasException, SormasToSormasValidationException {
-		S[] sharedEntities = sormasToSormasFacadeHelper.decryptSharedData(sharedData, getShareDataClass());
+		S[] receivedEntities = sormasToSormasFacadeHelper.decryptSharedData(sharedData, getShareDataClass());
 
 		Map<String, ValidationErrors> validationErrors = new HashMap<>();
-		List<P> entitiesToSave = new ArrayList<>(sharedEntities.length);
-		List<U> existingEntities = loadExistingEntities(Arrays.stream(sharedEntities).map(e -> e.getEntity().getUuid()).collect(Collectors.toList()));
+		List<P> entitiesToSave = new ArrayList<>(receivedEntities.length);
+		List<U> existingEntities =
+			loadExistingEntities(Arrays.stream(receivedEntities).map(e -> e.getEntity().getUuid()).collect(Collectors.toList()));
 		Map<String, U> existingEntitiesMap = existingEntities.stream().collect(Collectors.toMap(EntityDto::getUuid, Function.identity()));
 
-		for (S sharedEntity : sharedEntities) {
+		for (S receivedEntity : receivedEntities) {
 			try {
-				U entity = sharedEntity.getEntity();
+				U entity = receivedEntity.getEntity();
 				ValidationErrors entityErrors = validateExistingEntity(entity, existingEntities);
 				if (entityErrors.hasError()) {
 					validationErrors.put(buildEntityValidationGroupName(entity), entityErrors);
 				} else {
-					U exsitingEntity = existingEntitiesMap.get(sharedEntity.getEntity().getUuid());
-					P processedEntity = getSharedDataProcessor().processSharedData(sharedEntity, exsitingEntity);
+					U exsitingEntity = existingEntitiesMap.get(entity.getUuid());
+					P processedEntity = getReceivedDataProcessor().processReceivedData(receivedEntity, exsitingEntity);
 					entitiesToSave.add(processedEntity);
 				}
 			} catch (SormasToSormasValidationException validationException) {
@@ -239,23 +240,24 @@ public abstract class AbstractSormasToSormasInterface<T extends AbstractDomainOb
 
 	@Override
 	public void saveSyncedEntity(SormasToSormasEncryptedDataDto encryptedData) throws SormasToSormasException, SormasToSormasValidationException {
-		S[] sharedEntities = sormasToSormasFacadeHelper.decryptSharedData(encryptedData, getShareDataClass());
+		S[] receivedEntities = sormasToSormasFacadeHelper.decryptSharedData(encryptedData, getShareDataClass());
 
 		Map<String, ValidationErrors> validationErrors = new HashMap<>();
-		List<P> entitiesToSave = new ArrayList<>(sharedEntities.length);
-		List<U> existingEntities = loadExistingEntities(Arrays.stream(sharedEntities).map(e -> e.getEntity().getUuid()).collect(Collectors.toList()));
+		List<P> entitiesToSave = new ArrayList<>(receivedEntities.length);
+		List<U> existingEntities =
+			loadExistingEntities(Arrays.stream(receivedEntities).map(e -> e.getEntity().getUuid()).collect(Collectors.toList()));
 		Map<String, U> existingEntitiesMap = existingEntities.stream().collect(Collectors.toMap(EntityDto::getUuid, Function.identity()));
 
-		for (S sharedEntity : sharedEntities) {
+		for (S receivedEntity : receivedEntities) {
 			try {
-				U entity = sharedEntity.getEntity();
+				U entity = receivedEntity.getEntity();
 
 				ValidationErrors contactErrors = validateExistingEntity(entity, existingEntities);
 				if (contactErrors.hasError()) {
 					validationErrors.put(buildEntityValidationGroupName(entity), contactErrors);
 				} else {
-					U existingEntity = existingEntitiesMap.get(sharedEntity.getEntity().getUuid());
-					P processedContactData = getSharedDataProcessor().processSharedData(sharedEntity, existingEntity);
+					U existingEntity = existingEntitiesMap.get(entity.getUuid());
+					P processedContactData = getReceivedDataProcessor().processReceivedData(receivedEntity, existingEntity);
 					entitiesToSave.add(processedContactData);
 				}
 			} catch (SormasToSormasValidationException validationException) {
@@ -280,7 +282,7 @@ public abstract class AbstractSormasToSormasInterface<T extends AbstractDomainOb
 
 	protected abstract ShareDataBuilder<T, S> getShareDataBuilder();
 
-	protected abstract SharedDataProcessor<U, S, P> getSharedDataProcessor();
+	protected abstract ReceivedDataProcessor<U, S, P> getReceivedDataProcessor();
 
 	protected abstract ProcessedDataPersister<P> getProcessedDataPersister();
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/ReceivedDataProcessor.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/ReceivedDataProcessor.java
@@ -19,7 +19,7 @@ import de.symeda.sormas.api.sormastosormas.SormasToSormasDto;
 import de.symeda.sormas.api.sormastosormas.SormasToSormasValidationException;
 import de.symeda.sormas.api.utils.SormasToSormasEntityDto;
 
-public interface SharedDataProcessor<T extends SormasToSormasEntityDto, U extends SormasToSormasDto<T>, P extends ProcessedData<T>> {
+public interface ReceivedDataProcessor<T extends SormasToSormasEntityDto, U extends SormasToSormasDto<T>, P extends ProcessedData<T>> {
 
-	P processSharedData(U sharedData, T existingData) throws SormasToSormasValidationException;
+	P processReceivedData(U receivedData, T existingData) throws SormasToSormasValidationException;
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/ReceivedDataProcessorHelper.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/ReceivedDataProcessorHelper.java
@@ -72,7 +72,7 @@ import de.symeda.sormas.backend.user.UserService;
 
 @Stateless
 @LocalBean
-public class SharedDataProcessorHelper {
+public class ReceivedDataProcessorHelper {
 
 	@EJB
 	private UserService userService;
@@ -139,7 +139,7 @@ public class SharedDataProcessorHelper {
 
 		return validationErrors;
 	}
-	
+
 	private CountryReferenceDto processCountry(CountryReferenceDto country, String errorCaption, ValidationErrors validationErrors) {
 		CountryReferenceDto localCountry = loadLocalCountry(country);
 		if (country != null && localCountry == null) {
@@ -156,15 +156,26 @@ public class SharedDataProcessorHelper {
 	}
 
 	public DataHelper.Pair<InfrastructureData, List<String>> loadLocalInfrastructure(
-			RegionReferenceDto region,
-			DistrictReferenceDto district,
-			CommunityReferenceDto community,
-			FacilityType facilityType,
-			FacilityReferenceDto facility,
-			String facilityDetails,
-			PointOfEntryReferenceDto pointOfEntry,
-			String pointOfEntryDetails) {
-		return loadLocalInfrastructure(null, null, null, region, district, community, facilityType, facility, facilityDetails, pointOfEntry, pointOfEntryDetails);
+		RegionReferenceDto region,
+		DistrictReferenceDto district,
+		CommunityReferenceDto community,
+		FacilityType facilityType,
+		FacilityReferenceDto facility,
+		String facilityDetails,
+		PointOfEntryReferenceDto pointOfEntry,
+		String pointOfEntryDetails) {
+		return loadLocalInfrastructure(
+			null,
+			null,
+			null,
+			region,
+			district,
+			community,
+			facilityType,
+			facility,
+			facilityDetails,
+			pointOfEntry,
+			pointOfEntryDetails);
 	}
 
 	public DataHelper.Pair<InfrastructureData, List<String>> loadLocalInfrastructure(
@@ -376,7 +387,6 @@ public class SharedDataProcessorHelper {
 		}));
 	}
 
-
 	private ContinentReferenceDto loadLocalContinent(ContinentReferenceDto continent) {
 		if (continent == null) {
 			return null;
@@ -413,9 +423,8 @@ public class SharedDataProcessorHelper {
 		Optional<CountryReferenceDto> localCountry =
 			country.getExternalId() != null ? countryFacade.getByExternalId(country.getExternalId(), false).stream().findFirst() : Optional.empty();
 
-		if(!localCountry.isPresent()) {
-			localCountry = Optional.ofNullable(countryFacade.getByIsoCode(country.getIsoCode(), false))
-					.map(CountryFacadeEjb::toReferenceDto);
+		if (!localCountry.isPresent()) {
+			localCountry = Optional.ofNullable(countryFacade.getByIsoCode(country.getIsoCode(), false)).map(CountryFacadeEjb::toReferenceDto);
 		}
 
 		if (!localCountry.isPresent()) {
@@ -569,7 +578,7 @@ public class SharedDataProcessorHelper {
 		public CountryReferenceDto getCountry() {
 			return country;
 		}
-		
+
 		public RegionReferenceDto getRegion() {
 			return region;
 		}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/caze/ReceivedCaseProcessor.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/caze/ReceivedCaseProcessor.java
@@ -42,29 +42,29 @@ import de.symeda.sormas.api.sormastosormas.ValidationErrors;
 import de.symeda.sormas.api.sormastosormas.caze.SormasToSormasCaseDto;
 import de.symeda.sormas.api.utils.DataHelper;
 import de.symeda.sormas.backend.contact.ContactFacadeEjb.ContactFacadeEjbLocal;
-import de.symeda.sormas.backend.sormastosormas.SharedDataProcessor;
-import de.symeda.sormas.backend.sormastosormas.SharedDataProcessorHelper;
-import de.symeda.sormas.backend.sormastosormas.SharedDataProcessorHelper.InfrastructureData;
+import de.symeda.sormas.backend.sormastosormas.ReceivedDataProcessor;
+import de.symeda.sormas.backend.sormastosormas.ReceivedDataProcessorHelper;
+import de.symeda.sormas.backend.sormastosormas.ReceivedDataProcessorHelper.InfrastructureData;
 
 @Stateless
 @LocalBean
-public class SharedCaseProcessor implements SharedDataProcessor<CaseDataDto, SormasToSormasCaseDto, ProcessedCaseData> {
+public class ReceivedCaseProcessor implements ReceivedDataProcessor<CaseDataDto, SormasToSormasCaseDto, ProcessedCaseData> {
 
 	@EJB
-	private SharedDataProcessorHelper dataProcessorHelper;
+	private ReceivedDataProcessorHelper dataProcessorHelper;
 	@EJB
 	private ContactFacadeEjbLocal contactFacade;
 
 	@Override
-	public ProcessedCaseData processSharedData(SormasToSormasCaseDto sharedCase, CaseDataDto existingCaseData)
+	public ProcessedCaseData processReceivedData(SormasToSormasCaseDto receivedCase, CaseDataDto existingCaseData)
 		throws SormasToSormasValidationException {
 		Map<String, ValidationErrors> validationErrors = new HashMap<>();
 
-		PersonDto person = sharedCase.getPerson();
-		CaseDataDto caze = sharedCase.getEntity();
-		List<SormasToSormasCaseDto.AssociatedContactDto> associatedContacts = sharedCase.getAssociatedContacts();
-		List<SormasToSormasSampleDto> samples = sharedCase.getSamples();
-		SormasToSormasOriginInfoDto originInfo = sharedCase.getOriginInfo();
+		PersonDto person = receivedCase.getPerson();
+		CaseDataDto caze = receivedCase.getEntity();
+		List<SormasToSormasCaseDto.AssociatedContactDto> associatedContacts = receivedCase.getAssociatedContacts();
+		List<SormasToSormasSampleDto> samples = receivedCase.getSamples();
+		SormasToSormasOriginInfoDto originInfo = receivedCase.getOriginInfo();
 
 		ValidationErrors caseValidationErrors = new ValidationErrors();
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/caze/SormasToSormasCaseFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/caze/SormasToSormasCaseFacadeEjb.java
@@ -43,8 +43,8 @@ import de.symeda.sormas.backend.caze.CaseService;
 import de.symeda.sormas.backend.common.BaseAdoService;
 import de.symeda.sormas.backend.sormastosormas.AbstractSormasToSormasInterface;
 import de.symeda.sormas.backend.sormastosormas.ProcessedDataPersister;
+import de.symeda.sormas.backend.sormastosormas.ReceivedDataProcessor;
 import de.symeda.sormas.backend.sormastosormas.ShareDataBuilder;
-import de.symeda.sormas.backend.sormastosormas.SharedDataProcessor;
 import de.symeda.sormas.backend.sormastosormas.SormasToSormasShareInfo;
 import de.symeda.sormas.backend.sormastosormas.SormasToSormasShareInfoService;
 
@@ -60,7 +60,7 @@ public class SormasToSormasCaseFacadeEjb extends AbstractSormasToSormasInterface
 	@EJB
 	private CaseShareDataBuilder caseShareDataBuilder;
 	@EJB
-	private SharedCaseProcessor sharedCaseProcessor;
+	private ReceivedCaseProcessor receivedCaseProcessor;
 	@EJB
 	private ProcessedCaseDataPersister processedCaseDataPersister;
 	@EJB
@@ -82,9 +82,8 @@ public class SormasToSormasCaseFacadeEjb extends AbstractSormasToSormasInterface
 		return caseShareDataBuilder;
 	}
 
-	@Override
-	protected SharedDataProcessor<CaseDataDto, SormasToSormasCaseDto, ProcessedCaseData> getSharedDataProcessor() {
-		return sharedCaseProcessor;
+	protected ReceivedDataProcessor<CaseDataDto, SormasToSormasCaseDto, ProcessedCaseData> getReceivedDataProcessor() {
+		return receivedCaseProcessor;
 	}
 
 	@Override

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/contact/ReceivedContactProcessor.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/contact/ReceivedContactProcessor.java
@@ -33,25 +33,25 @@ import de.symeda.sormas.api.sormastosormas.SormasToSormasSampleDto;
 import de.symeda.sormas.api.sormastosormas.SormasToSormasValidationException;
 import de.symeda.sormas.api.sormastosormas.ValidationErrors;
 import de.symeda.sormas.api.sormastosormas.contact.SormasToSormasContactDto;
-import de.symeda.sormas.backend.sormastosormas.SharedDataProcessor;
-import de.symeda.sormas.backend.sormastosormas.SharedDataProcessorHelper;
+import de.symeda.sormas.backend.sormastosormas.ReceivedDataProcessor;
+import de.symeda.sormas.backend.sormastosormas.ReceivedDataProcessorHelper;
 
 @Stateless
 @LocalBean
-public class SharedContactProcessor implements SharedDataProcessor<ContactDto, SormasToSormasContactDto, ProcessedContactData> {
+public class ReceivedContactProcessor implements ReceivedDataProcessor<ContactDto, SormasToSormasContactDto, ProcessedContactData> {
 
 	@EJB
-	private SharedDataProcessorHelper dataProcessorHelper;
+	private ReceivedDataProcessorHelper dataProcessorHelper;
 
 	@Override
-	public ProcessedContactData processSharedData(SormasToSormasContactDto sharedContact, ContactDto existingContact)
+	public ProcessedContactData processReceivedData(SormasToSormasContactDto receivedContact, ContactDto existingContact)
 		throws SormasToSormasValidationException {
 		Map<String, ValidationErrors> validationErrors = new HashMap<>();
 
-		PersonDto person = sharedContact.getPerson();
-		ContactDto contact = sharedContact.getEntity();
-		List<SormasToSormasSampleDto> samples = sharedContact.getSamples();
-		SormasToSormasOriginInfoDto originInfo = sharedContact.getOriginInfo();
+		PersonDto person = receivedContact.getPerson();
+		ContactDto contact = receivedContact.getEntity();
+		List<SormasToSormasSampleDto> samples = receivedContact.getSamples();
+		SormasToSormasOriginInfoDto originInfo = receivedContact.getOriginInfo();
 
 		ValidationErrors contactValidationErrors = new ValidationErrors();
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/contact/SormasToSormasContactFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/contact/SormasToSormasContactFacadeEjb.java
@@ -45,8 +45,8 @@ import de.symeda.sormas.backend.contact.ContactFacadeEjb.ContactFacadeEjbLocal;
 import de.symeda.sormas.backend.contact.ContactService;
 import de.symeda.sormas.backend.sormastosormas.AbstractSormasToSormasInterface;
 import de.symeda.sormas.backend.sormastosormas.ProcessedDataPersister;
+import de.symeda.sormas.backend.sormastosormas.ReceivedDataProcessor;
 import de.symeda.sormas.backend.sormastosormas.ShareDataBuilder;
-import de.symeda.sormas.backend.sormastosormas.SharedDataProcessor;
 import de.symeda.sormas.backend.sormastosormas.SormasToSormasShareInfo;
 import de.symeda.sormas.backend.sormastosormas.SormasToSormasShareInfoService;
 
@@ -63,7 +63,7 @@ public class SormasToSormasContactFacadeEjb
 	@EJB
 	private ContactShareDataBuilder contactShareDataBuilder;
 	@EJB
-	private SharedContactProcessor sharedContactProcessor;
+	private ReceivedContactProcessor receivedContactProcessor;
 	@EJB
 	private ProcessedContactDataPersister processedContactDataPersister;
 	@EJB
@@ -88,8 +88,8 @@ public class SormasToSormasContactFacadeEjb
 	}
 
 	@Override
-	protected SharedDataProcessor<ContactDto, SormasToSormasContactDto, ProcessedContactData> getSharedDataProcessor() {
-		return sharedContactProcessor;
+	protected ReceivedDataProcessor<ContactDto, SormasToSormasContactDto, ProcessedContactData> getReceivedDataProcessor() {
+		return receivedContactProcessor;
 	}
 
 	@Override

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/event/SormasToSormasEventFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/event/SormasToSormasEventFacadeEjb.java
@@ -59,7 +59,7 @@ public class SormasToSormasEventFacadeEjb extends AbstractSormasToSormasInterfac
 	@EJB
 	private EventShareDataBuilder shareDataBuilder;
 	@EJB
-	private SharedEventProcessor sharedEventProcessor;
+	private ReceivedEventProcessor receivedEventProcessor;
 	@EJB
 	private ProcessedEventDataPersister processedEventDataPersister;
 	@EJB
@@ -125,8 +125,8 @@ public class SormasToSormasEventFacadeEjb extends AbstractSormasToSormasInterfac
 	}
 
 	@Override
-	protected SharedEventProcessor getSharedDataProcessor() {
-		return sharedEventProcessor;
+	protected ReceivedEventProcessor getReceivedDataProcessor() {
+		return receivedEventProcessor;
 	}
 
 	@Override


### PR DESCRIPTION
Fixes #5635 

### Problem Description

This is a spin off from #5599, I want to keep the PRs small and easy to review.

While working on #5597, I noticed a lot of potential for code cleanup and deduplication which once resolved would make my life easier.

### Proposed Change

`SharedDataProcessor` is a little bit of a misnomer. Sharing in S2S means the operation of passing an entity to another instance (opposed to sync and return). However, `SharedDataProcessor` is always invoked on any _received_ data during the save phase of share, sync, and return operations. Therefore I suppose to rename it to `ReceivedDataProcessor`. This change nicely aligns with other changes I have planned for `AbstractSormasToSormasInterface` making the resulting code easier to understand.

Also this PR unifies some variable naming which will make the diff for my planned code deduplication PR easier to review.