### PR TITLE
Fix opening older share requests which don't have contacts or event participants

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/sormastosormas/ShareRequestLayout.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/sormastosormas/ShareRequestLayout.java
@@ -50,7 +50,9 @@ public class ShareRequestLayout extends VerticalLayout {
 			ContactsPreviewGrid contactsGrid = addContactsGrid(Collections.emptyList());
 			casesGrid.getSelectionModel().addSelectionListener(event -> {
 				event.getFirstSelectedItem().ifPresent(casePreview -> {
-					contactsGrid.setItems(casePreview.getContacts());
+					if (casePreview.getContacts() != null) {
+						contactsGrid.setItems(casePreview.getContacts());
+					}
 				});
 			});
 
@@ -77,7 +79,9 @@ public class ShareRequestLayout extends VerticalLayout {
 
 			eventsGrid.getSelectionModel().addSelectionListener(event -> {
 				event.getFirstSelectedItem().ifPresent(eventPreview -> {
-					eventParticipantsGrid.setItems(eventPreview.getEventParticipants());
+					if(eventPreview.getEventParticipants() != null) {
+						eventParticipantsGrid.setItems(eventPreview.getEventParticipants());
+					}
 				});
 			});
 


### PR DESCRIPTION
Not related to the fix of the defect described in the issue.
The original issue cannot be reproduced anymore.

Closes #6067