### PR TITLE
#6080 persist case completeness without changedate

### DIFF
--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/caze/CaseFacadeEjbTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/caze/CaseFacadeEjbTest.java
@@ -2041,6 +2041,7 @@ public class CaseFacadeEjbTest extends AbstractBeanTest {
 		Case completenessUpdateResult2 = getCaseService().getByUuid(caseWithCompleteness.getUuid());
 
 		MatcherAssert.assertThat(completenessUpdateResult.getCompleteness(), notNullValue());
+		MatcherAssert.assertThat(completenessUpdateResult.getChangeDate(), equalTo(caseNoCompleteness.getChangeDate()));
 		MatcherAssert.assertThat(completenessUpdateResult2.getCompleteness(), is(0.7f));
 		MatcherAssert.assertThat(changedCases, is(1));
 


### PR DESCRIPTION
<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #6080 

Side effect: Auditlog is not triggered (the same with batch archive/dearchive of cases).