### PR TITLE
[#6573] move loading logic to ejbs

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/GeoInfrastructureBaseFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/GeoInfrastructureBaseFacade.java
@@ -12,7 +12,7 @@ import de.symeda.sormas.api.ReferenceDto;
 import de.symeda.sormas.api.utils.criteria.BaseCriteria;
 
 @Remote
-public interface InfrastructureBaseFacade<DTO extends EntityDto, INDEX_DTO extends Serializable, REF_DTO extends ReferenceDto, CRITERIA extends BaseCriteria>
+public interface GeoInfrastructureBaseFacade<DTO extends EntityDto, INDEX_DTO extends Serializable, REF_DTO extends ReferenceDto, CRITERIA extends BaseCriteria>
 	extends BaseFacade<DTO, INDEX_DTO, REF_DTO, CRITERIA> {
 
 	DTO save(@Valid DTO dto, boolean allowMerge);

--- a/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/GeoInfrastructureBaseFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/GeoInfrastructureBaseFacade.java
@@ -19,4 +19,6 @@ public interface GeoInfrastructureBaseFacade<DTO extends EntityDto, INDEX_DTO ex
 
 	List<REF_DTO> getByExternalId(String externalId, boolean includeArchivedEntities);
 
+	REF_DTO loadLocal(REF_DTO ref);
+
 }

--- a/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/area/AreaFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/area/AreaFacade.java
@@ -6,10 +6,10 @@ import java.util.List;
 import javax.ejb.Remote;
 import javax.validation.Valid;
 
-import de.symeda.sormas.api.infrastructure.InfrastructureBaseFacade;
+import de.symeda.sormas.api.infrastructure.GeoInfrastructureBaseFacade;
 
 @Remote
-public interface AreaFacade extends InfrastructureBaseFacade<AreaDto, AreaDto, AreaReferenceDto, AreaCriteria> {
+public interface AreaFacade extends GeoInfrastructureBaseFacade<AreaDto, AreaDto, AreaReferenceDto, AreaCriteria> {
 
 	List<AreaReferenceDto> getAllActiveAsReference();
 

--- a/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/area/AreaReferenceDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/area/AreaReferenceDto.java
@@ -1,8 +1,8 @@
 package de.symeda.sormas.api.infrastructure.area;
 
-import de.symeda.sormas.api.ReferenceDto;
+import de.symeda.sormas.api.InfrastructureDataReferenceDto;
 
-public class AreaReferenceDto extends ReferenceDto {
+public class AreaReferenceDto extends InfrastructureDataReferenceDto {
 
 	private static final long serialVersionUID = -6241927331721175673L;
 

--- a/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/community/CommunityFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/community/CommunityFacade.java
@@ -25,12 +25,12 @@ import javax.ejb.Remote;
 import javax.validation.Valid;
 
 import de.symeda.sormas.api.common.Page;
-import de.symeda.sormas.api.infrastructure.InfrastructureBaseFacade;
+import de.symeda.sormas.api.infrastructure.GeoInfrastructureBaseFacade;
 import de.symeda.sormas.api.infrastructure.district.DistrictReferenceDto;
 import de.symeda.sormas.api.utils.SortProperty;
 
 @Remote
-public interface CommunityFacade extends InfrastructureBaseFacade<CommunityDto, CommunityDto, CommunityReferenceDto, CommunityCriteria> {
+public interface CommunityFacade extends GeoInfrastructureBaseFacade<CommunityDto, CommunityDto, CommunityReferenceDto, CommunityCriteria> {
 
 	List<CommunityReferenceDto> getAllActiveByDistrict(String districtUuid);
 

--- a/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/continent/ContinentFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/continent/ContinentFacade.java
@@ -5,12 +5,12 @@ import java.util.List;
 
 import javax.ejb.Remote;
 
-import de.symeda.sormas.api.infrastructure.InfrastructureBaseFacade;
+import de.symeda.sormas.api.infrastructure.GeoInfrastructureBaseFacade;
 import de.symeda.sormas.api.infrastructure.country.CountryReferenceDto;
 import de.symeda.sormas.api.infrastructure.subcontinent.SubcontinentReferenceDto;
 
 @Remote
-public interface ContinentFacade extends InfrastructureBaseFacade<ContinentDto, ContinentIndexDto, ContinentReferenceDto, ContinentCriteria> {
+public interface ContinentFacade extends GeoInfrastructureBaseFacade<ContinentDto, ContinentIndexDto, ContinentReferenceDto, ContinentCriteria> {
 
 	List<ContinentReferenceDto> getByDefaultName(String name, boolean includeArchivedEntities);
 

--- a/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/country/CountryFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/country/CountryFacade.java
@@ -6,11 +6,11 @@ import java.util.List;
 import javax.ejb.Remote;
 
 import de.symeda.sormas.api.common.Page;
-import de.symeda.sormas.api.infrastructure.InfrastructureBaseFacade;
+import de.symeda.sormas.api.infrastructure.GeoInfrastructureBaseFacade;
 import de.symeda.sormas.api.utils.SortProperty;
 
 @Remote
-public interface CountryFacade extends InfrastructureBaseFacade<CountryDto, CountryIndexDto, CountryReferenceDto, CountryCriteria> {
+public interface CountryFacade extends GeoInfrastructureBaseFacade<CountryDto, CountryIndexDto, CountryReferenceDto, CountryCriteria> {
 
 	CountryDto getCountryByUuid(String uuid);
 

--- a/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/district/DistrictFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/district/DistrictFacade.java
@@ -24,12 +24,12 @@ import java.util.Map;
 import javax.ejb.Remote;
 
 import de.symeda.sormas.api.common.Page;
-import de.symeda.sormas.api.infrastructure.InfrastructureBaseFacade;
+import de.symeda.sormas.api.infrastructure.GeoInfrastructureBaseFacade;
 import de.symeda.sormas.api.infrastructure.region.RegionReferenceDto;
 import de.symeda.sormas.api.utils.SortProperty;
 
 @Remote
-public interface DistrictFacade extends InfrastructureBaseFacade<DistrictDto, DistrictIndexDto, DistrictReferenceDto, DistrictCriteria> {
+public interface DistrictFacade extends GeoInfrastructureBaseFacade<DistrictDto, DistrictIndexDto, DistrictReferenceDto, DistrictCriteria> {
 
 	List<DistrictReferenceDto> getAllActiveByArea(String areaUuid);
 

--- a/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/facility/FacilityFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/facility/FacilityFacade.java
@@ -24,12 +24,13 @@ import java.util.Map;
 
 import javax.ejb.Remote;
 
-import de.symeda.sormas.api.infrastructure.InfrastructureBaseFacade;
+import de.symeda.sormas.api.BaseFacade;
 import de.symeda.sormas.api.infrastructure.community.CommunityReferenceDto;
 import de.symeda.sormas.api.infrastructure.district.DistrictReferenceDto;
+import de.symeda.sormas.api.utils.ValidationRuntimeException;
 
 @Remote
-public interface FacilityFacade extends InfrastructureBaseFacade<FacilityDto, FacilityIndexDto, FacilityReferenceDto, FacilityCriteria> {
+public interface FacilityFacade extends BaseFacade<FacilityDto, FacilityIndexDto, FacilityReferenceDto, FacilityCriteria> {
 
 	List<FacilityReferenceDto> getActiveFacilitiesByCommunityAndType(
 		CommunityReferenceDto community,
@@ -53,6 +54,8 @@ public interface FacilityFacade extends InfrastructureBaseFacade<FacilityDto, Fa
 
 	List<FacilityDto> getAllWithoutRegionAfter(Date date);
 
+	List<FacilityReferenceDto> getByExternalId(String externalId, boolean includeArchivedEntities);
+
 	FacilityReferenceDto getFacilityReferenceByUuid(String uuid);
 
 	FacilityReferenceDto getFacilityReferenceById(long id);
@@ -75,4 +78,6 @@ public interface FacilityFacade extends InfrastructureBaseFacade<FacilityDto, Fa
 	List<FacilityReferenceDto> getByExternalIdAndType(String id, FacilityType type, boolean includeArchivedEntities);
 
 	List<FacilityExportDto> getExportList(FacilityCriteria facilityCriteria, Integer first, Integer max);
+
+	FacilityDto save(FacilityDto dto, boolean allowMerge) throws ValidationRuntimeException;
 }

--- a/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/pointofentry/PointOfEntryFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/pointofentry/PointOfEntryFacade.java
@@ -5,13 +5,13 @@ import java.util.List;
 
 import javax.ejb.Remote;
 
-import de.symeda.sormas.api.infrastructure.InfrastructureBaseFacade;
+import de.symeda.sormas.api.BaseFacade;
 import de.symeda.sormas.api.infrastructure.district.DistrictReferenceDto;
 import de.symeda.sormas.api.utils.ValidationRuntimeException;
 
 @Remote
 public interface PointOfEntryFacade
-	extends InfrastructureBaseFacade<PointOfEntryDto, PointOfEntryDto, PointOfEntryReferenceDto, PointOfEntryCriteria> {
+	extends BaseFacade<PointOfEntryDto, PointOfEntryDto, PointOfEntryReferenceDto, PointOfEntryCriteria> {
 
 	/**
 	 * @param includeOthers
@@ -19,6 +19,10 @@ public interface PointOfEntryFacade
 	 *            point of entry is not in the database.
 	 */
 	List<PointOfEntryReferenceDto> getAllActiveByDistrict(String districtUuid, boolean includeOthers);
+
+	List<PointOfEntryReferenceDto> getByExternalId(String name, boolean includeArchivedEntities);
+
+	PointOfEntryDto save(PointOfEntryDto dto, boolean allowMerge) throws ValidationRuntimeException;
 
 	void validate(PointOfEntryDto pointOfEntry) throws ValidationRuntimeException;
 

--- a/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/region/RegionFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/region/RegionFacade.java
@@ -23,11 +23,11 @@ import java.util.List;
 import javax.ejb.Remote;
 
 import de.symeda.sormas.api.common.Page;
-import de.symeda.sormas.api.infrastructure.InfrastructureBaseFacade;
+import de.symeda.sormas.api.infrastructure.GeoInfrastructureBaseFacade;
 import de.symeda.sormas.api.utils.SortProperty;
 
 @Remote
-public interface RegionFacade extends InfrastructureBaseFacade<RegionDto, RegionIndexDto, RegionReferenceDto, RegionCriteria> {
+public interface RegionFacade extends GeoInfrastructureBaseFacade<RegionDto, RegionIndexDto, RegionReferenceDto, RegionCriteria> {
 
 	List<RegionReferenceDto> getAllActiveByServerCountry();
 

--- a/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/subcontinent/SubcontinentFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/subcontinent/SubcontinentFacade.java
@@ -1,18 +1,16 @@
 package de.symeda.sormas.api.infrastructure.subcontinent;
 
+import de.symeda.sormas.api.infrastructure.GeoInfrastructureBaseFacade;
+import de.symeda.sormas.api.infrastructure.country.CountryReferenceDto;
+
 import java.util.Collection;
 import java.util.List;
 
 import javax.ejb.Remote;
 
-import de.symeda.sormas.api.infrastructure.InfrastructureBaseFacade;
-import de.symeda.sormas.api.infrastructure.country.CountryReferenceDto;
-
-import de.symeda.sormas.api.infrastructure.country.CountryReferenceDto;
-
 @Remote
 public interface SubcontinentFacade
-	extends InfrastructureBaseFacade<SubcontinentDto, SubcontinentIndexDto, SubcontinentReferenceDto, SubcontinentCriteria> {
+	extends GeoInfrastructureBaseFacade<SubcontinentDto, SubcontinentIndexDto, SubcontinentReferenceDto, SubcontinentCriteria> {
 
 	List<SubcontinentReferenceDto> getByDefaultName(String name, boolean includeArchivedEntities);
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/abstrct/AbstractInfrastructureAdoService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/abstrct/AbstractInfrastructureAdoService.java
@@ -1,4 +1,4 @@
-package de.symeda.sormas.backend.common;
+package de.symeda.sormas.backend.infrastructure.abstrct;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -11,6 +11,9 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
 import de.symeda.sormas.api.EntityRelevanceStatus;
+import de.symeda.sormas.backend.common.AbstractDomainObject;
+import de.symeda.sormas.backend.common.AdoServiceWithUserFilter;
+import de.symeda.sormas.backend.common.CriteriaBuilderHelper;
 import de.symeda.sormas.backend.util.QueryHelper;
 
 public abstract class AbstractInfrastructureAdoService<ADO extends InfrastructureAdo> extends AdoServiceWithUserFilter<ADO> {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/abstrct/InfrastructureAdo.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/abstrct/InfrastructureAdo.java
@@ -1,4 +1,6 @@
-package de.symeda.sormas.backend.common;
+package de.symeda.sormas.backend.infrastructure.abstrct;
+
+import de.symeda.sormas.backend.common.AbstractDomainObject;
 
 import javax.persistence.Column;
 import javax.persistence.MappedSuperclass;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/area/Area.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/area/Area.java
@@ -5,7 +5,7 @@ import static de.symeda.sormas.api.EntityDto.COLUMN_LENGTH_DEFAULT;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 
-import de.symeda.sormas.backend.common.InfrastructureAdo;
+import de.symeda.sormas.backend.infrastructure.abstrct.InfrastructureAdo;
 
 @Entity(name = "areas")
 public class Area extends InfrastructureAdo {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/area/AreaFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/area/AreaFacadeEjb.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import javax.ejb.EJB;
@@ -26,6 +27,7 @@ import de.symeda.sormas.api.infrastructure.area.AreaCriteria;
 import de.symeda.sormas.api.infrastructure.area.AreaDto;
 import de.symeda.sormas.api.infrastructure.area.AreaFacade;
 import de.symeda.sormas.api.infrastructure.area.AreaReferenceDto;
+import de.symeda.sormas.api.infrastructure.region.RegionReferenceDto;
 import de.symeda.sormas.api.utils.SortProperty;
 import de.symeda.sormas.api.utils.ValidationRuntimeException;
 import de.symeda.sormas.backend.infrastructure.region.Region;
@@ -188,6 +190,22 @@ public class AreaFacadeEjb implements AreaFacade {
 			.stream()
 			.map(AreaFacadeEjb::toReferenceDto)
 			.collect(Collectors.toList());
+	}
+
+	@Override
+	public AreaReferenceDto loadLocal(AreaReferenceDto area) {
+		if (area == null) {
+			return null;
+		}
+
+		Optional<AreaReferenceDto> localRegion =
+			area.getExternalId() != null ? getByExternalId(area.getExternalId(), false).stream().findFirst() : Optional.empty();
+
+		if (!localRegion.isPresent()) {
+			localRegion = getByName(area.getCaption(), false).stream().findFirst();
+		}
+
+		return localRegion.orElse(null);
 	}
 
 	public AreaDto toDto(Area source) {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/area/AreaService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/area/AreaService.java
@@ -16,7 +16,7 @@ import org.apache.commons.lang3.StringUtils;
 import de.symeda.sormas.api.EntityRelevanceStatus;
 import de.symeda.sormas.api.infrastructure.area.AreaCriteria;
 import de.symeda.sormas.api.utils.DataHelper;
-import de.symeda.sormas.backend.common.AbstractInfrastructureAdoService;
+import de.symeda.sormas.backend.infrastructure.abstrct.AbstractInfrastructureAdoService;
 import de.symeda.sormas.backend.common.CriteriaBuilderHelper;
 
 @Stateless

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/community/Community.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/community/Community.java
@@ -25,7 +25,7 @@ import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 
-import de.symeda.sormas.backend.common.InfrastructureAdo;
+import de.symeda.sormas.backend.infrastructure.abstrct.InfrastructureAdo;
 import de.symeda.sormas.backend.infrastructure.district.District;
 
 @Entity

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/community/CommunityFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/community/CommunityFacadeEjb.java
@@ -1,17 +1,14 @@
 /*
  * SORMAS® - Surveillance Outbreak Response Management & Analysis System
  * Copyright © 2016-2021 Helmholtz-Zentrum für Infektionsforschung GmbH (HZI)
- *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
@@ -24,6 +21,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import javax.ejb.EJB;
@@ -330,6 +328,22 @@ public class CommunityFacadeEjb implements CommunityFacade {
 			.stream()
 			.map(CommunityFacadeEjb::toReferenceDto)
 			.collect(Collectors.toList());
+	}
+
+
+	public CommunityReferenceDto loadLocal(CommunityReferenceDto community) {
+		if (community == null) {
+			return null;
+		}
+
+		Optional<CommunityReferenceDto> localCommunity =
+			community.getExternalId() != null ? getByExternalId(community.getExternalId(), false).stream().findFirst() : Optional.empty();
+
+		if (!localCommunity.isPresent()) {
+			localCommunity = getByName(community.getCaption(), null, false).stream().findFirst();
+		}
+
+		return localCommunity.orElse(null);
 	}
 
 	@Override

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/community/CommunityFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/community/CommunityFacadeEjb.java
@@ -330,7 +330,7 @@ public class CommunityFacadeEjb implements CommunityFacade {
 			.collect(Collectors.toList());
 	}
 
-
+	@Override
 	public CommunityReferenceDto loadLocal(CommunityReferenceDto community) {
 		if (community == null) {
 			return null;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/community/CommunityService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/community/CommunityService.java
@@ -38,7 +38,7 @@ import de.symeda.sormas.api.infrastructure.community.CommunityReferenceDto;
 import de.symeda.sormas.api.infrastructure.country.CountryReferenceDto;
 import de.symeda.sormas.api.infrastructure.district.DistrictReferenceDto;
 import de.symeda.sormas.api.utils.DataHelper;
-import de.symeda.sormas.backend.common.AbstractInfrastructureAdoService;
+import de.symeda.sormas.backend.infrastructure.abstrct.AbstractInfrastructureAdoService;
 import de.symeda.sormas.backend.common.CriteriaBuilderHelper;
 import de.symeda.sormas.backend.infrastructure.country.Country;
 import de.symeda.sormas.backend.infrastructure.country.CountryFacadeEjb.CountryFacadeEjbLocal;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/continent/Continent.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/continent/Continent.java
@@ -8,7 +8,7 @@ import javax.persistence.OneToMany;
 import javax.persistence.OrderBy;
 
 import de.symeda.sormas.api.infrastructure.continent.ContinentReferenceDto;
-import de.symeda.sormas.backend.common.InfrastructureAdo;
+import de.symeda.sormas.backend.infrastructure.abstrct.InfrastructureAdo;
 import de.symeda.sormas.backend.infrastructure.subcontinent.Subcontinent;
 
 @Entity

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/continent/ContinentFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/continent/ContinentFacadeEjb.java
@@ -281,6 +281,7 @@ public class ContinentFacadeEjb implements ContinentFacade {
 			.collect(Collectors.toList());
 	}
 
+	@Override
 	public ContinentReferenceDto loadLocal(ContinentReferenceDto continent) {
 		if (continent == null) {
 			return null;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/continent/ContinentService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/continent/ContinentService.java
@@ -12,7 +12,7 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
 import de.symeda.sormas.api.infrastructure.continent.ContinentCriteria;
-import de.symeda.sormas.backend.common.AbstractInfrastructureAdoService;
+import de.symeda.sormas.backend.infrastructure.abstrct.AbstractInfrastructureAdoService;
 import de.symeda.sormas.backend.common.CriteriaBuilderHelper;
 
 @Stateless

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/country/Country.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/country/Country.java
@@ -4,7 +4,7 @@ import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.ManyToOne;
 
-import de.symeda.sormas.backend.common.InfrastructureAdo;
+import de.symeda.sormas.backend.infrastructure.abstrct.InfrastructureAdo;
 import de.symeda.sormas.backend.infrastructure.subcontinent.Subcontinent;
 
 @Entity

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/country/CountryFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/country/CountryFacadeEjb.java
@@ -321,6 +321,7 @@ public class CountryFacadeEjb implements CountryFacade {
 			.collect(Collectors.toList());
 	}
 
+	@Override
 	public CountryReferenceDto loadLocal(CountryReferenceDto country) {
 		if (country == null) {
 			return null;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/country/CountryFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/country/CountryFacadeEjb.java
@@ -321,6 +321,25 @@ public class CountryFacadeEjb implements CountryFacade {
 			.collect(Collectors.toList());
 	}
 
+	public CountryReferenceDto loadLocal(CountryReferenceDto country) {
+		if (country == null) {
+			return null;
+		}
+
+		Optional<CountryReferenceDto> localCountry =
+			country.getExternalId() != null ? getByExternalId(country.getExternalId(), false).stream().findFirst() : Optional.empty();
+
+		if (!localCountry.isPresent()) {
+			localCountry = Optional.ofNullable(getByIsoCode(country.getIsoCode(), false)).map(CountryFacadeEjb::toReferenceDto);
+		}
+
+		if (!localCountry.isPresent()) {
+			localCountry = getReferencesByName(country.getCaption(), false).stream().findFirst();
+		}
+
+		return localCountry.orElse(null);
+	}
+
 	public List<CountryReferenceDto> getReferencesByName(String caption, boolean includeArchived) {
 		return countryService.getByDefaultName(caption, includeArchived).stream().map(CountryFacadeEjb::toReferenceDto).collect(Collectors.toList());
 	}
@@ -363,7 +382,6 @@ public class CountryFacadeEjb implements CountryFacade {
 
 		return em.createQuery(cq).getResultList();
 	}
-
 
 	@Override
 	public CountryDto getByUuid(String uuid) {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/country/CountryService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/country/CountryService.java
@@ -16,7 +16,7 @@ import javax.persistence.criteria.Root;
 import de.symeda.sormas.api.EntityRelevanceStatus;
 import de.symeda.sormas.api.infrastructure.country.CountryCriteria;
 import de.symeda.sormas.api.utils.DataHelper;
-import de.symeda.sormas.backend.common.AbstractInfrastructureAdoService;
+import de.symeda.sormas.backend.infrastructure.abstrct.AbstractInfrastructureAdoService;
 import de.symeda.sormas.backend.common.CriteriaBuilderHelper;
 import de.symeda.sormas.backend.infrastructure.subcontinent.Subcontinent;
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/district/District.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/district/District.java
@@ -30,7 +30,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.OrderBy;
 
-import de.symeda.sormas.backend.common.InfrastructureAdo;
+import de.symeda.sormas.backend.infrastructure.abstrct.InfrastructureAdo;
 import de.symeda.sormas.backend.infrastructure.region.Region;
 import de.symeda.sormas.backend.infrastructure.community.Community;
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/district/DistrictFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/district/DistrictFacadeEjb.java
@@ -1,17 +1,14 @@
 /*
  * SORMAS® - Surveillance Outbreak Response Management & Analysis System
  * Copyright © 2016-2021 Helmholtz-Zentrum für Infektionsforschung GmbH (HZI)
- *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
@@ -24,6 +21,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import javax.ejb.EJB;
@@ -332,6 +330,21 @@ public class DistrictFacadeEjb implements DistrictFacade {
 			.stream()
 			.map(DistrictFacadeEjb::toReferenceDto)
 			.collect(Collectors.toList());
+	}
+
+	public DistrictReferenceDto loadLocal(DistrictReferenceDto district) {
+		if (district == null) {
+			return null;
+		}
+
+		Optional<DistrictReferenceDto> localDistrict =
+			district.getExternalId() != null ? getByExternalId(district.getExternalId(), false).stream().findFirst() : Optional.empty();
+
+		if (!localDistrict.isPresent()) {
+			localDistrict = getByName(district.getCaption(), null, false).stream().findFirst();
+		}
+
+		return localDistrict.orElse(null);
 	}
 
 	@Override

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/district/DistrictFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/district/DistrictFacadeEjb.java
@@ -332,6 +332,7 @@ public class DistrictFacadeEjb implements DistrictFacade {
 			.collect(Collectors.toList());
 	}
 
+	@Override
 	public DistrictReferenceDto loadLocal(DistrictReferenceDto district) {
 		if (district == null) {
 			return null;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/district/DistrictService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/district/DistrictService.java
@@ -34,7 +34,7 @@ import de.symeda.sormas.api.EntityRelevanceStatus;
 import de.symeda.sormas.api.infrastructure.country.CountryReferenceDto;
 import de.symeda.sormas.api.infrastructure.district.DistrictCriteria;
 import de.symeda.sormas.api.utils.DataHelper;
-import de.symeda.sormas.backend.common.AbstractInfrastructureAdoService;
+import de.symeda.sormas.backend.infrastructure.abstrct.AbstractInfrastructureAdoService;
 import de.symeda.sormas.backend.common.CriteriaBuilderHelper;
 import de.symeda.sormas.backend.infrastructure.region.Region;
 import de.symeda.sormas.backend.infrastructure.country.Country;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/facility/Facility.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/facility/Facility.java
@@ -29,7 +29,7 @@ import javax.persistence.ManyToOne;
 import de.symeda.sormas.api.infrastructure.facility.FacilityHelper;
 import de.symeda.sormas.api.infrastructure.facility.FacilityType;
 import de.symeda.sormas.api.infrastructure.area.AreaType;
-import de.symeda.sormas.backend.common.InfrastructureAdo;
+import de.symeda.sormas.backend.infrastructure.abstrct.InfrastructureAdo;
 import de.symeda.sormas.backend.infrastructure.community.Community;
 import de.symeda.sormas.backend.infrastructure.district.District;
 import de.symeda.sormas.backend.infrastructure.region.Region;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/facility/FacilityFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/facility/FacilityFacadeEjb.java
@@ -24,6 +24,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import javax.ejb.EJB;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/facility/FacilityService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/facility/FacilityService.java
@@ -38,7 +38,7 @@ import de.symeda.sormas.api.infrastructure.facility.FacilityDto;
 import de.symeda.sormas.api.infrastructure.facility.FacilityType;
 import de.symeda.sormas.api.infrastructure.country.CountryReferenceDto;
 import de.symeda.sormas.api.utils.DataHelper;
-import de.symeda.sormas.backend.common.AbstractInfrastructureAdoService;
+import de.symeda.sormas.backend.infrastructure.abstrct.AbstractInfrastructureAdoService;
 import de.symeda.sormas.backend.common.CriteriaBuilderHelper;
 import de.symeda.sormas.backend.infrastructure.community.Community;
 import de.symeda.sormas.backend.infrastructure.country.Country;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/pointofentry/PointOfEntry.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/pointofentry/PointOfEntry.java
@@ -10,7 +10,7 @@ import javax.persistence.ManyToOne;
 
 import de.symeda.sormas.api.infrastructure.InfrastructureHelper;
 import de.symeda.sormas.api.infrastructure.pointofentry.PointOfEntryType;
-import de.symeda.sormas.backend.common.InfrastructureAdo;
+import de.symeda.sormas.backend.infrastructure.abstrct.InfrastructureAdo;
 import de.symeda.sormas.backend.infrastructure.district.District;
 import de.symeda.sormas.backend.infrastructure.region.Region;
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/pointofentry/PointOfEntryService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/pointofentry/PointOfEntryService.java
@@ -19,12 +19,11 @@ import de.symeda.sormas.api.infrastructure.pointofentry.PointOfEntryDto;
 import de.symeda.sormas.api.infrastructure.pointofentry.PointOfEntryType;
 import de.symeda.sormas.api.infrastructure.country.CountryReferenceDto;
 import de.symeda.sormas.api.utils.DataHelper;
-import de.symeda.sormas.backend.common.AbstractInfrastructureAdoService;
+import de.symeda.sormas.backend.infrastructure.abstrct.AbstractInfrastructureAdoService;
 import de.symeda.sormas.backend.common.CriteriaBuilderHelper;
 import de.symeda.sormas.backend.infrastructure.country.Country;
 import de.symeda.sormas.backend.infrastructure.country.CountryFacadeEjb.CountryFacadeEjbLocal;
 import de.symeda.sormas.backend.infrastructure.district.District;
-import de.symeda.sormas.backend.infrastructure.facility.Facility;
 import de.symeda.sormas.backend.infrastructure.region.Region;
 import de.symeda.sormas.backend.infrastructure.region.RegionService;
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/region/Region.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/region/Region.java
@@ -28,7 +28,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.OrderBy;
 
-import de.symeda.sormas.backend.common.InfrastructureAdo;
+import de.symeda.sormas.backend.infrastructure.abstrct.InfrastructureAdo;
 import de.symeda.sormas.backend.infrastructure.area.Area;
 import de.symeda.sormas.backend.infrastructure.country.Country;
 import de.symeda.sormas.backend.infrastructure.district.District;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/region/RegionFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/region/RegionFacadeEjb.java
@@ -400,6 +400,7 @@ public class RegionFacadeEjb implements RegionFacade {
 			.collect(Collectors.toList());
 	}
 
+	@Override
 	public RegionReferenceDto loadLocal(RegionReferenceDto region) {
 		if (region == null) {
 			return null;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/region/RegionFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/region/RegionFacadeEjb.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
@@ -397,6 +398,21 @@ public class RegionFacadeEjb implements RegionFacade {
 			.stream()
 			.map(RegionFacadeEjb::toReferenceDto)
 			.collect(Collectors.toList());
+	}
+
+	public RegionReferenceDto loadLocal(RegionReferenceDto region) {
+		if (region == null) {
+			return null;
+		}
+
+		Optional<RegionReferenceDto> localRegion =
+			region.getExternalId() != null ? getByExternalId(region.getExternalId(), false).stream().findFirst() : Optional.empty();
+
+		if (!localRegion.isPresent()) {
+			localRegion = getReferencesByName(region.getCaption(), false).stream().findFirst();
+		}
+
+		return localRegion.orElse(null);
 	}
 
 	private List<RegionReferenceDto> getAllActiveByPredicate(BiFunction<CriteriaBuilder, Root<Region>, Predicate> buildPredicate) {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/region/RegionService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/region/RegionService.java
@@ -34,7 +34,7 @@ import de.symeda.sormas.api.EntityRelevanceStatus;
 import de.symeda.sormas.api.infrastructure.country.CountryReferenceDto;
 import de.symeda.sormas.api.infrastructure.region.RegionCriteria;
 import de.symeda.sormas.api.utils.DataHelper;
-import de.symeda.sormas.backend.common.AbstractInfrastructureAdoService;
+import de.symeda.sormas.backend.infrastructure.abstrct.AbstractInfrastructureAdoService;
 import de.symeda.sormas.backend.common.CriteriaBuilderHelper;
 import de.symeda.sormas.backend.infrastructure.country.Country;
 import de.symeda.sormas.backend.infrastructure.country.CountryFacadeEjb.CountryFacadeEjbLocal;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/subcontinent/Subcontinent.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/subcontinent/Subcontinent.java
@@ -10,7 +10,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.OrderBy;
 
-import de.symeda.sormas.backend.common.InfrastructureAdo;
+import de.symeda.sormas.backend.infrastructure.abstrct.InfrastructureAdo;
 import de.symeda.sormas.backend.infrastructure.continent.Continent;
 import de.symeda.sormas.backend.infrastructure.country.Country;
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/subcontinent/SubcontinentFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/subcontinent/SubcontinentFacadeEjb.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import javax.ejb.EJB;
@@ -304,6 +305,19 @@ public class SubcontinentFacadeEjb implements SubcontinentFacade {
 			.stream()
 			.map(SubcontinentFacadeEjb::toReferenceDto)
 			.collect(Collectors.toList());
+	}
+
+	public SubcontinentReferenceDto loadLocal(SubcontinentReferenceDto subcontinent) {
+		if (subcontinent == null) {
+			return null;
+		}
+		Optional<SubcontinentReferenceDto> localSubcontinent =
+			subcontinent.getExternalId() != null ? getByExternalId(subcontinent.getExternalId(), false).stream().findFirst() : Optional.empty();
+		if (!localSubcontinent.isPresent()) {
+			localSubcontinent = getReferencesByName(subcontinent.getCaption(), false).stream().findFirst();
+		}
+
+		return localSubcontinent.orElse(null);
 	}
 
 	public List<SubcontinentReferenceDto> getReferencesByName(String caption, boolean includeArchived) {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/subcontinent/SubcontinentFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/subcontinent/SubcontinentFacadeEjb.java
@@ -307,6 +307,7 @@ public class SubcontinentFacadeEjb implements SubcontinentFacade {
 			.collect(Collectors.toList());
 	}
 
+	@Override
 	public SubcontinentReferenceDto loadLocal(SubcontinentReferenceDto subcontinent) {
 		if (subcontinent == null) {
 			return null;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/subcontinent/SubcontinentService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/subcontinent/SubcontinentService.java
@@ -13,7 +13,7 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
 import de.symeda.sormas.api.infrastructure.subcontinent.SubcontinentCriteria;
-import de.symeda.sormas.backend.common.AbstractInfrastructureAdoService;
+import de.symeda.sormas.backend.infrastructure.abstrct.AbstractInfrastructureAdoService;
 import de.symeda.sormas.backend.common.CriteriaBuilderHelper;
 import de.symeda.sormas.backend.infrastructure.continent.Continent;
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/data/infra/InfrastructureValidator.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/data/infra/InfrastructureValidator.java
@@ -1,6 +1,5 @@
 package de.symeda.sormas.backend.sormastosormas.data.infra;
 
-
 import de.symeda.sormas.api.caze.CaseDataDto;
 import de.symeda.sormas.api.infrastructure.facility.FacilityDto;
 import de.symeda.sormas.api.infrastructure.facility.FacilityReferenceDto;
@@ -42,464 +41,365 @@ import java.util.function.Consumer;
 @Stateless
 @LocalBean
 public class InfrastructureValidator {
-    @EJB
-    private UserService userService;
-    @EJB
-    private ContinentFacadeEjb.ContinentFacadeEjbLocal continentFacade;
-    @EJB
-    private SubcontinentFacadeEjb.SubcontinentFacadeEjbLocal subcontinentFacade;
-    @EJB
-    private RegionFacadeEjb.RegionFacadeEjbLocal regionFacade;
-    @EJB
-    private DistrictFacadeEjb.DistrictFacadeEjbLocal districtFacade;
-    @EJB
-    private CommunityFacadeEjb.CommunityFacadeEjbLocal communityFacade;
-    @EJB
-    private FacilityFacadeEjb.FacilityFacadeEjbLocal facilityFacade;
-    @EJB
-    private PointOfEntryFacadeEjb.PointOfEntryFacadeEjbLocal pointOfEntryFacade;
-    @EJB
-    private CountryFacadeEjb.CountryFacadeEjbLocal countryFacade;
-    @EJB
-    private SampleFacadeEjb.SampleFacadeEjbLocal sampleFacade;
-
-
-
-// todo this appears to be leaky as it is used in event processor etc as well
-
-
-    private ContinentReferenceDto loadLocalContinent(ContinentReferenceDto continent) {
-        if (continent == null) {
-            return null;
-        }
-        Optional<ContinentReferenceDto> localContinent = continent.getExternalId() != null
-                ? continentFacade.getByExternalId(continent.getExternalId(), false).stream().findFirst()
-                : Optional.empty();
-        if (!localContinent.isPresent()) {
-            localContinent = continentFacade.getReferencesByName(continent.getCaption(), false).stream().findFirst();
-        }
-
-        return localContinent.orElse(null);
-    }
-
-    private SubcontinentReferenceDto loadLocalSubcontinent(SubcontinentReferenceDto subcontinent) {
-        if (subcontinent == null) {
-            return null;
-        }
-        Optional<SubcontinentReferenceDto> localSubcontinent = subcontinent.getExternalId() != null
-                ? subcontinentFacade.getByExternalId(subcontinent.getExternalId(), false).stream().findFirst()
-                : Optional.empty();
-        if (!localSubcontinent.isPresent()) {
-            localSubcontinent = subcontinentFacade.getReferencesByName(subcontinent.getCaption(), false).stream().findFirst();
-        }
-
-        return localSubcontinent.orElse(null);
-    }
-
-    public CountryReferenceDto loadLocalCountry(CountryReferenceDto country) {
-        if (country == null) {
-            return null;
-        }
-
-        Optional<CountryReferenceDto> localCountry =
-                country.getExternalId() != null ? countryFacade.getByExternalId(country.getExternalId(), false).stream().findFirst() : Optional.empty();
-
-        if (!localCountry.isPresent()) {
-            localCountry = Optional.ofNullable(countryFacade.getByIsoCode(country.getIsoCode(), false)).map(CountryFacadeEjb::toReferenceDto);
-        }
-
-        if (!localCountry.isPresent()) {
-            localCountry = countryFacade.getReferencesByName(country.getCaption(), false).stream().findFirst();
-        }
-
-        return localCountry.orElse(null);
-    }
-
-    private RegionReferenceDto loadLocalRegion(RegionReferenceDto region) {
-        if (region == null) {
-            return null;
-        }
-
-        Optional<RegionReferenceDto> localRegion =
-                region.getExternalId() != null ? regionFacade.getByExternalId(region.getExternalId(), false).stream().findFirst() : Optional.empty();
-
-        if (!localRegion.isPresent()) {
-            localRegion = regionFacade.getReferencesByName(region.getCaption(), false).stream().findFirst();
-        }
-
-        return localRegion.orElse(null);
-    }
-
-    private DistrictReferenceDto loadLocalDistrict(DistrictReferenceDto district) {
-        if (district == null) {
-            return null;
-        }
-
-        Optional<DistrictReferenceDto> localDistrict = district.getExternalId() != null
-                ? districtFacade.getByExternalId(district.getExternalId(), false).stream().findFirst()
-                : Optional.empty();
-
-        if (!localDistrict.isPresent()) {
-            localDistrict = districtFacade.getByName(district.getCaption(), null, false).stream().findFirst();
-        }
-
-        return localDistrict.orElse(null);
-    }
-
-    private CommunityReferenceDto loadLocalCommunity(CommunityReferenceDto community) {
-        if (community == null) {
-            return null;
-        }
-
-        Optional<CommunityReferenceDto> localCommunity = community.getExternalId() != null
-                ? communityFacade.getByExternalId(community.getExternalId(), false).stream().findFirst()
-                : Optional.empty();
-
-        if (!localCommunity.isPresent()) {
-            localCommunity = communityFacade.getByName(community.getCaption(), null, false).stream().findFirst();
-        }
-
-        return localCommunity.orElse(null);
-    }
-
-    private InfrastructureValidator.WithDetails<FacilityReferenceDto> loadLocalFacility(FacilityReferenceDto facility, FacilityType facilityType, String facilityDetails) {
-        String facilityUuid = facility.getUuid();
-
-        if (FacilityDto.CONSTANT_FACILITY_UUIDS.contains(facilityUuid)) {
-
-            FacilityReferenceDto localFacility = facilityDetails != null
-                    ? facilityFacade.getByNameAndType(facilityDetails.trim(), null, null, facilityType, false).stream().findFirst().orElse(null)
-                    : null;
-            if (localFacility == null) {
-                localFacility = facilityFacade.getByUuid(facilityUuid).toReference();
-            } else {
-                facilityDetails = null;
-            }
-
-            return WithDetails.of(localFacility, facilityDetails);
-        } else {
-            Optional<FacilityReferenceDto> localFacility = facility.getExternalId() != null
-                    ? facilityFacade.getByExternalIdAndType(facility.getExternalId(), facilityType, false).stream().findFirst()
-                    : Optional.empty();
-
-            if (!localFacility.isPresent()) {
-                localFacility = facilityFacade.getByNameAndType(facility.getCaption(), null, null, facilityType, false).stream().findFirst();
-            }
-
-            final String details;
-            if (!localFacility.isPresent()) {
-                details = facility.getCaption();
-                localFacility = Optional.of(facilityFacade.getByUuid(FacilityDto.OTHER_FACILITY_UUID).toReference());
-            } else {
-                details = facilityDetails;
-            }
-
-            return localFacility.map((f) -> WithDetails.of(f, details)).orElse(null);
-        }
-    }
-
-    private WithDetails<PointOfEntryReferenceDto> loadLocalPointOfEntry(PointOfEntryReferenceDto pointOfEntry, String pointOfEntryDetails) {
-        String pointOfEntryUuid = pointOfEntry.getUuid();
-
-        if (PointOfEntryDto.CONSTANT_POE_UUIDS.contains(pointOfEntryUuid)) {
-            PointOfEntryReferenceDto localPointOfEntry = pointOfEntryDetails != null
-                    ? pointOfEntryFacade.getByName(pointOfEntryDetails.trim(), null, false).stream().findFirst().orElse(null)
-                    : null;
-            if (localPointOfEntry == null) {
-                localPointOfEntry = pointOfEntryFacade.getByUuid(pointOfEntryUuid).toReference();
-            } else {
-                pointOfEntryDetails = null;
-            }
-
-            return WithDetails.of(localPointOfEntry, pointOfEntryDetails);
-        } else {
-
-            Optional<PointOfEntryReferenceDto> localPointOfEntry = pointOfEntry.getExternalId() != null
-                    ? pointOfEntryFacade.getByExternalId(pointOfEntry.getExternalId(), false).stream().findFirst()
-                    : Optional.empty();
-
-            if (!localPointOfEntry.isPresent()) {
-                localPointOfEntry = pointOfEntryFacade.getByName(pointOfEntry.getCaption(), null, false).stream().findFirst();
-            }
-
-            final String details;
-            if (!localPointOfEntry.isPresent()) {
-                details = pointOfEntry.getCaption();
-                localPointOfEntry = Optional
-                        .of(pointOfEntryFacade.getByUuid(PointOfEntryDto.getOtherPointOfEntryUuid(pointOfEntry.getPointOfEntryType())).toReference());
-            } else {
-                details = pointOfEntryDetails;
-            }
-
-            return localPointOfEntry.map(p -> WithDetails.of(p, details)).orElse(null);
-        }
-    }
-
-
-
-    public DataHelper.Pair<InfrastructureValidator.InfrastructureData, List<ValidationErrorMessage>> loadLocalInfrastructure(
-            RegionReferenceDto region,
-            DistrictReferenceDto district,
-            CommunityReferenceDto community) {
-        return loadLocalInfrastructure(region, district, community, null, null, null, null, null);
-    }
-
-    public DataHelper.Pair<InfrastructureValidator.InfrastructureData, List<ValidationErrorMessage>> loadLocalInfrastructure(CaseDataDto caze) {
-        DataHelper.Pair<InfrastructureValidator.InfrastructureData, List<ValidationErrorMessage>> infrastructureAndErrors = loadLocalInfrastructure(
-                caze.getRegion(),
-                caze.getDistrict(),
-                caze.getCommunity(),
-                caze.getFacilityType(),
-                caze.getHealthFacility(),
-                caze.getHealthFacilityDetails(),
-                caze.getPointOfEntry(),
-                caze.getPointOfEntryDetails());
-
-        InfrastructureValidator.InfrastructureData infrastructureData = infrastructureAndErrors.getElement0();
-        List<ValidationErrorMessage> unmatchedFields = infrastructureAndErrors.getElement1();
-
-        RegionReferenceDto responsibleRegion = caze.getResponsibleRegion();
-        infrastructureData.responsibleRegion = loadLocalRegion(responsibleRegion);
-        if (responsibleRegion != null && infrastructureData.responsibleRegion == null) {
-            unmatchedFields.add(new ValidationErrorMessage(Validations.sormasToSormasResponsibleRegion, responsibleRegion.getCaption()));
-        }
-
-        DistrictReferenceDto responsibleDistrict = caze.getResponsibleDistrict();
-        infrastructureData.responsibleDistrict = loadLocalDistrict(responsibleDistrict);
-        if (responsibleDistrict != null && infrastructureData.responsibleDistrict == null) {
-            unmatchedFields.add(new ValidationErrorMessage(Validations.sormasToSormasResponsibleDistrict, responsibleDistrict.getCaption()));
-        }
-
-        CommunityReferenceDto responsibleCommunity = caze.getResponsibleCommunity();
-        infrastructureData.responsibleCommunity = loadLocalCommunity(responsibleCommunity);
-        if (responsibleCommunity != null && infrastructureData.responsibleCommunity == null) {
-            unmatchedFields.add(new ValidationErrorMessage(Validations.sormasToSormasResponsibleCommunity, responsibleCommunity.getCaption()));
-        }
-
-        return infrastructureAndErrors;
-    }
-
-    public DataHelper.Pair<InfrastructureValidator.InfrastructureData, List<ValidationErrorMessage>> loadLocalInfrastructure(
-            RegionReferenceDto region,
-            DistrictReferenceDto district,
-            CommunityReferenceDto community,
-            FacilityType facilityType,
-            FacilityReferenceDto facility,
-            String facilityDetails,
-            PointOfEntryReferenceDto pointOfEntry,
-            String pointOfEntryDetails) {
-        return loadLocalInfrastructure(
-                null,
-                null,
-                null,
-                region,
-                district,
-                community,
-                facilityType,
-                facility,
-                facilityDetails,
-                pointOfEntry,
-                pointOfEntryDetails);
-    }
-
-    public DataHelper.Pair<InfrastructureValidator.InfrastructureData, List<ValidationErrorMessage>> loadLocalInfrastructure(
-            ContinentReferenceDto continent,
-            SubcontinentReferenceDto subcontinent,
-            CountryReferenceDto country,
-            RegionReferenceDto region,
-            DistrictReferenceDto district,
-            CommunityReferenceDto community,
-            FacilityType facilityType,
-            FacilityReferenceDto facility,
-            String facilityDetails,
-            PointOfEntryReferenceDto pointOfEntry,
-            String pointOfEntryDetails) {
-
-        InfrastructureValidator.InfrastructureData infrastructureData = new InfrastructureValidator.InfrastructureData();
-        List<ValidationErrorMessage> unmatchedFields = new ArrayList<>();
-
-        infrastructureData.continent = loadLocalContinent(continent);
-        if (continent != null && infrastructureData.continent == null) {
-            unmatchedFields.add(new ValidationErrorMessage(Validations.sormasToSormasContinent, Captions.continent, continent.getCaption()));
-        }
-
-        infrastructureData.subcontinent = loadLocalSubcontinent(subcontinent);
-        if (subcontinent != null && infrastructureData.subcontinent == null) {
-            unmatchedFields.add(new ValidationErrorMessage(Validations.sormasToSormasSubcontinent, subcontinent.getCaption()));
-        }
-
-        infrastructureData.country = loadLocalCountry(country);
-        if (country != null && infrastructureData.country == null) {
-            unmatchedFields.add(new ValidationErrorMessage(Validations.sormasToSormasCountry, country.getCaption()));
-        }
-
-        infrastructureData.region = loadLocalRegion(region);
-        if (region != null && infrastructureData.region == null) {
-            unmatchedFields.add(new ValidationErrorMessage(Validations.sormasToSormasRegion, region.getCaption()));
-        }
-
-        infrastructureData.district = loadLocalDistrict(district);
-        if (district != null && infrastructureData.district == null) {
-            unmatchedFields.add(new ValidationErrorMessage(Validations.sormasToSormasDistrict, district.getCaption()));
-        }
-
-        infrastructureData.community = loadLocalCommunity(community);
-        if (community != null && infrastructureData.community == null) {
-            unmatchedFields.add(new ValidationErrorMessage(Validations.sormasToSormasCommunity, community.getCaption()));
-        }
-
-        if (facility != null) {
-            InfrastructureValidator.WithDetails<FacilityReferenceDto> localFacility = loadLocalFacility(facility, facilityType, facilityDetails);
-
-            if (localFacility.entity == null) {
-                unmatchedFields.add(new ValidationErrorMessage(Validations.sormasToSormasFacility, facility.getCaption()));
-            } else {
-                infrastructureData.facility = localFacility.entity;
-                infrastructureData.facilityDetails = localFacility.details;
-            }
-        }
-
-        if (pointOfEntry != null) {
-            InfrastructureValidator.WithDetails<PointOfEntryReferenceDto> localPointOfEntry = loadLocalPointOfEntry(pointOfEntry, pointOfEntryDetails);
-
-            if (localPointOfEntry.entity == null) {
-                unmatchedFields.add(new ValidationErrorMessage(Validations.sormasToSormasPointOfEntry, pointOfEntry.getCaption()));
-            } else {
-                infrastructureData.pointOfEntry = localPointOfEntry.entity;
-                infrastructureData.pointOfEntryDetails = localPointOfEntry.details;
-            }
-        }
-
-        return new DataHelper.Pair<>(infrastructureData, unmatchedFields);
-    }
-
-    public void handleInfraStructure(
-            DataHelper.Pair<InfrastructureValidator.InfrastructureData, List<ValidationErrorMessage>> infrastructureAndErrors,
-            String groupNameTag,
-            ValidationErrors validationErrors,
-            Consumer<InfrastructureValidator.InfrastructureData> onNoErrors) {
-
-        List<ValidationErrorMessage> errors = infrastructureAndErrors.getElement1();
-        if (errors.size() > 0) {
-            for(ValidationErrorMessage error: errors) {
-                validationErrors.add(new ValidationErrorGroup(groupNameTag), error);
-            }
-        } else {
-            onNoErrors.accept(infrastructureAndErrors.getElement0());
-        }
-
-
-
-    }
-
-    public void processLocation(LocationDto address, String groupNameTag, ValidationErrors validationErrors) {
-        DataHelper.Pair<InfrastructureData, List<ValidationErrorMessage>> infrastructureAndErrors = loadLocalInfrastructure(
-                address.getContinent(),
-                address.getSubcontinent(),
-                address.getCountry(),
-                address.getRegion(),
-                address.getDistrict(),
-                address.getCommunity(),
-                address.getFacilityType(),
-                address.getFacility(),
-                address.getFacilityDetails(),
-                null,
-                null);
-
-        handleInfraStructure(infrastructureAndErrors, groupNameTag, validationErrors, (infrastructure -> {
-            address.setContinent(infrastructure.getContinent());
-            address.setSubcontinent(infrastructure.getSubcontinent());
-            address.setCountry(infrastructure.getCountry());
-            address.setRegion(infrastructure.region);
-            address.setDistrict(infrastructure.district);
-            address.setCommunity(infrastructure.community);
-            address.setFacility(infrastructure.facility);
-            address.setFacilityDetails(infrastructure.facilityDetails);
-        }));
-    }
-
-
-    public static class InfrastructureData {
-
-        private ContinentReferenceDto continent;
-        private SubcontinentReferenceDto subcontinent;
-        private CountryReferenceDto country;
-        private RegionReferenceDto responsibleRegion;
-        private DistrictReferenceDto responsibleDistrict;
-        private CommunityReferenceDto responsibleCommunity;
-        private RegionReferenceDto region;
-        private DistrictReferenceDto district;
-        private CommunityReferenceDto community;
-        private FacilityReferenceDto facility;
-        private String facilityDetails;
-        private PointOfEntryReferenceDto pointOfEntry;
-        private String pointOfEntryDetails;
-
-        public ContinentReferenceDto getContinent() {
-            return continent;
-        }
-
-        public SubcontinentReferenceDto getSubcontinent() {
-            return subcontinent;
-        }
-
-        public CountryReferenceDto getCountry() {
-            return country;
-        }
-
-        public RegionReferenceDto getResponsibleRegion() {
-            return responsibleRegion;
-        }
-
-        public DistrictReferenceDto getResponsibleDistrict() {
-            return responsibleDistrict;
-        }
-
-        public CommunityReferenceDto getResponsibleCommunity() {
-            return responsibleCommunity;
-        }
-
-        public RegionReferenceDto getRegion() {
-            return region;
-        }
-
-        public DistrictReferenceDto getDistrict() {
-            return district;
-        }
-
-        public CommunityReferenceDto getCommunity() {
-            return community;
-        }
-
-        public FacilityReferenceDto getFacility() {
-            return facility;
-        }
-
-        public String getFacilityDetails() {
-            return facilityDetails;
-        }
-
-        public PointOfEntryReferenceDto getPointOfEntry() {
-            return pointOfEntry;
-        }
-
-        public String getPointOfEntryDetails() {
-            return pointOfEntryDetails;
-        }
-    }
-
-    private static final class WithDetails<T> {
-
-        private T entity;
-        private String details;
-
-        public static <T> WithDetails<T> of(T facility, String facilityDetails) {
-            WithDetails<T> localFacility = new WithDetails<>();
-
-            localFacility.entity = facility;
-            localFacility.details = facilityDetails;
-
-            return localFacility;
-        }
-    }
+
+	@EJB
+	private UserService userService;
+	@EJB
+	private ContinentFacadeEjb.ContinentFacadeEjbLocal continentFacade;
+	@EJB
+	private SubcontinentFacadeEjb.SubcontinentFacadeEjbLocal subcontinentFacade;
+	@EJB
+	private RegionFacadeEjb.RegionFacadeEjbLocal regionFacade;
+	@EJB
+	private DistrictFacadeEjb.DistrictFacadeEjbLocal districtFacade;
+	@EJB
+	private CommunityFacadeEjb.CommunityFacadeEjbLocal communityFacade;
+	@EJB
+	private FacilityFacadeEjb.FacilityFacadeEjbLocal facilityFacade;
+	@EJB
+	private PointOfEntryFacadeEjb.PointOfEntryFacadeEjbLocal pointOfEntryFacade;
+	@EJB
+	private CountryFacadeEjb.CountryFacadeEjbLocal countryFacade;
+	@EJB
+	private SampleFacadeEjb.SampleFacadeEjbLocal sampleFacade;
+
+	private WithDetails<PointOfEntryReferenceDto> loadLocalPointOfEntry(PointOfEntryReferenceDto pointOfEntry, String pointOfEntryDetails) {
+		String pointOfEntryUuid = pointOfEntry.getUuid();
+
+		if (PointOfEntryDto.CONSTANT_POE_UUIDS.contains(pointOfEntryUuid)) {
+			PointOfEntryReferenceDto localPointOfEntry = pointOfEntryDetails != null
+				? pointOfEntryFacade.getByName(pointOfEntryDetails.trim(), null, false).stream().findFirst().orElse(null)
+				: null;
+			if (localPointOfEntry == null) {
+				localPointOfEntry = pointOfEntryFacade.getByUuid(pointOfEntryUuid).toReference();
+			} else {
+				pointOfEntryDetails = null;
+			}
+
+			return WithDetails.of(localPointOfEntry, pointOfEntryDetails);
+		} else {
+
+			Optional<PointOfEntryReferenceDto> localPointOfEntry = pointOfEntry.getExternalId() != null
+				? pointOfEntryFacade.getByExternalId(pointOfEntry.getExternalId(), false).stream().findFirst()
+				: Optional.empty();
+
+			if (!localPointOfEntry.isPresent()) {
+				localPointOfEntry = pointOfEntryFacade.getByName(pointOfEntry.getCaption(), null, false).stream().findFirst();
+			}
+
+			final String details;
+			if (!localPointOfEntry.isPresent()) {
+				details = pointOfEntry.getCaption();
+				localPointOfEntry = Optional
+					.of(pointOfEntryFacade.getByUuid(PointOfEntryDto.getOtherPointOfEntryUuid(pointOfEntry.getPointOfEntryType())).toReference());
+			} else {
+				details = pointOfEntryDetails;
+			}
+
+			return localPointOfEntry.map(p -> WithDetails.of(p, details)).orElse(null);
+		}
+	}
+
+	private InfrastructureValidator.WithDetails<FacilityReferenceDto> loadLocalFacility(
+		FacilityReferenceDto facility,
+		FacilityType facilityType,
+		String facilityDetails) {
+		String facilityUuid = facility.getUuid();
+
+		if (FacilityDto.CONSTANT_FACILITY_UUIDS.contains(facilityUuid)) {
+
+			FacilityReferenceDto localFacility = facilityDetails != null
+				? facilityFacade.getByNameAndType(facilityDetails.trim(), null, null, facilityType, false).stream().findFirst().orElse(null)
+				: null;
+			if (localFacility == null) {
+				localFacility = facilityFacade.getByUuid(facilityUuid).toReference();
+			} else {
+				facilityDetails = null;
+			}
+
+			return WithDetails.of(localFacility, facilityDetails);
+		} else {
+			Optional<FacilityReferenceDto> localFacility = facility.getExternalId() != null
+				? facilityFacade.getByExternalIdAndType(facility.getExternalId(), facilityType, false).stream().findFirst()
+				: Optional.empty();
+
+			if (!localFacility.isPresent()) {
+				localFacility = facilityFacade.getByNameAndType(facility.getCaption(), null, null, facilityType, false).stream().findFirst();
+			}
+
+			final String details;
+			if (!localFacility.isPresent()) {
+				details = facility.getCaption();
+				localFacility = Optional.of(facilityFacade.getByUuid(FacilityDto.OTHER_FACILITY_UUID).toReference());
+			} else {
+				details = facilityDetails;
+			}
+
+			return localFacility.map((f) -> WithDetails.of(f, details)).orElse(null);
+		}
+	}
+
+	public DataHelper.Pair<InfrastructureValidator.InfrastructureData, List<ValidationErrorMessage>> loadLocalInfrastructure(
+		RegionReferenceDto region,
+		DistrictReferenceDto district,
+		CommunityReferenceDto community) {
+		return loadLocalInfrastructure(region, district, community, null, null, null, null, null);
+	}
+
+	public DataHelper.Pair<InfrastructureValidator.InfrastructureData, List<ValidationErrorMessage>> loadLocalInfrastructure(CaseDataDto caze) {
+		DataHelper.Pair<InfrastructureValidator.InfrastructureData, List<ValidationErrorMessage>> infrastructureAndErrors = loadLocalInfrastructure(
+			caze.getRegion(),
+			caze.getDistrict(),
+			caze.getCommunity(),
+			caze.getFacilityType(),
+			caze.getHealthFacility(),
+			caze.getHealthFacilityDetails(),
+			caze.getPointOfEntry(),
+			caze.getPointOfEntryDetails());
+
+		InfrastructureValidator.InfrastructureData infrastructureData = infrastructureAndErrors.getElement0();
+		List<ValidationErrorMessage> unmatchedFields = infrastructureAndErrors.getElement1();
+
+		RegionReferenceDto responsibleRegion = caze.getResponsibleRegion();
+		infrastructureData.responsibleRegion = regionFacade.loadLocal(responsibleRegion);
+		if (responsibleRegion != null && infrastructureData.responsibleRegion == null) {
+			unmatchedFields.add(new ValidationErrorMessage(Validations.sormasToSormasResponsibleRegion, responsibleRegion.getCaption()));
+		}
+
+		DistrictReferenceDto responsibleDistrict = caze.getResponsibleDistrict();
+		infrastructureData.responsibleDistrict = districtFacade.loadLocal(responsibleDistrict);
+		if (responsibleDistrict != null && infrastructureData.responsibleDistrict == null) {
+			unmatchedFields.add(new ValidationErrorMessage(Validations.sormasToSormasResponsibleDistrict, responsibleDistrict.getCaption()));
+		}
+
+		CommunityReferenceDto responsibleCommunity = caze.getResponsibleCommunity();
+		infrastructureData.responsibleCommunity = communityFacade.loadLocal(responsibleCommunity);
+		if (responsibleCommunity != null && infrastructureData.responsibleCommunity == null) {
+			unmatchedFields.add(new ValidationErrorMessage(Validations.sormasToSormasResponsibleCommunity, responsibleCommunity.getCaption()));
+		}
+
+		return infrastructureAndErrors;
+	}
+
+	public DataHelper.Pair<InfrastructureValidator.InfrastructureData, List<ValidationErrorMessage>> loadLocalInfrastructure(
+		RegionReferenceDto region,
+		DistrictReferenceDto district,
+		CommunityReferenceDto community,
+		FacilityType facilityType,
+		FacilityReferenceDto facility,
+		String facilityDetails,
+		PointOfEntryReferenceDto pointOfEntry,
+		String pointOfEntryDetails) {
+		return loadLocalInfrastructure(
+			null,
+			null,
+			null,
+			region,
+			district,
+			community,
+			facilityType,
+			facility,
+			facilityDetails,
+			pointOfEntry,
+			pointOfEntryDetails);
+	}
+
+	public DataHelper.Pair<InfrastructureValidator.InfrastructureData, List<ValidationErrorMessage>> loadLocalInfrastructure(
+		ContinentReferenceDto continent,
+		SubcontinentReferenceDto subcontinent,
+		CountryReferenceDto country,
+		RegionReferenceDto region,
+		DistrictReferenceDto district,
+		CommunityReferenceDto community,
+		FacilityType facilityType,
+		FacilityReferenceDto facility,
+		String facilityDetails,
+		PointOfEntryReferenceDto pointOfEntry,
+		String pointOfEntryDetails) {
+
+		InfrastructureValidator.InfrastructureData infrastructureData = new InfrastructureValidator.InfrastructureData();
+		List<ValidationErrorMessage> unmatchedFields = new ArrayList<>();
+
+		infrastructureData.continent = continentFacade.loadLocal(continent);
+		if (continent != null && infrastructureData.continent == null) {
+			unmatchedFields.add(new ValidationErrorMessage(Validations.sormasToSormasContinent, Captions.continent, continent.getCaption()));
+		}
+
+		infrastructureData.subcontinent = subcontinentFacade.loadLocal(subcontinent);
+		if (subcontinent != null && infrastructureData.subcontinent == null) {
+			unmatchedFields.add(new ValidationErrorMessage(Validations.sormasToSormasSubcontinent, subcontinent.getCaption()));
+		}
+
+		infrastructureData.country = countryFacade.loadLocal(country);
+		if (country != null && infrastructureData.country == null) {
+			unmatchedFields.add(new ValidationErrorMessage(Validations.sormasToSormasCountry, country.getCaption()));
+		}
+
+		infrastructureData.region = regionFacade.loadLocal(region);
+		if (region != null && infrastructureData.region == null) {
+			unmatchedFields.add(new ValidationErrorMessage(Validations.sormasToSormasRegion, region.getCaption()));
+		}
+
+		infrastructureData.district = districtFacade.loadLocal(district);
+		if (district != null && infrastructureData.district == null) {
+			unmatchedFields.add(new ValidationErrorMessage(Validations.sormasToSormasDistrict, district.getCaption()));
+		}
+
+		infrastructureData.community = communityFacade.loadLocal(community);
+		if (community != null && infrastructureData.community == null) {
+			unmatchedFields.add(new ValidationErrorMessage(Validations.sormasToSormasCommunity, community.getCaption()));
+		}
+
+		if (facility != null) {
+			InfrastructureValidator.WithDetails<FacilityReferenceDto> localFacility = loadLocalFacility(facility, facilityType, facilityDetails);
+
+			if (localFacility.entity == null) {
+				unmatchedFields.add(new ValidationErrorMessage(Validations.sormasToSormasFacility, facility.getCaption()));
+			} else {
+				infrastructureData.facility = localFacility.entity;
+				infrastructureData.facilityDetails = localFacility.details;
+			}
+		}
+
+		if (pointOfEntry != null) {
+			InfrastructureValidator.WithDetails<PointOfEntryReferenceDto> localPointOfEntry =
+				loadLocalPointOfEntry(pointOfEntry, pointOfEntryDetails);
+
+			if (localPointOfEntry.entity == null) {
+				unmatchedFields.add(new ValidationErrorMessage(Validations.sormasToSormasPointOfEntry, pointOfEntry.getCaption()));
+			} else {
+				infrastructureData.pointOfEntry = localPointOfEntry.entity;
+				infrastructureData.pointOfEntryDetails = localPointOfEntry.details;
+			}
+		}
+
+		return new DataHelper.Pair<>(infrastructureData, unmatchedFields);
+	}
+
+	public void handleInfraStructure(
+		DataHelper.Pair<InfrastructureValidator.InfrastructureData, List<ValidationErrorMessage>> infrastructureAndErrors,
+		String groupNameTag,
+		ValidationErrors validationErrors,
+		Consumer<InfrastructureValidator.InfrastructureData> onNoErrors) {
+
+		List<ValidationErrorMessage> errors = infrastructureAndErrors.getElement1();
+		if (errors.size() > 0) {
+			for (ValidationErrorMessage error : errors) {
+				validationErrors.add(new ValidationErrorGroup(groupNameTag), error);
+			}
+		} else {
+			onNoErrors.accept(infrastructureAndErrors.getElement0());
+		}
+
+	}
+
+	public void processLocation(LocationDto address, String groupNameTag, ValidationErrors validationErrors) {
+		DataHelper.Pair<InfrastructureData, List<ValidationErrorMessage>> infrastructureAndErrors = loadLocalInfrastructure(
+			address.getContinent(),
+			address.getSubcontinent(),
+			address.getCountry(),
+			address.getRegion(),
+			address.getDistrict(),
+			address.getCommunity(),
+			address.getFacilityType(),
+			address.getFacility(),
+			address.getFacilityDetails(),
+			null,
+			null);
+
+		handleInfraStructure(infrastructureAndErrors, groupNameTag, validationErrors, (infrastructure -> {
+			address.setContinent(infrastructure.getContinent());
+			address.setSubcontinent(infrastructure.getSubcontinent());
+			address.setCountry(infrastructure.getCountry());
+			address.setRegion(infrastructure.region);
+			address.setDistrict(infrastructure.district);
+			address.setCommunity(infrastructure.community);
+			address.setFacility(infrastructure.facility);
+			address.setFacilityDetails(infrastructure.facilityDetails);
+		}));
+	}
+
+	public static class InfrastructureData {
+
+		private ContinentReferenceDto continent;
+		private SubcontinentReferenceDto subcontinent;
+		private CountryReferenceDto country;
+		private RegionReferenceDto responsibleRegion;
+		private DistrictReferenceDto responsibleDistrict;
+		private CommunityReferenceDto responsibleCommunity;
+		private RegionReferenceDto region;
+		private DistrictReferenceDto district;
+		private CommunityReferenceDto community;
+		private FacilityReferenceDto facility;
+		private String facilityDetails;
+		private PointOfEntryReferenceDto pointOfEntry;
+		private String pointOfEntryDetails;
+
+		public ContinentReferenceDto getContinent() {
+			return continent;
+		}
+
+		public SubcontinentReferenceDto getSubcontinent() {
+			return subcontinent;
+		}
+
+		public CountryReferenceDto getCountry() {
+			return country;
+		}
+
+		public RegionReferenceDto getResponsibleRegion() {
+			return responsibleRegion;
+		}
+
+		public DistrictReferenceDto getResponsibleDistrict() {
+			return responsibleDistrict;
+		}
+
+		public CommunityReferenceDto getResponsibleCommunity() {
+			return responsibleCommunity;
+		}
+
+		public RegionReferenceDto getRegion() {
+			return region;
+		}
+
+		public DistrictReferenceDto getDistrict() {
+			return district;
+		}
+
+		public CommunityReferenceDto getCommunity() {
+			return community;
+		}
+
+		public FacilityReferenceDto getFacility() {
+			return facility;
+		}
+
+		public String getFacilityDetails() {
+			return facilityDetails;
+		}
+
+		public PointOfEntryReferenceDto getPointOfEntry() {
+			return pointOfEntry;
+		}
+
+		public String getPointOfEntryDetails() {
+			return pointOfEntryDetails;
+		}
+	}
+
+	private static final class WithDetails<T> {
+
+		private T entity;
+		private String details;
+
+		public static <T> WithDetails<T> of(T facility, String facilityDetails) {
+			WithDetails<T> localFacility = new WithDetails<>();
+
+			localFacility.entity = facility;
+			localFacility.details = facilityDetails;
+
+			return localFacility;
+		}
+	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/data/received/ReceivedDataProcessorHelper.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/data/received/ReceivedDataProcessorHelper.java
@@ -86,7 +86,7 @@ public class ReceivedDataProcessorHelper {
 	private SampleFacadeEjbLocal sampleFacade;
 	@EJB
 	private InfrastructureValidator infraValidator;
-	
+
 	public ValidationErrors processOriginInfo(SormasToSormasOriginInfoDto originInfo, String validationGroupCaption) {
 		if (originInfo == null) {
 			return ValidationErrors
@@ -140,7 +140,7 @@ public class ReceivedDataProcessorHelper {
 	}
 
 	private CountryReferenceDto processCountry(CountryReferenceDto country, String errorCaption, ValidationErrors validationErrors) {
-		CountryReferenceDto localCountry = infraValidator.loadLocalCountry(country);
+		CountryReferenceDto localCountry = countryFacade.loadLocal(country);
 		if (country != null && localCountry == null) {
 			validationErrors
 				.add(new ValidationErrorGroup(errorCaption), new ValidationErrorMessage(Validations.sormasToSormasCountry, country.getCaption()));
@@ -163,7 +163,7 @@ public class ReceivedDataProcessorHelper {
 			updateReportingUser(sample, existingSamplesMap.get(sample.getUuid()));
 
 			DataHelper.Pair<InfrastructureValidator.InfrastructureData, List<ValidationErrorMessage>> infrastructureAndErrors =
-					infraValidator.loadLocalInfrastructure(null, null, null, null, sample.getLab(), sample.getLabDetails(), null, null);
+				infraValidator.loadLocalInfrastructure(null, null, null, null, sample.getLab(), sample.getLabDetails(), null, null);
 
 			infraValidator.handleInfraStructure(infrastructureAndErrors, Captions.Sample_lab, sampleErrors, (infrastructureData -> {
 				sample.setLab(infrastructureData.getFacility());
@@ -175,15 +175,16 @@ public class ReceivedDataProcessorHelper {
 			}
 
 			sormasToSormasSample.getPathogenTests().forEach(pathogenTest -> {
-				DataHelper.Pair<InfrastructureValidator.InfrastructureData, List<ValidationErrorMessage>> ptInfrastructureAndErrors = infraValidator.loadLocalInfrastructure(
-					null,
-					null,
-					null,
-					FacilityType.LABORATORY,
-					pathogenTest.getLab(),
-					pathogenTest.getLabDetails(),
-					null,
-					null);
+				DataHelper.Pair<InfrastructureValidator.InfrastructureData, List<ValidationErrorMessage>> ptInfrastructureAndErrors =
+					infraValidator.loadLocalInfrastructure(
+						null,
+						null,
+						null,
+						FacilityType.LABORATORY,
+						pathogenTest.getLab(),
+						pathogenTest.getLabDetails(),
+						null,
+						null);
 
 				ValidationErrors pathogenTestErrors = new ValidationErrors();
 				infraValidator.handleInfraStructure(ptInfrastructureAndErrors, Captions.PathogenTest_lab, pathogenTestErrors, (infrastructureData -> {
@@ -210,7 +211,7 @@ public class ReceivedDataProcessorHelper {
 		updateReportingUser(contact, existingContact);
 
 		DataHelper.Pair<InfrastructureValidator.InfrastructureData, List<ValidationErrorMessage>> infrastructureAndErrors =
-				infraValidator.loadLocalInfrastructure(contact.getRegion(), contact.getDistrict(), contact.getCommunity());
+			infraValidator.loadLocalInfrastructure(contact.getRegion(), contact.getDistrict(), contact.getCommunity());
 
 		infraValidator.handleInfraStructure(infrastructureAndErrors, Captions.Contact, validationErrors, (infrastructure -> {
 			contact.setRegion(infrastructure.getRegion());
@@ -227,7 +228,7 @@ public class ReceivedDataProcessorHelper {
 		ValidationErrors validationErrors = new ValidationErrors();
 
 		DataHelper.Pair<InfrastructureValidator.InfrastructureData, List<ValidationErrorMessage>> infrastructureAndErrors =
-				infraValidator.loadLocalInfrastructure(contact.getRegion(), contact.getDistrict(), contact.getCommunity());
+			infraValidator.loadLocalInfrastructure(contact.getRegion(), contact.getDistrict(), contact.getCommunity());
 
 		infraValidator.handleInfraStructure(infrastructureAndErrors, Captions.Contact, validationErrors, (infrastructure -> {
 			contact.setRegion(infrastructure.getRegion());


### PR DESCRIPTION
Fixes #6573 
No de-duplication yet, loading code is now mostly residing in the EJBs. 

It became obvious now that the geo location related entities (what we currently call _infrastructure_ and should be called geo-location) are different from point of entry and facility (what should be called _infrastructure_). Therefore, point of entry and facility do not extend `InfrastructureBaseFacase` anymore. `InfrastructureBaseFacase` has been renamed to `GeoInfrastructureBaseFacase`. When we take care of https://github.com/hzi-braunschweig/SORMAS-Project/issues/6511 this will make more sense.