### PR TITLE
[#5679] move athentication flow to REST client

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/AbstractSormasToSormasInterface.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/AbstractSormasToSormasInterface.java
@@ -96,10 +96,8 @@ public abstract class AbstractSormasToSormasInterface<T extends AbstractDomainOb
 			associatedEntities.addAll(shareData.getAssociatedEntities());
 		}
 
-		sormasToSormasFacadeHelper.sendEntitiesToSormas(
-			entitiesToSend,
-			options,
-			(host, authToken, encryptedData) -> sormasToSormasRestClient.post(host, saveEndpoint, authToken, encryptedData));
+		sormasToSormasFacadeHelper
+			.sendEntitiesToSormas(entitiesToSend, options, (id, encryptedData) -> sormasToSormasRestClient.post(id, saveEndpoint, encryptedData));
 
 		entities.forEach(entity -> saveNewShareInfo(currentUser.toReference(), options, entity, this::setEntityShareInfoAssociatedObject));
 		associatedEntities.forEach(wrapper -> {
@@ -158,7 +156,7 @@ public abstract class AbstractSormasToSormasInterface<T extends AbstractDomainOb
 		sormasToSormasFacadeHelper.sendEntitiesToSormas(
 			Collections.singletonList(shareData.getDto()),
 			options,
-			(host, authToken, encryptedData) -> sormasToSormasRestClient.put(host, saveEndpoint, authToken, encryptedData));
+			(id, encryptedData) -> sormasToSormasRestClient.put(id, saveEndpoint, encryptedData));
 
 		entity.getSormasToSormasOriginInfo().setOwnershipHandedOver(false);
 		originInfoService.persist(entity.getSormasToSormasOriginInfo());
@@ -219,7 +217,7 @@ public abstract class AbstractSormasToSormasInterface<T extends AbstractDomainOb
 		sormasToSormasFacadeHelper.sendEntitiesToSormas(
 			Collections.singletonList(shareData.getDto()),
 			options,
-			(host, authToken, encryptedData) -> sormasToSormasRestClient.post(host, syncEndpoint, authToken, encryptedData));
+			(id, encryptedData) -> sormasToSormasRestClient.post(id, syncEndpoint, encryptedData));
 
 		SormasToSormasShareInfo shareInfo = getShareInfoByEntityAndOrganization(entity.getUuid(), options.getOrganization().getUuid());
 		updateShareInfoOptions(shareInfo, options);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasRestClient.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasRestClient.java
@@ -17,6 +17,10 @@ package de.symeda.sormas.backend.sormastosormas;
 
 import static de.symeda.sormas.api.sormastosormas.SormasToSormasApiConstants.SORMAS_REST_PATH;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import javax.ejb.EJB;
 import javax.enterprise.inject.Alternative;
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.client.Entity;
@@ -29,12 +33,19 @@ import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import de.symeda.sormas.api.i18n.I18nProperties;
+import de.symeda.sormas.api.i18n.Strings;
+import de.symeda.sormas.api.sormastosormas.SormasToSormasException;
+import de.symeda.sormas.backend.common.StartupShutdownService;
 import de.symeda.sormas.backend.util.ClientHelper;
 
 @Alternative
 public class SormasToSormasRestClient {
 
 	public static final String SORMAS_REST_URL_TEMPLATE = "https://%s" + SORMAS_REST_PATH + "%s";
+
+	@EJB
+	private ServerAccessDataService serverAccessDataService;
 
 	private final ObjectMapper mapper;
 
@@ -44,17 +55,29 @@ public class SormasToSormasRestClient {
 		mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
 	}
 
-	public Response post(String host, String endpoint, String authToken, Object entity) throws JsonProcessingException, ProcessingException {
+	public Response post(String id, String endpoint, Object entity) throws JsonProcessingException, ProcessingException, SormasToSormasException {
 
-		return buildRestClient(host, endpoint, authToken).post(Entity.entity(mapper.writeValueAsString(entity), MediaType.APPLICATION_JSON_TYPE));
+		return buildRestClient(id, endpoint).post(Entity.entity(mapper.writeValueAsString(entity), MediaType.APPLICATION_JSON_TYPE));
 	}
 
-	public Response put(String host, String endpoint, String authToken, Object entity) throws JsonProcessingException, ProcessingException {
+	public Response put(String id, String endpoint, Object entity) throws JsonProcessingException, ProcessingException, SormasToSormasException {
 
-		return buildRestClient(host, endpoint, authToken).put(Entity.entity(mapper.writeValueAsString(entity), MediaType.APPLICATION_JSON_TYPE));
+		return buildRestClient(id, endpoint).put(Entity.entity(mapper.writeValueAsString(entity), MediaType.APPLICATION_JSON_TYPE));
 	}
 
-	private Invocation.Builder buildRestClient(String host, String endpoint, String authToken) {
+	private String buildAuthToken(OrganizationServerAccessData targetServerAccessData) {
+		String userCredentials = StartupShutdownService.SORMAS_TO_SORMAS_USER_NAME + ":" + targetServerAccessData.getRestUserPassword();
+		return "Basic " + new String(Base64.getEncoder().encode(userCredentials.getBytes(StandardCharsets.UTF_8)));
+	}
+
+	private Invocation.Builder buildRestClient(String id, String endpoint) throws SormasToSormasException {
+
+		OrganizationServerAccessData targetServerAccessData = serverAccessDataService.getServerListItemById(id)
+			.orElseThrow(() -> new SormasToSormasException(I18nProperties.getString(Strings.errorSormasToSormasServerAccess)));
+
+		String host = targetServerAccessData.getHostName();
+		String authToken = buildAuthToken(targetServerAccessData);
+
 		return ClientHelper.newBuilderWithProxy()
 			.build()
 			.target(String.format(SORMAS_REST_URL_TEMPLATE, host, endpoint))

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/labmessage/SormasToSormasLabMessageFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/labmessage/SormasToSormasLabMessageFacadeEjb.java
@@ -72,7 +72,7 @@ public class SormasToSormasLabMessageFacadeEjb implements SormasToSormasLabMessa
 		sormasToSormasFacadeHelper.sendEntitiesToSormas(
 			dtos,
 			options,
-			(host, authToken, encryptedData) -> sormasToSormasRestClient.post(host, SAVE_SHARED_LAB_MESSAGE_ENDPOINT, authToken, encryptedData));
+			(id, encryptedData) -> sormasToSormasRestClient.post(id, SAVE_SHARED_LAB_MESSAGE_ENDPOINT, encryptedData));
 
 		labMessages.forEach(labMessage -> {
 			labMessage.setStatus(LabMessageStatus.FORWARDED);

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/MockProducer.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/MockProducer.java
@@ -149,7 +149,7 @@ public class MockProducer {
 		return principal;
 	}
 
-	public static SormasToSormasRestClient getSormasToSormasClient() {
+	public static SormasToSormasRestClient getSormasToSormasRestClient() {
 		return SORMAS_TO_SORMAS_REST_CLIENT;
 	}
 

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasCaseFacadeEjbTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasCaseFacadeEjbTest.java
@@ -21,13 +21,10 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.Matchers.startsWith;
 
-import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
@@ -78,7 +75,6 @@ import de.symeda.sormas.api.utils.DataHelper;
 import de.symeda.sormas.api.utils.YesNoUnknown;
 import de.symeda.sormas.backend.MockProducer;
 import de.symeda.sormas.backend.TestDataCreator;
-import de.symeda.sormas.backend.common.StartupShutdownService;
 import de.symeda.sormas.backend.user.User;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -110,18 +106,12 @@ public class SormasToSormasCaseFacadeEjbTest extends SormasToSormasFacadeTest {
 		options.setOrganization(new ServerAccessDataReferenceDto(SECOND_SERVER_ACCESS_CN));
 		options.setComment("Test comment");
 
-		Mockito.when(MockProducer.getSormasToSormasClient().post(Matchers.anyString(), Matchers.anyString(), Matchers.anyString(), Matchers.any()))
+		Mockito.when(MockProducer.getSormasToSormasRestClient().post(Matchers.anyString(), Matchers.anyString(), Matchers.any()))
 			.thenAnswer(invocation -> {
-				assertThat(invocation.getArgument(0, String.class), is(SECOND_SERVER_REST_URL));
+				assertThat(invocation.getArgument(0, String.class), is(SECOND_SERVER_ACCESS_CN));
 				assertThat(invocation.getArgument(1, String.class), is("/sormasToSormas/cases"));
 
-				String authToken = invocation.getArgument(2, String.class);
-				assertThat(authToken, startsWith("Basic "));
-				String credentials = new String(Base64.getDecoder().decode(authToken.replace("Basic ", "")), StandardCharsets.UTF_8);
-				// uses password from server-list.csv from `serveraccessdefault` package
-				assertThat(credentials, is(StartupShutdownService.SORMAS_TO_SORMAS_USER_NAME + ":" + SECOND_SERVER_REST_PASSWORD));
-
-				SormasToSormasEncryptedDataDto encryptedData = invocation.getArgument(3, SormasToSormasEncryptedDataDto.class);
+				SormasToSormasEncryptedDataDto encryptedData = invocation.getArgument(2, SormasToSormasEncryptedDataDto.class);
 				assertThat(encryptedData.getOrganizationId(), is(DEFAULT_SERVER_ACCESS_CN));
 
 				SormasToSormasCaseDto[] sharedCases = decryptSharesData(encryptedData.getData(), SormasToSormasCaseDto[].class);
@@ -177,9 +167,9 @@ public class SormasToSormasCaseFacadeEjbTest extends SormasToSormasFacadeTest {
 		options.setComment("Test comment");
 		options.setWithAssociatedContacts(true);
 
-		Mockito.when(MockProducer.getSormasToSormasClient().post(Matchers.anyString(), Matchers.anyString(), Matchers.anyString(), Matchers.any()))
+		Mockito.when(MockProducer.getSormasToSormasRestClient().post(Matchers.anyString(), Matchers.anyString(), Matchers.any()))
 			.thenAnswer(invocation -> {
-				SormasToSormasEncryptedDataDto encryptedData = invocation.getArgument(3, SormasToSormasEncryptedDataDto.class);
+				SormasToSormasEncryptedDataDto encryptedData = invocation.getArgument(2, SormasToSormasEncryptedDataDto.class);
 				SormasToSormasCaseDto[] sharedCases = decryptSharesData(encryptedData.getData(), SormasToSormasCaseDto[].class);
 
 				assertThat(sharedCases[0].getAssociatedContacts().size(), is(1));
@@ -237,9 +227,9 @@ public class SormasToSormasCaseFacadeEjbTest extends SormasToSormasFacadeTest {
 		options.setWithSamples(true);
 		options.setWithAssociatedContacts(true);
 
-		Mockito.when(MockProducer.getSormasToSormasClient().post(Matchers.anyString(), Matchers.anyString(), Matchers.anyString(), Matchers.any()))
+		Mockito.when(MockProducer.getSormasToSormasRestClient().post(Matchers.anyString(), Matchers.anyString(), Matchers.any()))
 			.thenAnswer(invocation -> {
-				SormasToSormasEncryptedDataDto encryptedData = invocation.getArgument(3, SormasToSormasEncryptedDataDto.class);
+				SormasToSormasEncryptedDataDto encryptedData = invocation.getArgument(2, SormasToSormasEncryptedDataDto.class);
 				SormasToSormasCaseDto[] sharedCases = decryptSharesData(encryptedData.getData(), SormasToSormasCaseDto[].class);
 
 				assertThat(sharedCases[0].getSamples().size(), is(2));
@@ -502,9 +492,9 @@ public class SormasToSormasCaseFacadeEjbTest extends SormasToSormasFacadeTest {
 		options.setOrganization(new ServerAccessDataReferenceDto(SECOND_SERVER_ACCESS_CN));
 		options.setPseudonymizePersonalData(true);
 
-		Mockito.when(MockProducer.getSormasToSormasClient().post(Matchers.anyString(), Matchers.anyString(), Matchers.anyString(), Matchers.any()))
+		Mockito.when(MockProducer.getSormasToSormasRestClient().post(Matchers.anyString(), Matchers.anyString(), Matchers.any()))
 			.thenAnswer(invocation -> {
-				SormasToSormasEncryptedDataDto encryptedData = invocation.getArgument(3, SormasToSormasEncryptedDataDto.class);
+				SormasToSormasEncryptedDataDto encryptedData = invocation.getArgument(2, SormasToSormasEncryptedDataDto.class);
 				SormasToSormasCaseDto[] sharedCases = decryptSharesData(encryptedData.getData(), SormasToSormasCaseDto[].class);
 				SormasToSormasCaseDto sharedCase = sharedCases[0];
 
@@ -539,9 +529,9 @@ public class SormasToSormasCaseFacadeEjbTest extends SormasToSormasFacadeTest {
 		options.setOrganization(new ServerAccessDataReferenceDto(SECOND_SERVER_ACCESS_CN));
 		options.setPseudonymizeSensitiveData(true);
 
-		Mockito.when(MockProducer.getSormasToSormasClient().post(Matchers.anyString(), Matchers.anyString(), Matchers.anyString(), Matchers.any()))
+		Mockito.when(MockProducer.getSormasToSormasRestClient().post(Matchers.anyString(), Matchers.anyString(), Matchers.any()))
 			.thenAnswer(invocation -> {
-				SormasToSormasEncryptedDataDto encryptedData = invocation.getArgument(3, SormasToSormasEncryptedDataDto.class);
+				SormasToSormasEncryptedDataDto encryptedData = invocation.getArgument(2, SormasToSormasEncryptedDataDto.class);
 				SormasToSormasCaseDto[] sharedCases = decryptSharesData(encryptedData.getData(), SormasToSormasCaseDto[].class);
 				SormasToSormasCaseDto sharedCase = sharedCases[0];
 
@@ -594,7 +584,7 @@ public class SormasToSormasCaseFacadeEjbTest extends SormasToSormasFacadeTest {
 		options.setWithSamples(true);
 		options.setComment("Test comment");
 
-		Mockito.when(MockProducer.getSormasToSormasClient().put(Matchers.anyString(), Matchers.anyString(), Matchers.anyString(), Matchers.any()))
+		Mockito.when(MockProducer.getSormasToSormasRestClient().put(Matchers.anyString(), Matchers.anyString(), Matchers.any()))
 			.thenAnswer(invocation -> Response.noContent().build());
 
 		getSormasToSormasCaseFacade().returnEntity(caze.getUuid(), options);

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasEventFacadeEjbTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasEventFacadeEjbTest.java
@@ -19,13 +19,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.startsWith;
 
-import java.nio.charset.StandardCharsets;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
@@ -77,14 +72,13 @@ import de.symeda.sormas.api.user.UserReferenceDto;
 import de.symeda.sormas.api.user.UserRole;
 import de.symeda.sormas.backend.MockProducer;
 import de.symeda.sormas.backend.TestDataCreator;
-import de.symeda.sormas.backend.common.StartupShutdownService;
 import de.symeda.sormas.backend.user.User;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SormasToSormasEventFacadeEjbTest extends SormasToSormasFacadeTest {
 
 	@Test
-	public void testShareEvent() throws SormasToSormasException, JsonProcessingException, NoSuchAlgorithmException, KeyManagementException {
+	public void testShareEvent() throws SormasToSormasException, JsonProcessingException {
 		TestDataCreator.RDCF rdcf = creator.createRDCF();
 		UserDto user = creator.createUser(rdcf, UserRole.NATIONAL_USER);
 
@@ -111,18 +105,12 @@ public class SormasToSormasEventFacadeEjbTest extends SormasToSormasFacadeTest {
 		options.setOrganization(new ServerAccessDataReferenceDto(SECOND_SERVER_ACCESS_CN));
 		options.setComment("Test comment");
 
-		Mockito.when(MockProducer.getSormasToSormasClient().post(Matchers.anyString(), Matchers.anyString(), Matchers.anyString(), Matchers.any()))
+		Mockito.when(MockProducer.getSormasToSormasRestClient().post(Matchers.anyString(), Matchers.anyString(), Matchers.any()))
 			.thenAnswer(invocation -> {
-				assertThat(invocation.getArgument(0, String.class), is(SECOND_SERVER_REST_URL));
+				assertThat(invocation.getArgument(0, String.class), is(SECOND_SERVER_ACCESS_CN));
 				assertThat(invocation.getArgument(1, String.class), is("/sormasToSormas/events"));
 
-				String authToken = invocation.getArgument(2, String.class);
-				assertThat(authToken, startsWith("Basic "));
-				String credentials = new String(Base64.getDecoder().decode(authToken.replace("Basic ", "")), StandardCharsets.UTF_8);
-				// uses password from server-list.csv from `serveraccessdefault` package
-				assertThat(credentials, is(StartupShutdownService.SORMAS_TO_SORMAS_USER_NAME + ":" + SECOND_SERVER_REST_PASSWORD));
-
-				SormasToSormasEncryptedDataDto encryptedData = invocation.getArgument(3, SormasToSormasEncryptedDataDto.class);
+				SormasToSormasEncryptedDataDto encryptedData = invocation.getArgument(2, SormasToSormasEncryptedDataDto.class);
 				SormasToSormasEventDto[] sharedEvents = decryptSharesData(encryptedData.getData(), SormasToSormasEventDto[].class);
 				SormasToSormasEventDto sharedEventData = sharedEvents[0];
 
@@ -159,8 +147,7 @@ public class SormasToSormasEventFacadeEjbTest extends SormasToSormasFacadeTest {
 	}
 
 	@Test
-	public void testShareEventWithSamples()
-		throws SormasToSormasException, JsonProcessingException, NoSuchAlgorithmException, KeyManagementException {
+	public void testShareEventWithSamples() throws SormasToSormasException, JsonProcessingException {
 		TestDataCreator.RDCF rdcf = creator.createRDCF();
 		UserDto user = creator.createUser(rdcf, UserRole.NATIONAL_USER);
 
@@ -203,12 +190,12 @@ public class SormasToSormasEventFacadeEjbTest extends SormasToSormasFacadeTest {
 		options.setWithSamples(true);
 		options.setComment("Test comment");
 
-		Mockito.when(MockProducer.getSormasToSormasClient().post(Matchers.anyString(), Matchers.anyString(), Matchers.anyString(), Matchers.any()))
+		Mockito.when(MockProducer.getSormasToSormasRestClient().post(Matchers.anyString(), Matchers.anyString(), Matchers.any()))
 			.thenAnswer(invocation -> {
-				assertThat(invocation.getArgument(0, String.class), is(SECOND_SERVER_REST_URL));
+				assertThat(invocation.getArgument(0, String.class), is(SECOND_SERVER_ACCESS_CN));
 				assertThat(invocation.getArgument(1, String.class), is("/sormasToSormas/events"));
 
-				SormasToSormasEncryptedDataDto encryptedData = invocation.getArgument(3, SormasToSormasEncryptedDataDto.class);
+				SormasToSormasEncryptedDataDto encryptedData = invocation.getArgument(2, SormasToSormasEncryptedDataDto.class);
 				SormasToSormasEventDto[] sharedEvents = decryptSharesData(encryptedData.getData(), SormasToSormasEventDto[].class);
 				SormasToSormasEventDto sharedEventData = sharedEvents[0];
 
@@ -396,7 +383,7 @@ public class SormasToSormasEventFacadeEjbTest extends SormasToSormasFacadeTest {
 		options.setWithEventParticipants(true);
 		options.setComment("Test comment");
 
-		Mockito.when(MockProducer.getSormasToSormasClient().put(Matchers.anyString(), Matchers.anyString(), Matchers.anyString(), Matchers.any()))
+		Mockito.when(MockProducer.getSormasToSormasRestClient().put(Matchers.anyString(), Matchers.anyString(), Matchers.any()))
 			.thenAnswer(invocation -> Response.noContent().build());
 
 		getSormasToSormasEventFacade().returnEntity(event.getUuid(), options);
@@ -514,7 +501,7 @@ public class SormasToSormasEventFacadeEjbTest extends SormasToSormasFacadeTest {
 		options.setWithEventParticipants(true);
 		options.setComment("Test comment");
 
-		Mockito.when(MockProducer.getSormasToSormasClient().post(Matchers.anyString(), Matchers.anyString(), Matchers.anyString(), Matchers.any()))
+		Mockito.when(MockProducer.getSormasToSormasRestClient().post(Matchers.anyString(), Matchers.anyString(), Matchers.any()))
 			.thenAnswer(invocation -> Response.noContent().build());
 
 		getSormasToSormasEventFacade().syncEntity(event.getUuid(), options);

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasRestClientTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasRestClientTest.java
@@ -1,0 +1,16 @@
+package de.symeda.sormas.backend.sormastosormas;
+
+import static de.symeda.sormas.backend.sormastosormas.SormasToSormasRestClient.SORMAS_REST_URL_TEMPLATE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.StringStartsWith.startsWith;
+
+import org.junit.Test;
+
+public class SormasToSormasRestClientTest {
+
+	@Test
+	public void testHttpsRestUrl() {
+		assertThat(SORMAS_REST_URL_TEMPLATE, startsWith("https://"));
+	}
+
+}


### PR DESCRIPTION
Fixes #5679 

### Info

This is a spin off from #5599, I want to keep the PRs small and easy to review.

While working on #5597, I noticed a lot of potential for code cleanup and deduplication which once resolved would make my life easier.

### Problem Description

`SormasToSormasRestClient` puts the burden of providing the correct authorization header for the S2S request on the developer at the call site. With the token based approach around the corner, we just want to call the REST API without worrying about the underlying details. Further, the certificate based S2S approach will also talk to an endpoint of S2S, which is yet another call side that has to take care of running authentication correctly.  This introduces code duplication around a security critical feature which we should avoid.

### Proposed change

Remove the auth token generation from the call side and move it into the `SormasToSormasRestClient` class. Further, the target of a S2S REST request is only determined by the receiving server's ID. All necessary information (e.g., host name) is derived from the ID.