### PR TITLE
Feature 5713 demis2sormas handle new profile map observation.identifier

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/i18n/Captions.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/i18n/Captions.java
@@ -1489,6 +1489,7 @@ public interface Captions {
 	String passportNumber = "passportNumber";
 	String PathogenTest = "PathogenTest";
 	String PathogenTest_cqValue = "PathogenTest.cqValue";
+	String PathogenTest_externalId = "PathogenTest.externalId";
 	String PathogenTest_fourFoldIncreaseAntibodyTiter = "PathogenTest.fourFoldIncreaseAntibodyTiter";
 	String PathogenTest_lab = "PathogenTest.lab";
 	String PathogenTest_labDetails = "PathogenTest.labDetails";

--- a/sormas-api/src/main/java/de/symeda/sormas/api/labmessage/TestReportDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/labmessage/TestReportDto.java
@@ -44,6 +44,8 @@ public class TestReportDto extends EntityDto {
 	private String testResultText;
 	@Size(max = COLUMN_LENGTH_TEXT, message = Validations.textTooLong)
 	private String typingId;
+	@Size(max = COLUMN_LENGTH_SMALL, message = Validations.textTooLong)
+	private String externalId;
 
 	private PathogenTestReferenceDto pathogenTest;
 
@@ -147,5 +149,13 @@ public class TestReportDto extends EntityDto {
 
 	public void setTypingId(String typingId) {
 		this.typingId = typingId;
+	}
+
+	public String getExternalId() {
+		return externalId;
+	}
+
+	public void setExternalId(String externalId) {
+		this.externalId = externalId;
 	}
 }

--- a/sormas-api/src/main/java/de/symeda/sormas/api/sample/PathogenTestDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/sample/PathogenTestDto.java
@@ -62,6 +62,7 @@ public class PathogenTestDto extends PseudonymizableDto {
 	public static final String CQ_VALUE = "cqValue";
 	public static final String REPORT_DATE = "reportDate";
 	public static final String VIA_LIMS = "viaLims";
+	public static final String EXTERNAL_ID = "externalId";
 
 	@Required
 	private SampleReferenceDto sample;
@@ -105,6 +106,9 @@ public class PathogenTestDto extends PseudonymizableDto {
 	private Date reportDate;
 	@HideForCountriesExcept(countries = CountryHelper.COUNTRY_CODE_GERMANY)
 	private boolean viaLims;
+	@HideForCountriesExcept(countries = CountryHelper.COUNTRY_CODE_GERMANY)
+	@Size(max = COLUMN_LENGTH_SMALL, message = Validations.textTooLong)
+	private String externalId;
 
 	public static PathogenTestDto build(SampleDto sample, UserDto currentUser) {
 
@@ -299,5 +303,13 @@ public class PathogenTestDto extends PseudonymizableDto {
 
 	public void setViaLims(boolean viaLims) {
 		this.viaLims = viaLims;
+	}
+
+	public String getExternalId() {
+		return externalId;
+	}
+
+	public void setExternalId(String externalId) {
+		this.externalId = externalId;
 	}
 }

--- a/sormas-api/src/main/resources/captions.properties
+++ b/sormas-api/src/main/resources/captions.properties
@@ -1576,6 +1576,7 @@ PathogenTest.testedDiseaseDetails=Tested disease name
 PathogenTest.typingId=Typing ID
 PathogenTest.serotype=Serotype
 PathogenTest.cqValue=CQ/CT Value
+PathogenTest.externalId=External ID
 PathogenTest.reportDate=Report date
 PathogenTest.viaLims=Via LIMS
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/labmessage/TestReport.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/labmessage/TestReport.java
@@ -21,6 +21,7 @@ import java.util.Date;
 
 import static de.symeda.sormas.api.EntityDto.COLUMN_LENGTH_BIG;
 import static de.symeda.sormas.api.EntityDto.COLUMN_LENGTH_DEFAULT;
+import static de.symeda.sormas.api.EntityDto.COLUMN_LENGTH_SMALL;
 
 @Entity(name = TestReport.TABLE_NAME)
 @Audited
@@ -54,6 +55,7 @@ public class TestReport extends CoreAdo {
 	private Boolean testResultVerified;
 	private String testResultText;
 	private String typingId;
+	private String externalId;
 
 	private PathogenTest pathogenTest;
 
@@ -157,11 +159,21 @@ public class TestReport extends CoreAdo {
 		this.pathogenTest = pathogenTest;
 	}
 
+	@Column(length = COLUMN_LENGTH_SMALL)
 	public String getTypingId() {
 		return typingId;
 	}
 
 	public void setTypingId(String typingId) {
 		this.typingId = typingId;
+	}
+
+	@Column(length = COLUMN_LENGTH_SMALL)
+	public String getExternalId() {
+		return externalId;
+	}
+
+	public void setExternalId(String externalId) {
+		this.externalId = externalId;
 	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/labmessage/TestReportFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/labmessage/TestReportFacadeEjb.java
@@ -77,6 +77,7 @@ public class TestReportFacadeEjb implements TestReportFacade {
 		target.setTestResultVerified(source.isTestResultVerified());
 		target.setTestResultText(source.getTestResultText());
 		target.setTypingId(source.getTypingId());
+		target.setExternalId(source.getExternalId());
 		if (source.getPathogenTest() != null) {
 			target.setPathogenTest(source.getPathogenTest().toReference());
 		}
@@ -98,6 +99,7 @@ public class TestReportFacadeEjb implements TestReportFacade {
 		target.setTestResultVerified(source.isTestResultVerified());
 		target.setTestResultText(source.getTestResultText());
 		target.setTypingId(source.getTypingId());
+		target.setExternalId(source.getExternalId());
 		target.setPathogenTest(pathogenTestService.getByReferenceDto(source.getPathogenTest()));
 
 		return target;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/PathogenTest.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/PathogenTest.java
@@ -19,6 +19,7 @@ package de.symeda.sormas.backend.sample;
 
 import static de.symeda.sormas.api.EntityDto.COLUMN_LENGTH_BIG;
 import static de.symeda.sormas.api.EntityDto.COLUMN_LENGTH_DEFAULT;
+import static de.symeda.sormas.api.EntityDto.COLUMN_LENGTH_SMALL;
 
 import java.util.Date;
 
@@ -93,6 +94,7 @@ public class PathogenTest extends CoreAdo {
 	private Float cqValue;
 	private Date reportDate;
 	private boolean viaLims;
+	private String externalId;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(nullable = false)
@@ -279,6 +281,15 @@ public class PathogenTest extends CoreAdo {
 
 	public void setViaLims(boolean viaLims) {
 		this.viaLims = viaLims;
+	}
+
+	@Column(length = COLUMN_LENGTH_SMALL)
+	public String getExternalId() {
+		return externalId;
+	}
+
+	public void setExternalId(String externalId) {
+		this.externalId = externalId;
 	}
 
 	public PathogenTestReferenceDto toReference() {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/PathogenTestFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/PathogenTestFacadeEjb.java
@@ -357,6 +357,7 @@ public class PathogenTestFacadeEjb implements PathogenTestFacade {
 		target.setCqValue(source.getCqValue());
 		target.setReportDate(source.getReportDate());
 		target.setViaLims(source.isViaLims());
+		target.setExternalId(source.getExternalId());
 
 		return target;
 	}
@@ -409,6 +410,7 @@ public class PathogenTestFacadeEjb implements PathogenTestFacade {
 		target.setCqValue(source.getCqValue());
 		target.setReportDate(source.getReportDate());
 		target.setViaLims(source.isViaLims());
+		target.setExternalId(source.getExternalId());
 
 		return target;
 	}

--- a/sormas-backend/src/main/resources/sql/sormas_schema.sql
+++ b/sormas-backend/src/main/resources/sql/sormas_schema.sql
@@ -7940,4 +7940,13 @@ ALTER TABLE task_history ADD COLUMN travelentry_id bigint;
 
 INSERT INTO schema_version (version_number, comment) VALUES (404, 'Add TravelEntries to tasks #5844');
 
+-- 2021-09-16 - Add PathogenTest.externalId and transfer it from lab messages #5713
+ALTER TABLE pathogentest ADD COLUMN externalid varchar(255);
+ALTER TABLE pathogentest_history ADD COLUMN externalid varchar(255);
+
+ALTER TABLE testreport ADD COLUMN externalid varchar(255);
+ALTER TABLE testreport_history ADD COLUMN externalid varchar(255);
+
+INSERT INTO schema_version (version_number, comment) VALUES (405, 'Add PathogenTest.externalId and transfer it from lab messages #5713');
+
 -- *** Insert new sql commands BEFORE this line. Remember to always consider _history tables. ***

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/labmessage/LabMessageController.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/labmessage/LabMessageController.java
@@ -747,6 +747,7 @@ public class LabMessageController {
 			pathogenTestDto.setTestDateTime(testReportDto.getTestDateTime());
 			pathogenTestDto.setTestResultText(testReportDto.getTestResultText());
 			pathogenTestDto.setTypingId(testReportDto.getTypingId());
+			pathogenTestDto.setExternalId(testReportDto.getExternalId());
 		}
 
 		pathogenTestDto.setTestedDisease(labMessageDto.getTestedDisease());

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/samples/PathogenTestForm.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/samples/PathogenTestForm.java
@@ -109,8 +109,7 @@ public class PathogenTestForm extends AbstractEditForm<PathogenTestDto> {
 
 		addDateField(PathogenTestDto.REPORT_DATE, DateField.class, 0);
 		addField(PathogenTestDto.VIA_LIMS);
-		TextField externalIdField = addField(PathogenTestDto.EXTERNAL_ID, TextField.class);
-		externalIdField.setEnabled(false);
+		addField(PathogenTestDto.EXTERNAL_ID);
 		ComboBox testTypeField = addField(PathogenTestDto.TEST_TYPE, ComboBox.class);
 		ComboBox pcrTestSpecification = addField(PathogenTestDto.PCR_TEST_SPECIFICATION, ComboBox.class);
 		TextField testTypeTextField = addField(PathogenTestDto.TEST_TYPE_TEXT, TextField.class);

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/samples/PathogenTestForm.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/samples/PathogenTestForm.java
@@ -17,6 +17,7 @@
  *******************************************************************************/
 package de.symeda.sormas.ui.samples;
 
+import static de.symeda.sormas.ui.utils.CssStyles.TEXTFIELD_ROW;
 import static de.symeda.sormas.ui.utils.CssStyles.VSPACE_3;
 import static de.symeda.sormas.ui.utils.CssStyles.VSPACE_TOP_4;
 import static de.symeda.sormas.ui.utils.LayoutUtil.fluidRowLocs;
@@ -63,7 +64,7 @@ public class PathogenTestForm extends AbstractEditForm<PathogenTestDto> {
 
 	//@formatter:off
 	private static final String HTML_LAYOUT = 
-			fluidRowLocs(PathogenTestDto.REPORT_DATE, PathogenTestDto.VIA_LIMS) +
+			fluidRowLocs(6, PathogenTestDto.REPORT_DATE, 3, PathogenTestDto.EXTERNAL_ID, 3, PathogenTestDto.VIA_LIMS) +
 			fluidRowLocs(PathogenTestDto.TEST_TYPE, PathogenTestDto.PCR_TEST_SPECIFICATION) +
 			fluidRowLocs(PathogenTestDto.TESTED_DISEASE, PathogenTestDto.TESTED_DISEASE_VARIANT) +
 			fluidRowLocs("", PathogenTestDto.TYPING_ID) +
@@ -108,6 +109,8 @@ public class PathogenTestForm extends AbstractEditForm<PathogenTestDto> {
 
 		addDateField(PathogenTestDto.REPORT_DATE, DateField.class, 0);
 		addField(PathogenTestDto.VIA_LIMS);
+		TextField externalIdField = addField(PathogenTestDto.EXTERNAL_ID, TextField.class);
+		externalIdField.setEnabled(false);
 		ComboBox testTypeField = addField(PathogenTestDto.TEST_TYPE, ComboBox.class);
 		ComboBox pcrTestSpecification = addField(PathogenTestDto.PCR_TEST_SPECIFICATION, ComboBox.class);
 		TextField testTypeTextField = addField(PathogenTestDto.TEST_TYPE_TEXT, TextField.class);


### PR DESCRIPTION
<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #5713. In contrast to the specification, I made the externalId field in the pathogen test form editable. Reasons are:

- it does not make sense to show it when creating a new pathogen test (if not processing lab messages), when it is not editable
- maybe users want to manually add a pathogen test with an external id (e.g. when that was recieved via FAX)
- pathogen test external ids do not need to stay in sync with something else. It is helpful if it they do match the Observation.Identifier.value used in DEMIS, but nothing seriously breaks if they don't. Do you have objections regarding this point, @HolgerReiseVSys?

This is a feature, so it sould be merged after 1.64 was released.

