### PR TITLE
[#5693] avoid leaky abstraction in SormasToSormasEncryptionService

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/sormastosormas/SormasToSormasEntityInterface.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/sormastosormas/SormasToSormasEntityInterface.java
@@ -34,7 +34,7 @@ public interface SormasToSormasEntityInterface {
 
 	void acceptShareRequest(String uuid) throws SormasToSormasException, SormasToSormasValidationException;
 
-	byte[] getDataForShareRequest(String uuid) throws SormasToSormasException;
+	SormasToSormasEncryptedDataDto getDataForShareRequest(String uuid) throws SormasToSormasException;
 
 	void shareEntities(List<String> entityUuids, SormasToSormasOptionsDto options) throws SormasToSormasException;
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasEncryptionService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasEncryptionService.java
@@ -36,11 +36,15 @@ import org.bouncycastle.cms.CMSException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 
 import de.symeda.sormas.api.SormasToSormasConfig;
 import de.symeda.sormas.api.i18n.I18nProperties;
 import de.symeda.sormas.api.i18n.Strings;
+import de.symeda.sormas.api.sormastosormas.SormasToSormasEncryptedDataDto;
 import de.symeda.sormas.api.sormastosormas.SormasToSormasException;
 import de.symeda.sormas.backend.crypt.CmsCreator;
 import de.symeda.sormas.backend.crypt.CmsReader;
@@ -55,6 +59,14 @@ public class SormasToSormasEncryptionService {
 	protected SormasToSormasConfig sormasToSormasConfig;
 	@EJB
 	protected ServerAccessDataService serverAccessDataService;
+
+	private final ObjectMapper objectMapper;
+
+	public SormasToSormasEncryptionService() {
+		objectMapper = new ObjectMapper();
+		objectMapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE);
+		objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+	}
 
 	private KeyStore getKeystore() throws CertificateException, KeyStoreException, IOException, NoSuchAlgorithmException {
 		return loadStore(sormasToSormasConfig.getKeystoreName(), sormasToSormasConfig.getKeystorePass());
@@ -91,6 +103,10 @@ public class SormasToSormasEncryptionService {
 		PrivateKey ownKey = (PrivateKey) keystore.getKey(ownId, sormasToSormasConfig.getKeystorePass().toCharArray());
 		X509Certificate otherCert = (X509Certificate) truststore.getCertificate(otherId);
 
+		if (otherCert == null) {
+			throw new SormasToSormasException(String.format("No certificate for id %s could be found", otherId));
+		}
+
 		switch (mode) {
 		case ENCRYPTION:
 			return CmsCreator.signAndEncrypt(data, ownCert, ownKey, otherCert, true);
@@ -101,18 +117,23 @@ public class SormasToSormasEncryptionService {
 		}
 	}
 
-	public byte[] signAndEncrypt(byte[] data, String recipientId) throws SormasToSormasException {
+	public SormasToSormasEncryptedDataDto signAndEncrypt(Object entities, String recipientId) throws SormasToSormasException {
 		try {
-			return cipher(Mode.ENCRYPTION, data, recipientId);
+			OrganizationServerAccessData serverAccessData = serverAccessDataService.getServerAccessData()
+				.orElseThrow(() -> new SormasToSormasException(I18nProperties.getString(Strings.errorSormasToSormasServerAccess)));
+
+			byte[] encryptedData = cipher(Mode.ENCRYPTION, objectMapper.writeValueAsBytes(entities), recipientId);
+			return new SormasToSormasEncryptedDataDto(serverAccessData.getId(), encryptedData);
 		} catch (Exception e) {
 			LOGGER.error("Could not sign and encrypt data", e);
 			throw new SormasToSormasException(I18nProperties.getString(Strings.errorSormasToSormasEncrypt));
 		}
 	}
 
-	public byte[] decryptAndVerify(byte[] data, String senderId) throws SormasToSormasException {
+	public <T> T decryptAndVerify(SormasToSormasEncryptedDataDto encryptedData, Class<T> dataType) throws SormasToSormasException {
 		try {
-			return cipher(Mode.DECRYPTION, data, senderId);
+			byte[] decryptedData = cipher(Mode.DECRYPTION, encryptedData.getData(), encryptedData.getOrganizationId());
+			return objectMapper.readValue(decryptedData, dataType);
 		} catch (Exception e) {
 			LOGGER.error("Could not decrypt and verify data", e);
 			throw new SormasToSormasException(I18nProperties.getString(Strings.errorSormasToSormasDecrypt));

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasFacadeEjb.java
@@ -36,6 +36,7 @@ import javax.persistence.criteria.Root;
 
 import de.symeda.sormas.api.sormastosormas.ServerAccessDataReferenceDto;
 import de.symeda.sormas.api.sormastosormas.SormasToSormasApiConstants;
+import de.symeda.sormas.api.sormastosormas.SormasToSormasEncryptedDataDto;
 import de.symeda.sormas.api.sormastosormas.SormasToSormasEntityInterface;
 import de.symeda.sormas.api.sormastosormas.SormasToSormasException;
 import de.symeda.sormas.api.sormastosormas.SormasToSormasFacade;
@@ -132,7 +133,7 @@ public class SormasToSormasFacadeEjb implements SormasToSormasFacade {
 			shareInfo.getOrganizationId(),
 			(host, authToken) -> sormasToSormasRestClient
 				.post(host, REVOKE_REQUEST_ENDPOINT, authToken, Collections.singletonList(shareInfo.getRequestUuid())),
-			byte[].class);
+			SormasToSormasEncryptedDataDto.class);
 
 		shareInfo.setRequestStatus(ShareRequestStatus.REVOKED);
 		shareInfoService.ensurePersisted(shareInfo);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/labmessage/SormasToSormasLabMessageFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/labmessage/SormasToSormasLabMessageFacadeEjb.java
@@ -46,6 +46,7 @@ import de.symeda.sormas.api.utils.ValidationRuntimeException;
 import de.symeda.sormas.backend.labmessage.LabMessage;
 import de.symeda.sormas.backend.labmessage.LabMessageFacadeEjb.LabMessageFacadeEjbLocal;
 import de.symeda.sormas.backend.labmessage.LabMessageService;
+import de.symeda.sormas.backend.sormastosormas.SormasToSormasEncryptionService;
 import de.symeda.sormas.backend.sormastosormas.SormasToSormasFacadeHelper;
 import de.symeda.sormas.backend.sormastosormas.SormasToSormasRestClient;
 
@@ -62,6 +63,9 @@ public class SormasToSormasLabMessageFacadeEjb implements SormasToSormasLabMessa
 	private LabMessageFacadeEjbLocal labMessageFacade;
 	@Inject
 	private SormasToSormasRestClient sormasToSormasRestClient;
+
+	@EJB
+	private SormasToSormasEncryptionService encryptionService;
 
 	@Override
 	public void sendLabMessages(List<String> uuids, SormasToSormasOptionsDto options) throws SormasToSormasException {
@@ -82,7 +86,7 @@ public class SormasToSormasLabMessageFacadeEjb implements SormasToSormasLabMessa
 
 	@Override
 	public void saveLabMessages(SormasToSormasEncryptedDataDto encryptedData) throws SormasToSormasException, SormasToSormasValidationException {
-		LabMessageDto[] sharedLabMessages = sormasToSormasFacadeHelper.decryptSharedData(encryptedData, LabMessageDto[].class);
+		LabMessageDto[] sharedLabMessages = encryptionService.decryptAndVerify(encryptedData, LabMessageDto[].class);
 
 		Map<String, ValidationErrors> validationErrors = new HashMap<>();
 		List<LabMessageDto> labMessagesToSave = new ArrayList<>(sharedLabMessages.length);

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasCaseFacadeEjbTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasCaseFacadeEjbTest.java
@@ -297,10 +297,10 @@ public class SormasToSormasCaseFacadeEjbTest extends SormasToSormasFacadeTest {
 		caze.getClinicalCourse().getHealthConditions().setAsplenia(YesNoUnknown.YES);
 		caze.getMaternalHistory().setChildrenNumber(2);
 
-		byte[] encryptedData =
+		SormasToSormasEncryptedDataDto encryptedData =
 			encryptShareDataAsArray(new SormasToSormasCaseDto(person, caze, createSormasToSormasOriginInfo(DEFAULT_SERVER_ACCESS_CN, false)));
 
-		getSormasToSormasCaseFacade().saveSharedEntities(new SormasToSormasEncryptedDataDto(DEFAULT_SERVER_ACCESS_CN, encryptedData), null);
+		getSormasToSormasCaseFacade().saveSharedEntities(encryptedData, null);
 
 		CaseDataDto savedCase = getCaseFacade().getCaseDataByUuid(caze.getUuid());
 
@@ -345,10 +345,10 @@ public class SormasToSormasCaseFacadeEjbTest extends SormasToSormasFacadeTest {
 		caze.getClinicalCourse().getHealthConditions().setAsplenia(YesNoUnknown.YES);
 		caze.getMaternalHistory().setChildrenNumber(2);
 
-		byte[] encryptedData =
+		SormasToSormasEncryptedDataDto encryptedData =
 			encryptShareDataAsArray(new SormasToSormasCaseDto(person, caze, createSormasToSormasOriginInfo(DEFAULT_SERVER_ACCESS_CN, false)));
 
-		getSormasToSormasCaseFacade().saveSharedEntities(new SormasToSormasEncryptedDataDto(DEFAULT_SERVER_ACCESS_CN, encryptedData), null);
+		getSormasToSormasCaseFacade().saveSharedEntities(encryptedData, null);
 
 		CaseDataDto savedCase = getCaseFacade().getCaseDataByUuid(caze.getUuid());
 
@@ -392,9 +392,9 @@ public class SormasToSormasCaseFacadeEjbTest extends SormasToSormasFacadeTest {
 		portHealthInfo.setAirlineName("Test Airline");
 		caze.setPortHealthInfo(portHealthInfo);
 
-		byte[] encryptedData =
+		SormasToSormasEncryptedDataDto encryptedData =
 			encryptShareDataAsArray(new SormasToSormasCaseDto(person, caze, createSormasToSormasOriginInfo(DEFAULT_SERVER_ACCESS_CN, false)));
-		getSormasToSormasCaseFacade().saveSharedEntities(new SormasToSormasEncryptedDataDto(DEFAULT_SERVER_ACCESS_CN, encryptedData), null);
+		getSormasToSormasCaseFacade().saveSharedEntities(encryptedData, null);
 
 		CaseDataDto savedCase = getCaseFacade().getCaseDataByUuid(caze.getUuid());
 
@@ -422,9 +422,9 @@ public class SormasToSormasCaseFacadeEjbTest extends SormasToSormasFacadeTest {
 		portHealthInfo.setAirlineName("Test Airline");
 		caze.setPortHealthInfo(portHealthInfo);
 
-		byte[] encryptedData =
+		SormasToSormasEncryptedDataDto encryptedData =
 			encryptShareDataAsArray(new SormasToSormasCaseDto(person, caze, createSormasToSormasOriginInfo(DEFAULT_SERVER_ACCESS_CN, false)));
-		getSormasToSormasCaseFacade().saveSharedEntities(new SormasToSormasEncryptedDataDto(DEFAULT_SERVER_ACCESS_CN, encryptedData), null);
+		getSormasToSormasCaseFacade().saveSharedEntities(encryptedData, null);
 
 		CaseDataDto savedCase = getCaseFacade().getCaseDataByUuid(caze.getUuid());
 
@@ -450,8 +450,8 @@ public class SormasToSormasCaseFacadeEjbTest extends SormasToSormasFacadeTest {
 		SormasToSormasCaseDto shareData = new SormasToSormasCaseDto(person, caze, createSormasToSormasOriginInfo(DEFAULT_SERVER_ACCESS_CN, false));
 		shareData.setAssociatedContacts(Collections.singletonList(new SormasToSormasCaseDto.AssociatedContactDto(contactPerson, contact)));
 
-		byte[] encryptedData = encryptShareDataAsArray(shareData);
-		getSormasToSormasCaseFacade().saveSharedEntities(new SormasToSormasEncryptedDataDto(DEFAULT_SERVER_ACCESS_CN, encryptedData), null);
+		SormasToSormasEncryptedDataDto encryptedData = encryptShareDataAsArray(shareData);
+		getSormasToSormasCaseFacade().saveSharedEntities(encryptedData, null);
 
 		CaseDataDto savedCase = getCaseFacade().getCaseDataByUuid(caze.getUuid());
 		ContactDto savedContact = getContactFacade().getContactByUuid(contact.getUuid());
@@ -475,8 +475,8 @@ public class SormasToSormasCaseFacadeEjbTest extends SormasToSormasFacadeTest {
 		SormasToSormasCaseDto shareData = new SormasToSormasCaseDto(person, caze, createSormasToSormasOriginInfo(DEFAULT_SERVER_ACCESS_CN, false));
 		shareData.setSamples(Collections.singletonList(sample));
 
-		byte[] encryptedData = encryptShareDataAsArray(shareData);
-		getSormasToSormasCaseFacade().saveSharedEntities(new SormasToSormasEncryptedDataDto(DEFAULT_SERVER_ACCESS_CN, encryptedData), null);
+		SormasToSormasEncryptedDataDto encryptedData = encryptShareDataAsArray(shareData);
+		getSormasToSormasCaseFacade().saveSharedEntities(encryptedData, null);
 
 		CaseDataDto savedCase = getCaseFacade().getCaseDataByUuid(caze.getUuid());
 		SampleDto savedSample = getSampleFacade().getSampleByUuid(sample.getSample().getUuid());
@@ -696,10 +696,10 @@ public class SormasToSormasCaseFacadeEjbTest extends SormasToSormasFacadeTest {
 				new SormasToSormasSampleDto(newSample, Collections.emptyList(), Collections.emptyList()),
 				new SormasToSormasSampleDto(newSample2, Collections.emptyList(), Collections.emptyList())));
 
-		byte[] encryptedData = encryptShareDataAsArray(shareData);
+		SormasToSormasEncryptedDataDto encryptedData = encryptShareDataAsArray(shareData);
 
 		try {
-			getSormasToSormasCaseFacade().saveReturnedEntity(new SormasToSormasEncryptedDataDto(DEFAULT_SERVER_ACCESS_CN, encryptedData));
+			getSormasToSormasCaseFacade().saveReturnedEntity(encryptedData);
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
@@ -744,10 +744,10 @@ public class SormasToSormasCaseFacadeEjbTest extends SormasToSormasFacadeTest {
 		CaseDataDto caze = createRemoteCaseDto(rdcf.remoteRdcf, person);
 		caze.setHealthFacility(new FacilityReferenceDto("unknown", "Unknown facility", "unknown"));
 
-		byte[] encryptedData =
+		SormasToSormasEncryptedDataDto encryptedData =
 			encryptShareDataAsArray(new SormasToSormasCaseDto(person, caze, createSormasToSormasOriginInfo(DEFAULT_SERVER_ACCESS_CN, false)));
 
-		getSormasToSormasCaseFacade().saveSharedEntities(new SormasToSormasEncryptedDataDto(DEFAULT_SERVER_ACCESS_CN, encryptedData), null);
+		getSormasToSormasCaseFacade().saveSharedEntities(encryptedData, null);
 
 		CaseDataDto savedCase = getCaseFacade().getCaseDataByUuid(caze.getUuid());
 
@@ -772,9 +772,9 @@ public class SormasToSormasCaseFacadeEjbTest extends SormasToSormasFacadeTest {
 		portHealthInfo.setAirlineName("Test Airline");
 		caze.setPortHealthInfo(portHealthInfo);
 
-		byte[] encryptedData =
+		SormasToSormasEncryptedDataDto encryptedData =
 			encryptShareDataAsArray(new SormasToSormasCaseDto(person, caze, createSormasToSormasOriginInfo(DEFAULT_SERVER_ACCESS_CN, false)));
-		getSormasToSormasCaseFacade().saveSharedEntities(new SormasToSormasEncryptedDataDto(DEFAULT_SERVER_ACCESS_CN, encryptedData), null);
+		getSormasToSormasCaseFacade().saveSharedEntities(encryptedData, null);
 
 		CaseDataDto savedCase = getCaseFacade().getCaseDataByUuid(caze.getUuid());
 
@@ -815,10 +815,10 @@ public class SormasToSormasCaseFacadeEjbTest extends SormasToSormasFacadeTest {
 
 		SormasToSormasCaseDto shareData = new SormasToSormasCaseDto(person, caze, originInfo);
 
-		byte[] encryptedData = encryptShareDataAsArray(shareData);
+		SormasToSormasEncryptedDataDto encryptedData = encryptShareDataAsArray(shareData);
 
 		try {
-			getSormasToSormasCaseFacade().saveReturnedEntity(new SormasToSormasEncryptedDataDto(DEFAULT_SERVER_ACCESS_CN, encryptedData));
+			getSormasToSormasCaseFacade().saveReturnedEntity(encryptedData);
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
@@ -861,10 +861,10 @@ public class SormasToSormasCaseFacadeEjbTest extends SormasToSormasFacadeTest {
 
 		SormasToSormasCaseDto shareData = new SormasToSormasCaseDto(person, caze, originInfo);
 
-		byte[] encryptedData = encryptShareDataAsArray(shareData);
+		SormasToSormasEncryptedDataDto encryptedData = encryptShareDataAsArray(shareData);
 
 		try {
-			getSormasToSormasCaseFacade().saveReturnedEntity(new SormasToSormasEncryptedDataDto(DEFAULT_SERVER_ACCESS_CN, encryptedData));
+			getSormasToSormasCaseFacade().saveReturnedEntity(encryptedData);
 		} catch (Exception e) {
 			e.printStackTrace();
 		}

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasContactFacadeEjbTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasContactFacadeEjbTest.java
@@ -206,9 +206,9 @@ public class SormasToSormasContactFacadeEjbTest extends SormasToSormasFacadeTest
 
 		ContactDto contact = createRemoteContactDto(rdcf.remoteRdcf, person);
 
-		byte[] encryptedData =
+		SormasToSormasEncryptedDataDto encryptedData =
 			encryptShareDataAsArray(new SormasToSormasContactDto(person, contact, createSormasToSormasOriginInfo(DEFAULT_SERVER_ACCESS_CN, false)));
-		getSormasToSormasContactFacade().saveSharedEntities(new SormasToSormasEncryptedDataDto(DEFAULT_SERVER_ACCESS_CN, encryptedData), null);
+		getSormasToSormasContactFacade().saveSharedEntities(encryptedData, null);
 
 		ContactDto savedContact = getContactFacade().getContactByUuid(contact.getUuid());
 
@@ -243,8 +243,8 @@ public class SormasToSormasContactFacadeEjbTest extends SormasToSormasFacadeTest
 			new SormasToSormasContactDto(person, contact, createSormasToSormasOriginInfo(DEFAULT_SERVER_ACCESS_CN, false));
 		shareData.setSamples(Collections.singletonList(sample));
 
-		byte[] encryptedData = encryptShareDataAsArray(shareData);
-		getSormasToSormasContactFacade().saveSharedEntities(new SormasToSormasEncryptedDataDto(DEFAULT_SERVER_ACCESS_CN, encryptedData), null);
+		SormasToSormasEncryptedDataDto encryptedData = encryptShareDataAsArray(shareData);
+		getSormasToSormasContactFacade().saveSharedEntities(encryptedData, null);
 
 		ContactDto savedContact = getContactFacade().getContactByUuid(contact.getUuid());
 		SampleDto savedSample = getSampleFacade().getSampleByUuid(sample.getSample().getUuid());
@@ -354,9 +354,9 @@ public class SormasToSormasContactFacadeEjbTest extends SormasToSormasFacadeTest
 				new SormasToSormasSampleDto(sharedSample, Collections.emptyList(), Collections.emptyList()),
 				new SormasToSormasSampleDto(newSample, Collections.emptyList(), Collections.emptyList())));
 
-		byte[] encryptedData = encryptShareDataAsArray(shareData);
+		SormasToSormasEncryptedDataDto encryptedData = encryptShareDataAsArray(shareData);
 
-		getSormasToSormasContactFacade().saveReturnedEntity(new SormasToSormasEncryptedDataDto(DEFAULT_SERVER_ACCESS_CN, encryptedData));
+		getSormasToSormasContactFacade().saveReturnedEntity(encryptedData);
 
 		ContactDto returnedContact = getContactFacade().getContactByUuid(contact.getUuid());
 		assertThat(returnedContact.getQuarantine(), is(QuarantineType.HOTEL));

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasEventFacadeEjbTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasEventFacadeEjbTest.java
@@ -256,10 +256,10 @@ public class SormasToSormasEventFacadeEjbTest extends SormasToSormasFacadeTest {
 		event.setSrcMediaName("Test media website");
 		event.setSrcMediaDetails("Test media details");
 
-		byte[] encryptedData =
+		SormasToSormasEncryptedDataDto encryptedData =
 			encryptShareDataAsArray(new SormasToSormasEventDto(event, createSormasToSormasOriginInfo(DEFAULT_SERVER_ACCESS_CN, false)));
 
-		getSormasToSormasEventFacade().saveSharedEntities(new SormasToSormasEncryptedDataDto(DEFAULT_SERVER_ACCESS_CN, encryptedData), null);
+		getSormasToSormasEventFacade().saveSharedEntities(encryptedData, null);
 
 		EventDto savedEvent = getEventFacade().getEventByUuid(event.getUuid());
 
@@ -295,9 +295,9 @@ public class SormasToSormasEventFacadeEjbTest extends SormasToSormasFacadeTest {
 		SormasToSormasEventDto shareData = new SormasToSormasEventDto(event, createSormasToSormasOriginInfo(DEFAULT_SERVER_ACCESS_CN, false));
 		shareData.setEventParticipants(Collections.singletonList(eventParticipant));
 
-		byte[] encryptedData = encryptShareDataAsArray(shareData);
+		SormasToSormasEncryptedDataDto encryptedData = encryptShareDataAsArray(shareData);
 
-		getSormasToSormasEventFacade().saveSharedEntities(new SormasToSormasEncryptedDataDto(DEFAULT_SERVER_ACCESS_CN, encryptedData), null);
+		getSormasToSormasEventFacade().saveSharedEntities(encryptedData, null);
 
 		EventParticipantDto savedParticipant = getEventParticipantFacade().getEventParticipantByUuid(eventParticipant.getUuid());
 
@@ -344,9 +344,9 @@ public class SormasToSormasEventFacadeEjbTest extends SormasToSormasFacadeTest {
 		shareData.setSamples(
 			Collections.singletonList(
 				new SormasToSormasSampleDto(sample, Collections.singletonList(pathogenTest), Collections.singletonList(additionalTest))));
-		byte[] encryptedData = encryptShareDataAsArray(shareData);
+		SormasToSormasEncryptedDataDto encryptedData = encryptShareDataAsArray(shareData);
 
-		getSormasToSormasEventFacade().saveSharedEntities(new SormasToSormasEncryptedDataDto(DEFAULT_SERVER_ACCESS_CN, encryptedData), null);
+		getSormasToSormasEventFacade().saveSharedEntities(encryptedData, null);
 
 		SampleDto savedSample = getSampleFacade().getSampleByUuid(sample.getUuid());
 		assertThat(savedSample, is(notNullValue()));
@@ -466,9 +466,9 @@ public class SormasToSormasEventFacadeEjbTest extends SormasToSormasFacadeTest {
 		shareData.setEventParticipants(Arrays.asList(eventParticipant, newEventParticipant));
 		shareData.setSamples(Collections.singletonList(new SormasToSormasSampleDto(newSample, Collections.emptyList(), Collections.emptyList())));
 
-		byte[] encryptedData = encryptShareDataAsArray(shareData);
+		SormasToSormasEncryptedDataDto encryptedData = encryptShareDataAsArray(shareData);
 
-		getSormasToSormasEventFacade().saveReturnedEntity(new SormasToSormasEncryptedDataDto(DEFAULT_SERVER_ACCESS_CN, encryptedData));
+		getSormasToSormasEventFacade().saveReturnedEntity(encryptedData);
 
 		EventDto returnedEvent = getEventFacade().getEventByUuid(event.getUuid());
 		assertThat(returnedEvent.getEventDesc(), is("Test updated description"));
@@ -509,16 +509,11 @@ public class SormasToSormasEventFacadeEjbTest extends SormasToSormasFacadeTest {
 		PersonDto person = creator.createPerson();
 		EventParticipantDto eventParticipant = creator.createEventParticipant(event.toReference(), person, "Involved", officer);
 
-		getSormasToSormasShareInfoService().persist(
-			createShareInfo(
-				getUserService().getByUuid(officer.getUuid()),
-				SECOND_SERVER_ACCESS_CN,
-				false,
-				i -> {
-					i.getEvents().add(new ShareInfoEvent(i, getEventService().getByUuid(event.getUuid())));
-					i.getEventParticipants()
-						.add(new ShareInfoEventParticipant(i, getEventParticipantService().getByUuid(eventParticipant.getUuid())));
-				}));
+		getSormasToSormasShareInfoService()
+			.persist(createShareInfo(getUserService().getByUuid(officer.getUuid()), SECOND_SERVER_ACCESS_CN, false, i -> {
+				i.getEvents().add(new ShareInfoEvent(i, getEventService().getByUuid(event.getUuid())));
+				i.getEventParticipants().add(new ShareInfoEventParticipant(i, getEventParticipantService().getByUuid(eventParticipant.getUuid())));
+			}));
 
 		EventParticipantDto newEventParticipant = creator.createEventParticipant(event.toReference(), person, "Involved", officer);
 
@@ -588,9 +583,9 @@ public class SormasToSormasEventFacadeEjbTest extends SormasToSormasFacadeTest {
 		SormasToSormasEventDto shareData = new SormasToSormasEventDto(event, createSormasToSormasOriginInfo(DEFAULT_SERVER_ACCESS_CN, true));
 		shareData.setEventParticipants(Arrays.asList(eventParticipant, newEventParticipant));
 
-		byte[] encryptedData = encryptShareDataAsArray(shareData);
+		SormasToSormasEncryptedDataDto encryptedData = encryptShareDataAsArray(shareData);
 
-		getSormasToSormasEventFacade().saveSyncedEntity(new SormasToSormasEncryptedDataDto(DEFAULT_SERVER_ACCESS_CN, encryptedData));
+		getSormasToSormasEventFacade().saveSyncedEntity(encryptedData);
 
 		EventDto syncedEvent = getEventFacade().getEventByUuid(event.getUuid());
 		assertThat(syncedEvent.getEventDesc(), is("Test updated description"));

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasFacadeTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasFacadeTest.java
@@ -51,6 +51,7 @@ import de.symeda.sormas.api.sample.SampleDto;
 import de.symeda.sormas.api.sample.SampleMaterial;
 import de.symeda.sormas.api.sample.SamplePurpose;
 import de.symeda.sormas.api.sample.SampleSource;
+import de.symeda.sormas.api.sormastosormas.SormasToSormasEncryptedDataDto;
 import de.symeda.sormas.api.sormastosormas.SormasToSormasException;
 import de.symeda.sormas.api.sormastosormas.SormasToSormasOriginInfoDto;
 import de.symeda.sormas.api.sormastosormas.SormasToSormasSampleDto;
@@ -158,15 +159,14 @@ public class SormasToSormasFacadeTest extends AbstractBeanTest {
 		return shareInfo;
 	}
 
-	protected byte[] encryptShareDataAsArray(Object shareData) throws JsonProcessingException, SormasToSormasException {
+	protected SormasToSormasEncryptedDataDto encryptShareDataAsArray(Object shareData) throws JsonProcessingException, SormasToSormasException {
 		return encryptShareData(Collections.singletonList(shareData));
 	}
 
-	protected byte[] encryptShareData(Object shareData) throws JsonProcessingException, SormasToSormasException {
+	protected SormasToSormasEncryptedDataDto encryptShareData(Object shareData) throws SormasToSormasException {
 		mockDefaultServerAccess();
 
-		byte[] data = objectMapper.writeValueAsBytes(shareData);
-		byte[] encryptedData = getSormasToSormasEncryptionService().signAndEncrypt(data, SECOND_SERVER_ACCESS_CN);
+		SormasToSormasEncryptedDataDto encryptedData = getSormasToSormasEncryptionService().signAndEncrypt(shareData, SECOND_SERVER_ACCESS_CN);
 
 		mockSecondServerAccess();
 
@@ -176,12 +176,12 @@ public class SormasToSormasFacadeTest extends AbstractBeanTest {
 	protected <T> T decryptSharesData(byte[] data, Class<T> dataType) throws SormasToSormasException, IOException {
 		mockSecondServerAccess();
 
-		byte[] decryptData = getSormasToSormasEncryptionService().decryptAndVerify(data, DEFAULT_SERVER_ACCESS_CN);
-		T parsedData = objectMapper.readValue(decryptData, dataType);
+		T decryptData =
+			getSormasToSormasEncryptionService().decryptAndVerify(new SormasToSormasEncryptedDataDto(DEFAULT_SERVER_ACCESS_CN, data), dataType);
 
 		mockDefaultServerAccess();
 
-		return parsedData;
+		return decryptData;
 	}
 
 	protected void mockDefaultServerAccess() {

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasLabMessageFacadeEjbTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasLabMessageFacadeEjbTest.java
@@ -94,8 +94,8 @@ public class SormasToSormasLabMessageFacadeEjbTest extends SormasToSormasFacadeT
 		Date dateNow = new Date();
 		setLabMessageFields(labMessage, dateNow);
 
-		byte[] encryptedData = encryptShareDataAsArray(labMessage);
-		getSormasToSormasLabMessageFacade().saveLabMessages(new SormasToSormasEncryptedDataDto(DEFAULT_SERVER_ACCESS_CN, encryptedData));
+		SormasToSormasEncryptedDataDto encryptedData = encryptShareDataAsArray(labMessage);
+		getSormasToSormasLabMessageFacade().saveLabMessages(encryptedData);
 
 		LabMessageDto savedLabMessage = getLabMessageFacade().getByUuid(labMessage.getUuid());
 		assertThat(savedLabMessage, is(notNullValue()));


### PR DESCRIPTION
@vidi42 I currently try to establish correct interfaces to move forward with the 2nd gen S2S approach. I noticed that a lot of interfaces are leaky and there is 0 reason to let the developers handle the bytes on their own.

This is the first part of my changes to handle encryption and rest calls better.