### PR TITLE
[#6696] use constant UUIDs for region, district, community

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/utils/DataHelper.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/utils/DataHelper.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.UUID;
 
 import javax.annotation.Nullable;
 
@@ -64,6 +65,10 @@ public final class DataHelper {
 		byte[] bytes = longToBytes(randomUuid.getLeastSignificantBits(), randomUuid.getMostSignificantBits());
 		String uuid = Base32.encode(bytes, 6);
 		return uuid;
+	}
+
+	public static String createConstantUuid(int seed) {
+		return new UUID(0, seed).toString();
 	}
 
 	public static boolean isSame(HasUuid left, HasUuid right) {

--- a/sormas-api/src/main/java/de/symeda/sormas/api/utils/DefaultEntityHelper.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/utils/DefaultEntityHelper.java
@@ -61,7 +61,7 @@ public class DefaultEntityHelper {
 			POE_INF_USERNAME_AND_PASSWORD);
 	}
 
-	public enum Infrastructure {
+	public enum DefaultInfrastructureUuidSeed {
 		REGION,
 		DISTRICT,
 		COMMUNITY,

--- a/sormas-api/src/main/java/de/symeda/sormas/api/utils/DefaultEntityHelper.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/utils/DefaultEntityHelper.java
@@ -24,7 +24,7 @@ import java.util.Set;
 
 import de.symeda.sormas.api.user.UserDto;
 
-public class DefaultUserHelper {
+public class DefaultEntityHelper {
 
 	// default usernames and passwords
 	public static final DataHelper.Pair<String, String> ADMIN_USERNAME_AND_PASSWORD = new DataHelper.Pair<>("admin", "sadmin");
@@ -59,6 +59,14 @@ public class DefaultUserHelper {
 			HOSP_INF_USERNAME_AND_PASSWORD,
 			COMM_OFF_USERNAME_AND_PASSWORD,
 			POE_INF_USERNAME_AND_PASSWORD);
+	}
+
+	public enum Infrastructure {
+		REGION,
+		DISTRICT,
+		COMMUNITY,
+		FACILITY,
+		POINT_OF_ENTRY
 	}
 
 	public static boolean isDefaultUser(String username) {

--- a/sormas-api/src/test/java/de/symeda/sormas/api/utils/DefaultEntityHelperTest.java
+++ b/sormas-api/src/test/java/de/symeda/sormas/api/utils/DefaultEntityHelperTest.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 
 import de.symeda.sormas.api.user.UserDto;
 
-public class DefaultUserHelperTest {
+public class DefaultEntityHelperTest {
 
 	private static final String DEFAULT_ADMIN_USERNAME = "admin";
 	private static final String DEFAULT_ADMIN_PASS = "sadmin";
@@ -71,22 +71,22 @@ public class DefaultUserHelperTest {
 	@Test
 	public void testIsDefaultUser() {
 		for (String defaultUser : DEFAULT_USERS.keySet()) {
-			assertTrue(DefaultUserHelper.isDefaultUser(defaultUser));
+			assertTrue(DefaultEntityHelper.isDefaultUser(defaultUser));
 		}
 	}
 
 	@Test
 	public void testGetDefaultPassword() {
 		for (String defaultUser : DEFAULT_USERS.keySet()) {
-			assertEquals(DEFAULT_USERS.get(defaultUser), DefaultUserHelper.getDefaultPassword(defaultUser));
+			assertEquals(DEFAULT_USERS.get(defaultUser), DefaultEntityHelper.getDefaultPassword(defaultUser));
 		}
 	}
 
 	private void testUsesDefaultPasswordHelper(String username, String defaultPassword) {
 		String seed = UUID.randomUUID().toString();
 		String randomPass = UUID.randomUUID().toString();
-		assertTrue(DefaultUserHelper.usesDefaultPassword(username, PasswordHelper.encodePassword(defaultPassword, seed), seed));
-		assertFalse(DefaultUserHelper.usesDefaultPassword(username, PasswordHelper.encodePassword(randomPass, seed), seed));
+		assertTrue(DefaultEntityHelper.usesDefaultPassword(username, PasswordHelper.encodePassword(defaultPassword, seed), seed));
+		assertFalse(DefaultEntityHelper.usesDefaultPassword(username, PasswordHelper.encodePassword(randomPass, seed), seed));
 	}
 
 	@Test
@@ -105,10 +105,10 @@ public class DefaultUserHelperTest {
 		UserDto randomUser = new UserDto();
 		randomUser.setUserName(UUID.randomUUID().toString());
 
-		assertTrue(DefaultUserHelper.currentUserUsesDefaultPassword(defaultDtos, admin));
-		assertFalse(DefaultUserHelper.currentUserUsesDefaultPassword(defaultDtos, randomUser));
+		assertTrue(DefaultEntityHelper.currentUserUsesDefaultPassword(defaultDtos, admin));
+		assertFalse(DefaultEntityHelper.currentUserUsesDefaultPassword(defaultDtos, randomUser));
 		defaultDtos.remove(admin);
-		assertFalse(DefaultUserHelper.currentUserUsesDefaultPassword(defaultDtos, admin));
+		assertFalse(DefaultEntityHelper.currentUserUsesDefaultPassword(defaultDtos, admin));
 	}
 
 	@Test
@@ -120,18 +120,18 @@ public class DefaultUserHelperTest {
 		UserDto randomUser = new UserDto();
 		randomUser.setUserName(UUID.randomUUID().toString());
 
-		assertTrue(DefaultUserHelper.otherUsersUseDefaultPassword(defaultDtos, randomUser));
-		assertFalse(DefaultUserHelper.otherUsersUseDefaultPassword(defaultDtos, admin));
+		assertTrue(DefaultEntityHelper.otherUsersUseDefaultPassword(defaultDtos, randomUser));
+		assertFalse(DefaultEntityHelper.otherUsersUseDefaultPassword(defaultDtos, admin));
 		defaultDtos.add(randomUser);
-		assertTrue(DefaultUserHelper.otherUsersUseDefaultPassword(defaultDtos, admin));
-		assertTrue(DefaultUserHelper.otherUsersUseDefaultPassword(defaultDtos, randomUser));
-		assertFalse(DefaultUserHelper.otherUsersUseDefaultPassword(new ArrayList<UserDto>(), admin));
+		assertTrue(DefaultEntityHelper.otherUsersUseDefaultPassword(defaultDtos, admin));
+		assertTrue(DefaultEntityHelper.otherUsersUseDefaultPassword(defaultDtos, randomUser));
+		assertFalse(DefaultEntityHelper.otherUsersUseDefaultPassword(new ArrayList<UserDto>(), admin));
 	}
 
 	@Test
 	public void getDefaultUserNames() {
-		assertEquals(DEFAULT_USERS.size(), DefaultUserHelper.getDefaultUserNames().size());
-		Set<String> result = DefaultUserHelper.getDefaultUserNames();
+		assertEquals(DEFAULT_USERS.size(), DefaultEntityHelper.getDefaultUserNames().size());
+		Set<String> result = DefaultEntityHelper.getDefaultUserNames();
 		for (String defaultUser : DEFAULT_USERS.keySet()) {
 			assertTrue(result.contains(defaultUser));
 		}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/StartupShutdownService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/StartupShutdownService.java
@@ -229,7 +229,7 @@ public class StartupShutdownService {
 		Region region = null;
 		if (regionService.count() == 0) {
 			region = new Region();
-			region.setUuid(DataHelper.createConstantUuid(DefaultEntityHelper.Infrastructure.REGION.ordinal()));
+			region.setUuid(DataHelper.createConstantUuid(DefaultEntityHelper.DefaultInfrastructureUuidSeed.REGION.ordinal()));
 			region.setName(I18nProperties.getCaption(Captions.defaultRegion, "Default Region"));
 			region.setEpidCode("DEF-REG");
 			region.setDistricts(new ArrayList<District>());
@@ -240,7 +240,7 @@ public class StartupShutdownService {
 		District district = null;
 		if (districtService.count() == 0) {
 			district = new District();
-			district.setUuid(DataHelper.createConstantUuid(DefaultEntityHelper.Infrastructure.DISTRICT.ordinal()));
+			district.setUuid(DataHelper.createConstantUuid(DefaultEntityHelper.DefaultInfrastructureUuidSeed.DISTRICT.ordinal()));
 			district.setName(I18nProperties.getCaption(Captions.defaultDistrict, "Default District"));
 			if (region == null) {
 				region = regionService.getAll().get(0);
@@ -256,7 +256,7 @@ public class StartupShutdownService {
 		Community community = null;
 		if (communityService.count() == 0) {
 			community = new Community();
-			community.setUuid(DataHelper.createConstantUuid(DefaultEntityHelper.Infrastructure.COMMUNITY.ordinal()));
+			community.setUuid(DataHelper.createConstantUuid(DefaultEntityHelper.DefaultInfrastructureUuidSeed.COMMUNITY.ordinal()));
 			community.setName(I18nProperties.getCaption(Captions.defaultCommunity, "Default Community"));
 			if (district == null) {
 				district = districtService.getAll().get(0);
@@ -351,7 +351,8 @@ public class StartupShutdownService {
 				return;
 			}
 
-			Region region = regionService.getByUuid(DataHelper.createConstantUuid(DefaultEntityHelper.Infrastructure.REGION.ordinal()));
+			Region region =
+				regionService.getByUuid(DataHelper.createConstantUuid(DefaultEntityHelper.DefaultInfrastructureUuidSeed.REGION.ordinal()));
 			District district = region.getDistricts().get(0);
 			Community community = district.getCommunities().get(0);
 			List<Facility> healthFacilities = facilityService.getActiveFacilitiesByCommunityAndType(community, FacilityType.HOSPITAL, false, false);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/StartupShutdownService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/StartupShutdownService.java
@@ -71,7 +71,7 @@ import de.symeda.sormas.api.infrastructure.pointofentry.PointOfEntryType;
 import de.symeda.sormas.api.infrastructure.country.CountryReferenceDto;
 import de.symeda.sormas.api.user.UserRole;
 import de.symeda.sormas.api.utils.DataHelper;
-import de.symeda.sormas.api.utils.DefaultUserHelper;
+import de.symeda.sormas.api.utils.DefaultEntityHelper;
 import de.symeda.sormas.api.utils.PasswordHelper;
 import de.symeda.sormas.backend.common.ConfigFacadeEjb.ConfigFacadeEjbLocal;
 import de.symeda.sormas.backend.contact.Contact;
@@ -229,7 +229,7 @@ public class StartupShutdownService {
 		Region region = null;
 		if (regionService.count() == 0) {
 			region = new Region();
-			region.setUuid(DataHelper.createUuid());
+			region.setUuid(DataHelper.createConstantUuid(DefaultEntityHelper.Infrastructure.REGION.ordinal()));
 			region.setName(I18nProperties.getCaption(Captions.defaultRegion, "Default Region"));
 			region.setEpidCode("DEF-REG");
 			region.setDistricts(new ArrayList<District>());
@@ -240,7 +240,7 @@ public class StartupShutdownService {
 		District district = null;
 		if (districtService.count() == 0) {
 			district = new District();
-			district.setUuid(DataHelper.createUuid());
+			district.setUuid(DataHelper.createConstantUuid(DefaultEntityHelper.Infrastructure.DISTRICT.ordinal()));
 			district.setName(I18nProperties.getCaption(Captions.defaultDistrict, "Default District"));
 			if (region == null) {
 				region = regionService.getAll().get(0);
@@ -256,7 +256,7 @@ public class StartupShutdownService {
 		Community community = null;
 		if (communityService.count() == 0) {
 			community = new Community();
-			community.setUuid(DataHelper.createUuid());
+			community.setUuid(DataHelper.createConstantUuid(DefaultEntityHelper.Infrastructure.COMMUNITY.ordinal()));
 			community.setName(I18nProperties.getCaption(Captions.defaultCommunity, "Default Community"));
 			if (district == null) {
 				district = districtService.getAll().get(0);
@@ -341,7 +341,7 @@ public class StartupShutdownService {
 					UserRole.ADMIN,
 					"ad",
 					"min",
-					DefaultUserHelper.ADMIN_USERNAME_AND_PASSWORD,
+					DefaultEntityHelper.ADMIN_USERNAME_AND_PASSWORD,
 					u -> {});
 			//@formatter:on
 
@@ -351,7 +351,7 @@ public class StartupShutdownService {
 				return;
 			}
 
-			Region region = regionService.getAll().get(0);
+			Region region = regionService.getByUuid(DataHelper.createConstantUuid(DefaultEntityHelper.Infrastructure.REGION.ordinal()));
 			District district = region.getDistricts().get(0);
 			Community community = district.getCommunities().get(0);
 			List<Facility> healthFacilities = facilityService.getActiveFacilitiesByCommunityAndType(community, FacilityType.HOSPITAL, false, false);
@@ -367,7 +367,7 @@ public class StartupShutdownService {
 				UserRole.SURVEILLANCE_SUPERVISOR,
 				"Surveillance",
 				"Supervisor",
-				DefaultUserHelper.SURV_SUP_USERNAME_AND_PASSWORD,
+				DefaultEntityHelper.SURV_SUP_USERNAME_AND_PASSWORD,
 				u -> u.setRegion(region));
 
 			// Create Case Supervisor
@@ -375,7 +375,7 @@ public class StartupShutdownService {
 				UserRole.CASE_SUPERVISOR,
 				"Case",
 				"Supervisor",
-				DefaultUserHelper.CASE_SUP_USERNAME_AND_PASSWORD,
+				DefaultEntityHelper.CASE_SUP_USERNAME_AND_PASSWORD,
 				u -> u.setRegion(region));
 
 			// Create Contact Supervisor
@@ -383,7 +383,7 @@ public class StartupShutdownService {
 				UserRole.CONTACT_SUPERVISOR,
 				"Contact",
 				"Supervisor",
-				DefaultUserHelper.CONT_SUP_USERNAME_AND_PASSWORD,
+				DefaultEntityHelper.CONT_SUP_USERNAME_AND_PASSWORD,
 				u -> u.setRegion(region));
 
 			// Create Point of Entry Supervisor
@@ -391,7 +391,7 @@ public class StartupShutdownService {
 				UserRole.POE_SUPERVISOR,
 				"Point of Entry",
 				"Supervisor",
-				DefaultUserHelper.POE_SUP_USERNAME_AND_PASSWORD,
+				DefaultEntityHelper.POE_SUP_USERNAME_AND_PASSWORD,
 				u -> u.setRegion(region));
 
 			// Create Laboratory Officer
@@ -399,7 +399,7 @@ public class StartupShutdownService {
 				UserRole.LAB_USER,
 				"Laboratory",
 				"Officer",
-				DefaultUserHelper.LAB_OFF_USERNAME_AND_PASSWORD,
+				DefaultEntityHelper.LAB_OFF_USERNAME_AND_PASSWORD,
 				u -> u.setLaboratory(laboratory));
 
 			// Create Event Officer
@@ -407,7 +407,7 @@ public class StartupShutdownService {
 				UserRole.EVENT_OFFICER,
 				"Event",
 				"Officer",
-				DefaultUserHelper.EVE_OFF_USERNAME_AND_PASSWORD,
+				DefaultEntityHelper.EVE_OFF_USERNAME_AND_PASSWORD,
 				u -> u.setRegion(region));
 
 			// Create National User
@@ -416,7 +416,7 @@ public class StartupShutdownService {
 					UserRole.NATIONAL_USER,
 					"National",
 					"User",
-					DefaultUserHelper.NAT_USER_USERNAME_AND_PASSWORD,
+					DefaultEntityHelper.NAT_USER_USERNAME_AND_PASSWORD,
 					u -> {});
 			//@formatter:on
 
@@ -426,7 +426,7 @@ public class StartupShutdownService {
 					UserRole.NATIONAL_CLINICIAN,
 					"National",
 					"Clinician",
-					DefaultUserHelper.NAT_CLIN_USERNAME_AND_PASSWORD,
+					DefaultEntityHelper.NAT_CLIN_USERNAME_AND_PASSWORD,
 					u -> {});
 			//@formatter:on
 
@@ -436,7 +436,7 @@ public class StartupShutdownService {
 				UserRole.SURVEILLANCE_OFFICER,
 				"Surveillance",
 				"Officer",
-				DefaultUserHelper.SURV_OFF_USERNAME_AND_PASSWORD,
+				DefaultEntityHelper.SURV_OFF_USERNAME_AND_PASSWORD,
 				u -> {
 					u.setRegion(region);
 					u.setDistrict(district);
@@ -449,7 +449,7 @@ public class StartupShutdownService {
 					UserRole.HOSPITAL_INFORMANT,
 					"Hospital",
 					"Informant",
-					DefaultUserHelper.HOSP_INF_USERNAME_AND_PASSWORD,
+					DefaultEntityHelper.HOSP_INF_USERNAME_AND_PASSWORD,
 					u -> {
 						u.setRegion(region);
 						u.setDistrict(district);
@@ -464,7 +464,7 @@ public class StartupShutdownService {
 					UserRole.COMMUNITY_OFFICER,
 					"Community",
 					"Officer",
-					DefaultUserHelper.COMM_OFF_USERNAME_AND_PASSWORD,
+					DefaultEntityHelper.COMM_OFF_USERNAME_AND_PASSWORD,
 					u -> {
 						u.setRegion(region);
 						u.setDistrict(district);
@@ -478,7 +478,7 @@ public class StartupShutdownService {
 					UserRole.POE_INFORMANT,
 					"Poe",
 					"Informant",
-					DefaultUserHelper.POE_INF_USERNAME_AND_PASSWORD,
+					DefaultEntityHelper.POE_INF_USERNAME_AND_PASSWORD,
 					u -> {
 						u.setUserName("PoeInf");
 						u.setRegion(region);
@@ -503,7 +503,6 @@ public class StartupShutdownService {
 		userService.persist(user);
 		userUpdateEvent.fire(new UserUpdateEvent(user));
 		return user;
-
 	}
 
 	private void createOrUpdateSormasToSormasUser() {
@@ -515,7 +514,7 @@ public class StartupShutdownService {
 
 			createOrUpdateDefaultUser(
 				Collections.singleton(UserRole.SORMAS_TO_SORMAS_CLIENT),
-				DefaultUserHelper.SORMAS_TO_SORMAS_USER_NAME,
+				DefaultEntityHelper.SORMAS_TO_SORMAS_USER_NAME,
 				new String(pwd),
 				"Sormas to Sormas",
 				"Client");

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/user/UserFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/user/UserFacadeEjb.java
@@ -60,7 +60,7 @@ import de.symeda.sormas.api.user.UserRole;
 import de.symeda.sormas.api.user.UserRole.UserRoleValidationException;
 import de.symeda.sormas.api.user.UserSyncResult;
 import de.symeda.sormas.api.utils.DataHelper;
-import de.symeda.sormas.api.utils.DefaultUserHelper;
+import de.symeda.sormas.api.utils.DefaultEntityHelper;
 import de.symeda.sormas.api.utils.PasswordHelper;
 import de.symeda.sormas.api.utils.SortProperty;
 import de.symeda.sormas.backend.caze.Case;
@@ -589,15 +589,15 @@ public class UserFacadeEjb implements UserFacade {
 			// a list of all users with a default password is returned
 			return userService.getAllDefaultUsers()
 				.stream()
-				.filter(user -> DefaultUserHelper.usesDefaultPassword(user.getUserName(), user.getPassword(), user.getSeed()))
+				.filter(user -> DefaultEntityHelper.usesDefaultPassword(user.getUserName(), user.getPassword(), user.getSeed()))
 				.map(UserFacadeEjb::toDto)
 				.collect(Collectors.toList());
 
 		} else {
 			// user has only access to himself
 			// the list will include him/her or will be empty
-			if (DefaultUserHelper.isDefaultUser(currentUser.getUserName())
-				&& DefaultUserHelper.usesDefaultPassword(currentUser.getUserName(), currentUser.getPassword(), currentUser.getSeed())) {
+			if (DefaultEntityHelper.isDefaultUser(currentUser.getUserName())
+				&& DefaultEntityHelper.usesDefaultPassword(currentUser.getUserName(), currentUser.getPassword(), currentUser.getSeed())) {
 				return Collections.singletonList(UserFacadeEjb.toDto(currentUser));
 			} else {
 				return Collections.emptyList();

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/user/UserService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/user/UserService.java
@@ -52,7 +52,7 @@ import de.symeda.sormas.api.user.UserCriteria;
 import de.symeda.sormas.api.user.UserRight;
 import de.symeda.sormas.api.user.UserRole;
 import de.symeda.sormas.api.utils.DataHelper;
-import de.symeda.sormas.api.utils.DefaultUserHelper;
+import de.symeda.sormas.api.utils.DefaultEntityHelper;
 import de.symeda.sormas.api.utils.PasswordHelper;
 import de.symeda.sormas.backend.caze.Case;
 import de.symeda.sormas.backend.common.AbstractDomainObject;
@@ -581,7 +581,7 @@ public class UserService extends AdoServiceWithUserFilter<User> {
 		CriteriaBuilder cb = em.getCriteriaBuilder();
 		CriteriaQuery<User> cq = cb.createQuery(getElementClass());
 		Root<User> from = cq.from(getElementClass());
-		cq.where(cb.and(createDefaultFilter(cb, from), from.get(User.USER_NAME).in(DefaultUserHelper.getDefaultUserNames())));
+		cq.where(cb.and(createDefaultFilter(cb, from), from.get(User.USER_NAME).in(DefaultEntityHelper.getDefaultUserNames())));
 		cq.orderBy(cb.asc(from.get(User.USER_NAME)));
 
 		return em.createQuery(cq).getResultList();

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/user/UserTestHelper.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/user/UserTestHelper.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 
 import de.symeda.sormas.api.user.UserRole;
 import de.symeda.sormas.api.utils.DataHelper;
-import de.symeda.sormas.api.utils.DefaultUserHelper;
+import de.symeda.sormas.api.utils.DefaultEntityHelper;
 import de.symeda.sormas.api.utils.PasswordHelper;
 
 public class UserTestHelper {
@@ -45,17 +45,17 @@ public class UserTestHelper {
 	public static Set<User> generateDefaultUsers(boolean generateDefaultAdmin) {
 		Set<User> defaultUsers = new HashSet<>();
 		if (generateDefaultAdmin) {
-			defaultUsers.add(createDefaultUser(UserRole.ADMIN, DefaultUserHelper.ADMIN_USERNAME_AND_PASSWORD));
+			defaultUsers.add(createDefaultUser(UserRole.ADMIN, DefaultEntityHelper.ADMIN_USERNAME_AND_PASSWORD));
 		}
-		defaultUsers.add(createDefaultUser(UserRole.SURVEILLANCE_SUPERVISOR, DefaultUserHelper.SURV_SUP_USERNAME_AND_PASSWORD));
-		defaultUsers.add(createDefaultUser(UserRole.CASE_SUPERVISOR, DefaultUserHelper.CASE_SUP_USERNAME_AND_PASSWORD));
-		defaultUsers.add(createDefaultUser(UserRole.CONTACT_SUPERVISOR, DefaultUserHelper.CONT_SUP_USERNAME_AND_PASSWORD));
-		defaultUsers.add(createDefaultUser(UserRole.POE_SUPERVISOR, DefaultUserHelper.POE_SUP_USERNAME_AND_PASSWORD));
-		defaultUsers.add(createDefaultUser(UserRole.LAB_USER, DefaultUserHelper.LAB_OFF_USERNAME_AND_PASSWORD));
-		defaultUsers.add(createDefaultUser(UserRole.EVENT_OFFICER, DefaultUserHelper.EVE_OFF_USERNAME_AND_PASSWORD));
-		defaultUsers.add(createDefaultUser(UserRole.NATIONAL_USER, DefaultUserHelper.NAT_USER_USERNAME_AND_PASSWORD));
-		defaultUsers.add(createDefaultUser(UserRole.NATIONAL_CLINICIAN, DefaultUserHelper.NAT_CLIN_USERNAME_AND_PASSWORD));
-		defaultUsers.add(createDefaultUser(UserRole.SURVEILLANCE_OFFICER, DefaultUserHelper.SURV_OFF_USERNAME_AND_PASSWORD));
+		defaultUsers.add(createDefaultUser(UserRole.SURVEILLANCE_SUPERVISOR, DefaultEntityHelper.SURV_SUP_USERNAME_AND_PASSWORD));
+		defaultUsers.add(createDefaultUser(UserRole.CASE_SUPERVISOR, DefaultEntityHelper.CASE_SUP_USERNAME_AND_PASSWORD));
+		defaultUsers.add(createDefaultUser(UserRole.CONTACT_SUPERVISOR, DefaultEntityHelper.CONT_SUP_USERNAME_AND_PASSWORD));
+		defaultUsers.add(createDefaultUser(UserRole.POE_SUPERVISOR, DefaultEntityHelper.POE_SUP_USERNAME_AND_PASSWORD));
+		defaultUsers.add(createDefaultUser(UserRole.LAB_USER, DefaultEntityHelper.LAB_OFF_USERNAME_AND_PASSWORD));
+		defaultUsers.add(createDefaultUser(UserRole.EVENT_OFFICER, DefaultEntityHelper.EVE_OFF_USERNAME_AND_PASSWORD));
+		defaultUsers.add(createDefaultUser(UserRole.NATIONAL_USER, DefaultEntityHelper.NAT_USER_USERNAME_AND_PASSWORD));
+		defaultUsers.add(createDefaultUser(UserRole.NATIONAL_CLINICIAN, DefaultEntityHelper.NAT_CLIN_USERNAME_AND_PASSWORD));
+		defaultUsers.add(createDefaultUser(UserRole.SURVEILLANCE_OFFICER, DefaultEntityHelper.SURV_OFF_USERNAME_AND_PASSWORD));
 		return defaultUsers;
 	}
 

--- a/sormas-rest/src/main/java/de/symeda/sormas/rest/security/MultiAuthenticationMechanism.java
+++ b/sormas-rest/src/main/java/de/symeda/sormas/rest/security/MultiAuthenticationMechanism.java
@@ -35,7 +35,7 @@ import de.symeda.sormas.api.ConfigFacade;
 import de.symeda.sormas.api.FacadeProvider;
 import de.symeda.sormas.api.sormastosormas.SormasToSormasApiConstants;
 import de.symeda.sormas.api.user.UserRole;
-import de.symeda.sormas.api.utils.DefaultUserHelper;
+import de.symeda.sormas.api.utils.DefaultEntityHelper;
 import de.symeda.sormas.rest.security.config.KeycloakConfigResolver;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
@@ -109,7 +109,7 @@ public class MultiAuthenticationMechanism implements HttpAuthenticationMechanism
 	private AuthenticationStatus validateRequestS2S(HttpMessageContext context) {
 
 		return context.notifyContainerAboutLogin(
-			() -> DefaultUserHelper.SORMAS_TO_SORMAS_USER_NAME,
+			() -> DefaultEntityHelper.SORMAS_TO_SORMAS_USER_NAME,
 			new HashSet<>(Collections.singletonList(UserRole.SORMAS_TO_SORMAS_CLIENT.name())));
 	}
 }

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/login/DefaultPasswordUIHelper.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/login/DefaultPasswordUIHelper.java
@@ -23,7 +23,7 @@ import com.vaadin.ui.UI;
 
 import de.symeda.sormas.api.FacadeProvider;
 import de.symeda.sormas.api.user.UserDto;
-import de.symeda.sormas.api.utils.DefaultUserHelper;
+import de.symeda.sormas.api.utils.DefaultEntityHelper;
 
 public class DefaultPasswordUIHelper {
 
@@ -53,8 +53,8 @@ public class DefaultPasswordUIHelper {
 				originalLoginListener.loginSuccessful();
 			} else {
 				UserDto currentUser = FacadeProvider.getUserFacade().getCurrentUser();
-				boolean currentUserUsesDefaultPassword = DefaultUserHelper.currentUserUsesDefaultPassword(usersWithDefaultPassword, currentUser);
-				boolean otherUsersWithDefaultPassword = DefaultUserHelper.otherUsersUseDefaultPassword(usersWithDefaultPassword, currentUser);
+				boolean currentUserUsesDefaultPassword = DefaultEntityHelper.currentUserUsesDefaultPassword(usersWithDefaultPassword, currentUser);
+				boolean otherUsersWithDefaultPassword = DefaultEntityHelper.otherUsersUseDefaultPassword(usersWithDefaultPassword, currentUser);
 				if (currentUserUsesDefaultPassword) {
 					vaadinUI.addWindow(new ChangeDefaultUserPasswordWindow(otherUsersWithDefaultPassword ? () -> {
 						vaadinUI.addWindow(


### PR DESCRIPTION
Fixes #6696 
This is intentionally leaving out point of entry and facility. This is because they are (not yet included) in central, meaning UUIDs of these two types will also vary in the wild. To mimic this behavior while testing, both of the corresponding default entities will have random UUIDs.