### PR TITLE
[#6587] abstract class for shared functionality

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/InfrastructureDataReferenceDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/InfrastructureDataReferenceDto.java
@@ -20,14 +20,14 @@ public abstract class InfrastructureDataReferenceDto extends ReferenceDto implem
 	private static final long serialVersionUID = -3451269378082767059L;
 	private String externalId;
 
-	public InfrastructureDataReferenceDto() {
+	protected InfrastructureDataReferenceDto() {
 	}
 
-	public InfrastructureDataReferenceDto(String uuid) {
+	protected InfrastructureDataReferenceDto(String uuid) {
 		super(uuid);
 	}
 
-	public InfrastructureDataReferenceDto(String uuid, String caption, String externalId) {
+	protected InfrastructureDataReferenceDto(String uuid, String caption, String externalId) {
 		super(uuid, caption);
 		this.externalId = externalId;
 	}

--- a/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/GeoLocationFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/GeoLocationFacade.java
@@ -1,7 +1,7 @@
 package de.symeda.sormas.api.infrastructure;
 
 import de.symeda.sormas.api.EntityDto;
-import de.symeda.sormas.api.ReferenceDto;
+import de.symeda.sormas.api.InfrastructureDataReferenceDto;
 import de.symeda.sormas.api.utils.criteria.BaseCriteria;
 
 import javax.ejb.Remote;
@@ -17,9 +17,8 @@ import java.util.List;
  * @param <CRITERIA>
  */
 @Remote
-public interface GeoLocationFacade<DTO extends EntityDto, INDEX_DTO extends Serializable, REF_DTO extends ReferenceDto, CRITERIA extends BaseCriteria>
+public interface GeoLocationFacade<DTO extends EntityDto, INDEX_DTO extends Serializable, REF_DTO extends InfrastructureDataReferenceDto, CRITERIA extends BaseCriteria>
 	extends InfrastructureBaseFacade<DTO, INDEX_DTO, REF_DTO, CRITERIA> {
-	// todo REF_DTO should be InfrastructureDataReferenceDto
 
 	List<REF_DTO> getReferencesByName(String name, boolean includeArchived);
 }

--- a/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/GeoLocationFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/GeoLocationFacade.java
@@ -19,6 +19,7 @@ import java.util.List;
 @Remote
 public interface GeoLocationFacade<DTO extends EntityDto, INDEX_DTO extends Serializable, REF_DTO extends ReferenceDto, CRITERIA extends BaseCriteria>
 	extends InfrastructureBaseFacade<DTO, INDEX_DTO, REF_DTO, CRITERIA> {
+	// todo REF_DTO should be InfrastructureDataReferenceDto
 
 	List<REF_DTO> getReferencesByName(String name, boolean includeArchived);
 }

--- a/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/InfrastructureBaseFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/InfrastructureBaseFacade.java
@@ -8,15 +8,16 @@ import javax.validation.Valid;
 
 import de.symeda.sormas.api.BaseFacade;
 import de.symeda.sormas.api.EntityDto;
+import de.symeda.sormas.api.InfrastructureDataReferenceDto;
 import de.symeda.sormas.api.ReferenceDto;
 import de.symeda.sormas.api.infrastructure.continent.ContinentReferenceDto;
 import de.symeda.sormas.api.utils.criteria.BaseCriteria;
 
 @Remote
-public interface InfrastructureBaseFacade<DTO extends EntityDto, INDEX_DTO extends Serializable, REF_DTO extends ReferenceDto, CRITERIA extends BaseCriteria>
+public interface InfrastructureBaseFacade<DTO extends EntityDto, INDEX_DTO extends Serializable, REF_DTO extends InfrastructureDataReferenceDto, CRITERIA extends BaseCriteria>
 	extends BaseFacade<DTO, INDEX_DTO, REF_DTO, CRITERIA> {
 
-	// todo REF_DTO should be InfrastructureDataReferenceDto
+
 	// todo investigate if we can move the save function up the hierarchy
 	DTO save(@Valid DTO dto, boolean allowMerge);
 

--- a/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/InfrastructureBaseFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/InfrastructureBaseFacade.java
@@ -16,6 +16,8 @@ import de.symeda.sormas.api.utils.criteria.BaseCriteria;
 public interface InfrastructureBaseFacade<DTO extends EntityDto, INDEX_DTO extends Serializable, REF_DTO extends ReferenceDto, CRITERIA extends BaseCriteria>
 	extends BaseFacade<DTO, INDEX_DTO, REF_DTO, CRITERIA> {
 
+	// todo REF_DTO should be InfrastructureDataReferenceDto
+	// todo investigate if we can move the save function up the hierarchy
 	DTO save(@Valid DTO dto, boolean allowMerge);
 
 	List<REF_DTO> getByExternalId(String externalId, boolean includeArchivedEntities);

--- a/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/area/AreaReferenceDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/area/AreaReferenceDto.java
@@ -3,6 +3,7 @@ package de.symeda.sormas.api.infrastructure.area;
 import de.symeda.sormas.api.ReferenceDto;
 
 public class AreaReferenceDto extends ReferenceDto {
+	// todo should this also extend InfrastructureDataReferenceDto? 
 
 	private static final long serialVersionUID = -6241927331721175673L;
 

--- a/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/area/AreaReferenceDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/area/AreaReferenceDto.java
@@ -1,9 +1,8 @@
 package de.symeda.sormas.api.infrastructure.area;
 
-import de.symeda.sormas.api.ReferenceDto;
+import de.symeda.sormas.api.InfrastructureDataReferenceDto;
 
-public class AreaReferenceDto extends ReferenceDto {
-	// todo should this also extend InfrastructureDataReferenceDto? 
+public class AreaReferenceDto extends InfrastructureDataReferenceDto {
 
 	private static final long serialVersionUID = -6241927331721175673L;
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/AbstractBaseEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/AbstractBaseEjb.java
@@ -4,7 +4,7 @@ import de.symeda.sormas.backend.common.AbstractDomainObject;
 import de.symeda.sormas.backend.common.AdoServiceWithUserFilter;
 
 // todo should we use BaseAdoService?
-public abstract class AbstractBaseEjb<DTO extends AbstractDomainObject, SRV extends AdoServiceWithUserFilter<DTO>> {
+public abstract class AbstractBaseEjb<ADO extends AbstractDomainObject, SRV extends AdoServiceWithUserFilter<ADO>> {
 
 	protected SRV service;
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/AbstractBaseEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/AbstractBaseEjb.java
@@ -1,0 +1,23 @@
+package de.symeda.sormas.backend;
+
+import de.symeda.sormas.backend.common.AbstractDomainObject;
+import de.symeda.sormas.backend.common.AdoServiceWithUserFilter;
+
+// todo should we use BaseAdoService?
+public abstract class AbstractBaseEjb<DTO extends AbstractDomainObject, SRV extends AdoServiceWithUserFilter<DTO>> {
+
+	protected SRV service;
+
+	protected AbstractBaseEjb() {
+	}
+
+	protected AbstractBaseEjb(SRV service) {
+		this.service = service;
+	}
+
+	// todo cannot be filled right now as we are missing ArchivableAbstractDomainObject
+	// with this abstract class e.g., ImmunizationFacadeEjb could be wired up to this as well
+	public abstract void archive(String uuid);
+
+	public abstract void dearchive(String uuid);
+}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/AbstractBaseEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/AbstractBaseEjb.java
@@ -1,7 +1,4 @@
-package de.symeda.sormas.backend;
-
-import de.symeda.sormas.backend.common.AbstractDomainObject;
-import de.symeda.sormas.backend.common.AdoServiceWithUserFilter;
+package de.symeda.sormas.backend.common;
 
 // todo should we use BaseAdoService?
 public abstract class AbstractBaseEjb<ADO extends AbstractDomainObject, SRV extends AdoServiceWithUserFilter<ADO>> {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/AbstractBaseEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/AbstractBaseEjb.java
@@ -1,6 +1,5 @@
 package de.symeda.sormas.backend.common;
 
-// todo should we use BaseAdoService?
 public abstract class AbstractBaseEjb<ADO extends AbstractDomainObject, SRV extends AdoServiceWithUserFilter<ADO>> {
 
 	protected SRV service;
@@ -17,4 +16,6 @@ public abstract class AbstractBaseEjb<ADO extends AbstractDomainObject, SRV exte
 	public abstract void archive(String uuid);
 
 	public abstract void dearchive(String uuid);
+
+	// FIXME(@JonasCir) #6821: Add missing functions like save, getByUuid etc
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/AbstractDomainObject.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/AbstractDomainObject.java
@@ -92,7 +92,7 @@ public abstract class AbstractDomainObject implements Serializable, Cloneable, H
 	public String getUuid() {
 
 		if (uuid == null) {
-			/**
+			/*
 			 * New objects should automatically get a UUID.
 			 * This should be returned already before saving via getUuid().
 			 * The generation of UUIDs is relatively time-consuming. Most objects are loaded from the database.

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/AbstractInfrastructureEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/AbstractInfrastructureEjb.java
@@ -36,24 +36,17 @@ public abstract class AbstractInfrastructureEjb<ADO extends InfrastructureAdo, S
 
 	public void dearchive(String uuid) {
 		checkInfraDataLocked();
-		doDearchive(uuid);
-	}
 
-	protected void dearchiveUnchecked(String uuid) {
-		doDearchive(uuid);
-	}
-
-	private void checkInfraDataLocked() {
-		if (!featureConfiguration.isFeatureEnabled(FeatureType.EDIT_INFRASTRUCTURE_DATA)) {
-			throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.infrastructureDataLocked));
-		}
-	}
-
-	private void doDearchive(String uuid) {
 		ADO ado = service.getByUuid(uuid);
 		if (ado != null) {
 			ado.setArchived(false);
 			service.ensurePersisted(ado);
+		}
+	}
+
+	protected void checkInfraDataLocked() {
+		if (!featureConfiguration.isFeatureEnabled(FeatureType.EDIT_INFRASTRUCTURE_DATA)) {
+			throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.infrastructureDataLocked));
 		}
 	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/AbstractInfrastructureEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/AbstractInfrastructureEjb.java
@@ -4,7 +4,7 @@ import de.symeda.sormas.api.feature.FeatureType;
 import de.symeda.sormas.api.i18n.I18nProperties;
 import de.symeda.sormas.api.i18n.Validations;
 import de.symeda.sormas.api.utils.ValidationRuntimeException;
-import de.symeda.sormas.backend.AbstractBaseEjb;
+import de.symeda.sormas.backend.common.AbstractBaseEjb;
 import de.symeda.sormas.backend.common.AbstractInfrastructureAdoService;
 import de.symeda.sormas.backend.common.InfrastructureAdo;
 import de.symeda.sormas.backend.feature.FeatureConfigurationFacadeEjb;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/AbstractInfrastructureEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/AbstractInfrastructureEjb.java
@@ -9,8 +9,8 @@ import de.symeda.sormas.backend.common.AbstractInfrastructureAdoService;
 import de.symeda.sormas.backend.common.InfrastructureAdo;
 import de.symeda.sormas.backend.feature.FeatureConfigurationFacadeEjb;
 
-public abstract class AbstractInfrastructureEjb<DTO extends InfrastructureAdo, SRV extends AbstractInfrastructureAdoService<DTO>>
-	extends AbstractBaseEjb<DTO, SRV> {
+public abstract class AbstractInfrastructureEjb<ADO extends InfrastructureAdo, SRV extends AbstractInfrastructureAdoService<ADO>>
+	extends AbstractBaseEjb<ADO, SRV> {
 
 	protected FeatureConfigurationFacadeEjb featureConfiguration;
 
@@ -27,10 +27,10 @@ public abstract class AbstractInfrastructureEjb<DTO extends InfrastructureAdo, S
 	public void archive(String uuid) {
 		// todo this should be really in the parent but right now there the setter for archived is not available there
 		checkInfraDataLocked();
-		DTO dto = service.getByUuid(uuid);
-		if (dto != null) {
-			dto.setArchived(true);
-			service.ensurePersisted(dto);
+		ADO ado = service.getByUuid(uuid);
+		if (ado != null) {
+			ado.setArchived(true);
+			service.ensurePersisted(ado);
 		}
 	}
 
@@ -50,10 +50,10 @@ public abstract class AbstractInfrastructureEjb<DTO extends InfrastructureAdo, S
 	}
 
 	private void doDearchive(String uuid) {
-		DTO dto = service.getByUuid(uuid);
-		if (dto != null) {
-			dto.setArchived(false);
-			service.ensurePersisted(dto);
+		ADO ado = service.getByUuid(uuid);
+		if (ado != null) {
+			ado.setArchived(false);
+			service.ensurePersisted(ado);
 		}
 	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/AbstractInfrastructureEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/AbstractInfrastructureEjb.java
@@ -1,0 +1,55 @@
+package de.symeda.sormas.backend.infrastructure;
+
+import de.symeda.sormas.api.feature.FeatureType;
+import de.symeda.sormas.api.i18n.I18nProperties;
+import de.symeda.sormas.api.i18n.Validations;
+import de.symeda.sormas.api.utils.ValidationRuntimeException;
+import de.symeda.sormas.backend.AbstractBaseEjb;
+import de.symeda.sormas.backend.common.AbstractInfrastructureAdoService;
+import de.symeda.sormas.backend.common.InfrastructureAdo;
+import de.symeda.sormas.backend.feature.FeatureConfigurationFacadeEjb;
+
+public abstract class AbstractInfrastructureEjb<DTO extends InfrastructureAdo, SRV extends AbstractInfrastructureAdoService<DTO>>
+	extends AbstractBaseEjb<DTO, SRV> {
+
+	protected FeatureConfigurationFacadeEjb featureConfiguration;
+
+	protected AbstractInfrastructureEjb() {
+		super();
+	}
+
+	protected AbstractInfrastructureEjb(SRV service, FeatureConfigurationFacadeEjb featureConfiguration) {
+		super(service);
+		this.featureConfiguration = featureConfiguration;
+	}
+
+	@Override
+	public void archive(String uuid) {
+		// todo this should be really in the parent but right now there the setter for archived is not available there
+		DTO dto = service.getByUuid(uuid);
+		if (dto != null) {
+			dto.setArchived(true);
+			service.ensurePersisted(dto);
+		}
+	}
+
+	public void dearchive(String uuid) {
+		if (!featureConfiguration.isFeatureEnabled(FeatureType.EDIT_INFRASTRUCTURE_DATA)) {
+			throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.infrastructureDataLocked));
+		}
+		doDearchive(uuid);
+	}
+
+	protected void dearchiveUnchecked(String uuid) {
+		doDearchive(uuid);
+	}
+
+	private void doDearchive(String uuid) {
+		DTO dto = service.getByUuid(uuid);
+		if (dto != null) {
+			dto.setArchived(false);
+			service.ensurePersisted(dto);
+		}
+	}
+
+}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/AbstractInfrastructureEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/AbstractInfrastructureEjb.java
@@ -26,6 +26,7 @@ public abstract class AbstractInfrastructureEjb<DTO extends InfrastructureAdo, S
 	@Override
 	public void archive(String uuid) {
 		// todo this should be really in the parent but right now there the setter for archived is not available there
+		checkInfraDataLocked();
 		DTO dto = service.getByUuid(uuid);
 		if (dto != null) {
 			dto.setArchived(true);
@@ -34,14 +35,18 @@ public abstract class AbstractInfrastructureEjb<DTO extends InfrastructureAdo, S
 	}
 
 	public void dearchive(String uuid) {
-		if (!featureConfiguration.isFeatureEnabled(FeatureType.EDIT_INFRASTRUCTURE_DATA)) {
-			throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.infrastructureDataLocked));
-		}
+		checkInfraDataLocked();
 		doDearchive(uuid);
 	}
 
 	protected void dearchiveUnchecked(String uuid) {
 		doDearchive(uuid);
+	}
+
+	private void checkInfraDataLocked() {
+		if (!featureConfiguration.isFeatureEnabled(FeatureType.EDIT_INFRASTRUCTURE_DATA)) {
+			throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.infrastructureDataLocked));
+		}
 	}
 
 	private void doDearchive(String uuid) {
@@ -51,5 +56,4 @@ public abstract class AbstractInfrastructureEjb<DTO extends InfrastructureAdo, S
 			service.ensurePersisted(dto);
 		}
 	}
-
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/area/AreaFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/area/AreaFacadeEjb.java
@@ -116,6 +116,7 @@ public class AreaFacadeEjb extends AbstractInfrastructureEjb<Area, AreaService> 
 
 	@Override
 	public AreaDto save(@Valid AreaDto dto, boolean allowMerge) {
+		checkInfraDataLocked();
 		Area area = service.getByUuid(dto.getUuid());
 
 		if (area == null) {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/area/AreaFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/area/AreaFacadeEjb.java
@@ -137,11 +137,6 @@ public class AreaFacadeEjb extends AbstractInfrastructureEjb<Area, AreaService> 
 	}
 
 	@Override
-	public void dearchive(String uuid) {
-		super.dearchiveUnchecked(uuid);
-	}
-
-	@Override
 	public boolean isUsedInOtherInfrastructureData(Collection<String> areaUuids) {
 		return service.isUsedInInfrastructureData(areaUuids, Region.AREA, Region.class);
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/area/AreaFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/area/AreaFacadeEjb.java
@@ -6,9 +6,9 @@ import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import javax.ejb.EJB;
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
+import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.criteria.CriteriaBuilder;
@@ -28,28 +28,35 @@ import de.symeda.sormas.api.infrastructure.area.AreaFacade;
 import de.symeda.sormas.api.infrastructure.area.AreaReferenceDto;
 import de.symeda.sormas.api.utils.SortProperty;
 import de.symeda.sormas.api.utils.ValidationRuntimeException;
+import de.symeda.sormas.backend.feature.FeatureConfigurationFacadeEjb.FeatureConfigurationFacadeEjbLocal;
+import de.symeda.sormas.backend.infrastructure.AbstractInfrastructureEjb;
 import de.symeda.sormas.backend.infrastructure.region.Region;
 import de.symeda.sormas.backend.util.DtoHelper;
 import de.symeda.sormas.backend.util.ModelConstants;
 import de.symeda.sormas.backend.util.QueryHelper;
 
 @Stateless(name = "AreaFacade")
-public class AreaFacadeEjb implements AreaFacade {
+public class AreaFacadeEjb extends AbstractInfrastructureEjb<Area, AreaService> implements AreaFacade {
 
 	@PersistenceContext(unitName = ModelConstants.PERSISTENCE_UNIT_NAME)
 	private EntityManager em;
 
-	@EJB
-	private AreaService areaService;
+	public AreaFacadeEjb() {
+	}
+
+	@Inject
+	protected AreaFacadeEjb(AreaService service, FeatureConfigurationFacadeEjbLocal featureConfiguration) {
+		super(service, featureConfiguration);
+	}
 
 	@Override
 	public List<AreaReferenceDto> getAllActiveAsReference() {
-		return areaService.getAllActive(Area.NAME, true).stream().map(AreaFacadeEjb::toReferenceDto).collect(Collectors.toList());
+		return service.getAllActive(Area.NAME, true).stream().map(AreaFacadeEjb::toReferenceDto).collect(Collectors.toList());
 	}
 
 	@Override
 	public AreaDto getByUuid(String uuid) {
-		return toDto(areaService.getByUuid(uuid));
+		return toDto(service.getByUuid(uuid));
 	}
 
 	@Override
@@ -58,7 +65,7 @@ public class AreaFacadeEjb implements AreaFacade {
 		CriteriaQuery<Area> cq = cb.createQuery(Area.class);
 		Root<Area> areaRoot = cq.from(Area.class);
 
-		Predicate filter = areaService.buildCriteriaFilter(criteria, cb, areaRoot);
+		Predicate filter = service.buildCriteriaFilter(criteria, cb, areaRoot);
 		if (filter != null) {
 			cq.where(filter);
 		}
@@ -93,7 +100,7 @@ public class AreaFacadeEjb implements AreaFacade {
 		CriteriaQuery<Long> cq = cb.createQuery(Long.class);
 		Root<Area> areaRoot = cq.from(Area.class);
 
-		Predicate filter = areaService.buildCriteriaFilter(criteria, cb, areaRoot);
+		Predicate filter = service.buildCriteriaFilter(criteria, cb, areaRoot);
 		if (filter != null) {
 			cq.where(filter);
 		}
@@ -109,10 +116,10 @@ public class AreaFacadeEjb implements AreaFacade {
 
 	@Override
 	public AreaDto save(@Valid AreaDto dto, boolean allowMerge) {
-		Area area = areaService.getByUuid(dto.getUuid());
+		Area area = service.getByUuid(dto.getUuid());
 
 		if (area == null) {
-			List<Area> duplicates = areaService.getByName(dto.getName(), true);
+			List<Area> duplicates = service.getByName(dto.getName(), true);
 			if (!duplicates.isEmpty()) {
 				if (allowMerge) {
 					area = duplicates.get(0);
@@ -125,50 +132,38 @@ public class AreaFacadeEjb implements AreaFacade {
 		}
 
 		area = fromDto(dto, area, true);
-		areaService.ensurePersisted(area);
+		service.ensurePersisted(area);
 		return toDto(area);
 	}
 
 	@Override
+	public void dearchive(String uuid) {
+		super.dearchiveUnchecked(uuid);
+	}
+
+	@Override
 	public boolean isUsedInOtherInfrastructureData(Collection<String> areaUuids) {
-		return areaService.isUsedInInfrastructureData(areaUuids, Region.AREA, Region.class);
-	}
-
-	@Override
-	public void archive(String areaUuid) {
-		Area area = areaService.getByUuid(areaUuid);
-		area.setArchived(true);
-		areaService.ensurePersisted(area);
-	}
-
-	@Override
-	public void dearchive(String areaUuid) {
-		Area area = areaService.getByUuid(areaUuid);
-		area.setArchived(false);
-		areaService.ensurePersisted(area);
+		return service.isUsedInInfrastructureData(areaUuids, Region.AREA, Region.class);
 	}
 
 	@Override
 	public List<AreaReferenceDto> getByName(String name, boolean includeArchived) {
-		return areaService.getByName(name, includeArchived).stream().map(AreaFacadeEjb::toReferenceDto).collect(Collectors.toList());
+		return service.getByName(name, includeArchived).stream().map(AreaFacadeEjb::toReferenceDto).collect(Collectors.toList());
 	}
 
 	@Override
 	public List<AreaDto> getAllAfter(Date date) {
-		return areaService.getAll((cb, root) -> areaService.createChangeDateFilter(cb, root, date))
-			.stream()
-			.map(this::toDto)
-			.collect(Collectors.toList());
+		return service.getAll((cb, root) -> service.createChangeDateFilter(cb, root, date)).stream().map(this::toDto).collect(Collectors.toList());
 	}
 
 	@Override
 	public List<AreaDto> getByUuids(List<String> uuids) {
-		return areaService.getByUuids(uuids).stream().map(this::toDto).collect(Collectors.toList());
+		return service.getByUuids(uuids).stream().map(this::toDto).collect(Collectors.toList());
 	}
 
 	@Override
 	public List<String> getAllUuids() {
-		return areaService.getAllUuids();
+		return service.getAllUuids();
 	}
 
 	public Area fromDto(@NotNull AreaDto source, Area target, boolean checkChangeDate) {
@@ -184,10 +179,7 @@ public class AreaFacadeEjb implements AreaFacade {
 	@Override
 	public List<AreaReferenceDto> getByExternalId(String externalId, boolean includeArchivedEntities) {
 
-		return areaService.getByExternalId(externalId, includeArchivedEntities)
-			.stream()
-			.map(AreaFacadeEjb::toReferenceDto)
-			.collect(Collectors.toList());
+		return service.getByExternalId(externalId, includeArchivedEntities).stream().map(AreaFacadeEjb::toReferenceDto).collect(Collectors.toList());
 	}
 
 	public AreaDto toDto(Area source) {
@@ -208,8 +200,7 @@ public class AreaFacadeEjb implements AreaFacade {
 		if (entity == null) {
 			return null;
 		}
-		AreaReferenceDto dto = new AreaReferenceDto(entity.getUuid(), entity.toString());
-		return dto;
+		return new AreaReferenceDto(entity.getUuid(), entity.toString());
 	}
 
 	@Override
@@ -221,6 +212,12 @@ public class AreaFacadeEjb implements AreaFacade {
 	@Stateless
 	public static class AreaFacadeEjbLocal extends AreaFacadeEjb {
 
-	}
+		public AreaFacadeEjbLocal() {
+		}
 
+		@Inject
+		protected AreaFacadeEjbLocal(AreaService service, FeatureConfigurationFacadeEjbLocal featureConfiguration) {
+			super(service, featureConfiguration);
+		}
+	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/community/CommunityFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/community/CommunityFacadeEjb.java
@@ -268,10 +268,7 @@ public class CommunityFacadeEjb extends AbstractInfrastructureEjb<Community, Com
 
 	@Override
 	public CommunityDto save(@Valid CommunityDto dto, boolean allowMerge) throws ValidationRuntimeException {
-
-		if (!featureConfiguration.isFeatureEnabled(FeatureType.EDIT_INFRASTRUCTURE_DATA)) {
-			throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.infrastructureDataLocked));
-		}
+		checkInfraDataLocked();
 
 		if (dto.getDistrict() == null) {
 			throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.validDistrict));

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/community/CommunityFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/community/CommunityFacadeEjb.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import javax.ejb.EJB;
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
+import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.criteria.CriteriaBuilder;
@@ -52,6 +53,7 @@ import de.symeda.sormas.api.infrastructure.district.DistrictReferenceDto;
 import de.symeda.sormas.api.utils.SortProperty;
 import de.symeda.sormas.api.utils.ValidationRuntimeException;
 import de.symeda.sormas.backend.feature.FeatureConfigurationFacadeEjb.FeatureConfigurationFacadeEjbLocal;
+import de.symeda.sormas.backend.infrastructure.AbstractInfrastructureEjb;
 import de.symeda.sormas.backend.infrastructure.district.District;
 import de.symeda.sormas.backend.infrastructure.district.DistrictFacadeEjb;
 import de.symeda.sormas.backend.infrastructure.district.DistrictService;
@@ -64,25 +66,29 @@ import de.symeda.sormas.backend.util.ModelConstants;
 import de.symeda.sormas.backend.util.QueryHelper;
 
 @Stateless(name = "CommunityFacade")
-public class CommunityFacadeEjb implements CommunityFacade {
+public class CommunityFacadeEjb extends AbstractInfrastructureEjb<Community, CommunityService> implements CommunityFacade {
 
 	@PersistenceContext(unitName = ModelConstants.PERSISTENCE_UNIT_NAME)
 	private EntityManager em;
 
 	@EJB
-	private CommunityService communityService;
-	@EJB
 	private UserService userService;
 	@EJB
 	private DistrictService districtService;
-	@EJB
-	private FeatureConfigurationFacadeEjbLocal featureConfiguration;
+
+	public CommunityFacadeEjb() {
+	}
+
+	@Inject
+	protected CommunityFacadeEjb(CommunityService service, FeatureConfigurationFacadeEjbLocal featureConfiguration) {
+		super(service, featureConfiguration);
+	}
 
 	@Override
 	public List<CommunityReferenceDto> getAllActiveByDistrict(String districtUuid) {
 
 		District district = districtService.getByUuid(districtUuid);
-		return district.getCommunities().stream().filter(c -> !c.isArchived()).map(f -> toReferenceDto(f)).collect(Collectors.toList());
+		return district.getCommunities().stream().filter(c -> !c.isArchived()).map(CommunityFacadeEjb::toReferenceDto).collect(Collectors.toList());
 	}
 
 	@Override
@@ -94,33 +100,13 @@ public class CommunityFacadeEjb implements CommunityFacade {
 
 		selectDtoFields(cq, community);
 
-		Predicate filter = communityService.createChangeDateFilter(cb, community, date);
+		Predicate filter = service.createChangeDateFilter(cb, community, date);
 
 		if (filter != null) {
 			cq.where(filter);
 		}
 
 		return em.createQuery(cq).getResultList();
-	}
-
-	@Override
-	public void archive(String communityUuid) {
-
-		Community community = communityService.getByUuid(communityUuid);
-		community.setArchived(true);
-		communityService.ensurePersisted(community);
-	}
-
-	@Override
-	public void dearchive(String communityUuid) {
-
-		if (!featureConfiguration.isFeatureEnabled(FeatureType.EDIT_INFRASTRUCTURE_DATA)) {
-			throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.infrastructureDataLocked));
-		}
-
-		Community community = communityService.getByUuid(communityUuid);
-		community.setArchived(false);
-		communityService.ensurePersisted(community);
 	}
 
 	// Need to be in the same order as in the constructor
@@ -156,7 +142,7 @@ public class CommunityFacadeEjb implements CommunityFacade {
 
 		Predicate filter = null;
 		if (criteria != null) {
-			filter = communityService.buildCriteriaFilter(criteria, cb, community);
+			filter = service.buildCriteriaFilter(criteria, cb, community);
 		}
 
 		if (filter != null) {
@@ -215,7 +201,7 @@ public class CommunityFacadeEjb implements CommunityFacade {
 		Predicate filter = null;
 
 		if (criteria != null) {
-			filter = communityService.buildCriteriaFilter(criteria, cb, root);
+			filter = service.buildCriteriaFilter(criteria, cb, root);
 		}
 
 		if (filter != null) {
@@ -233,27 +219,27 @@ public class CommunityFacadeEjb implements CommunityFacade {
 			return Collections.emptyList();
 		}
 
-		return communityService.getAllUuids();
+		return service.getAllUuids();
 	}
 
 	@Override
 	public CommunityDto getByUuid(String uuid) {
-		return toDto(communityService.getByUuid(uuid));
+		return toDto(service.getByUuid(uuid));
 	}
 
 	@Override
 	public List<CommunityDto> getByUuids(List<String> uuids) {
-		return communityService.getByUuids(uuids).stream().map(c -> toDto(c)).collect(Collectors.toList());
+		return service.getByUuids(uuids).stream().map(this::toDto).collect(Collectors.toList());
 	}
 
 	@Override
 	public CommunityReferenceDto getCommunityReferenceByUuid(String uuid) {
-		return toReferenceDto(communityService.getByUuid(uuid));
+		return toReferenceDto(service.getByUuid(uuid));
 	}
 
 	@Override
 	public CommunityReferenceDto getCommunityReferenceById(long id) {
-		return toReferenceDto(communityService.getById(id));
+		return toReferenceDto(service.getById(id));
 	}
 
 	@Override
@@ -291,14 +277,14 @@ public class CommunityFacadeEjb implements CommunityFacade {
 			throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.validDistrict));
 		}
 
-		Community community = communityService.getByUuid(dto.getUuid());
+		Community community = service.getByUuid(dto.getUuid());
 
 		if (community == null) {
 			List<CommunityReferenceDto> duplicates = getByName(dto.getName(), dto.getDistrict(), true);
 			if (!duplicates.isEmpty()) {
 				if (allowMerge) {
 					String uuid = duplicates.get(0).getUuid();
-					community = communityService.getByUuid(uuid);
+					community = service.getByUuid(uuid);
 					CommunityDto dtoToMerge = getByUuid(uuid);
 					dto = DtoHelper.copyDtoValues(dtoToMerge, dto, true);
 				} else {
@@ -307,14 +293,14 @@ public class CommunityFacadeEjb implements CommunityFacade {
 			}
 		}
 		community = fillOrBuildEntity(dto, community, true);
-		communityService.ensurePersisted(community);
+		service.ensurePersisted(community);
 		return toDto(community);
 	}
 
 	@Override
 	public List<CommunityReferenceDto> getByName(String name, DistrictReferenceDto districtRef, boolean includeArchivedEntities) {
 
-		return communityService.getByName(name, districtService.getByReferenceDto(districtRef), includeArchivedEntities)
+		return service.getByName(name, districtService.getByReferenceDto(districtRef), includeArchivedEntities)
 			.stream()
 			.map(CommunityFacadeEjb::toReferenceDto)
 			.collect(Collectors.toList());
@@ -323,7 +309,7 @@ public class CommunityFacadeEjb implements CommunityFacade {
 	@Override
 	public List<CommunityReferenceDto> getByExternalId(String externalId, boolean includeArchivedEntities) {
 
-		return communityService.getByExternalId(externalId, includeArchivedEntities)
+		return service.getByExternalId(externalId, includeArchivedEntities)
 			.stream()
 			.map(CommunityFacadeEjb::toReferenceDto)
 			.collect(Collectors.toList());
@@ -336,7 +322,7 @@ public class CommunityFacadeEjb implements CommunityFacade {
 
 	@Override
 	public boolean isUsedInOtherInfrastructureData(Collection<String> communityUuids) {
-		return communityService.isUsedInInfrastructureData(communityUuids, Facility.COMMUNITY, Facility.class);
+		return service.isUsedInInfrastructureData(communityUuids, Facility.COMMUNITY, Facility.class);
 	}
 
 	@Override
@@ -402,5 +388,12 @@ public class CommunityFacadeEjb implements CommunityFacade {
 	@Stateless
 	public static class CommunityFacadeEjbLocal extends CommunityFacadeEjb {
 
+		public CommunityFacadeEjbLocal() {
+		}
+
+		@Inject
+		protected CommunityFacadeEjbLocal(CommunityService service, FeatureConfigurationFacadeEjbLocal featureConfiguration) {
+			super(service, featureConfiguration);
+		}
 	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/continent/ContinentFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/continent/ContinentFacadeEjb.java
@@ -196,10 +196,7 @@ public class ContinentFacadeEjb extends AbstractInfrastructureEjb<Continent, Con
 
 	@Override
 	public ContinentDto save(@Valid ContinentDto dto, boolean allowMerge) {
-
-		if (!featureConfiguration.isFeatureEnabled(FeatureType.EDIT_INFRASTRUCTURE_DATA)) {
-			throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.infrastructureDataLocked));
-		}
+		checkInfraDataLocked();
 
 		Continent continent = service.getByUuid(dto.getUuid());
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/continent/ContinentFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/continent/ContinentFacadeEjb.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 import javax.ejb.EJB;
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
+import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.criteria.CriteriaBuilder;
@@ -50,6 +51,7 @@ import de.symeda.sormas.api.infrastructure.subcontinent.SubcontinentReferenceDto
 import de.symeda.sormas.api.utils.SortProperty;
 import de.symeda.sormas.api.utils.ValidationRuntimeException;
 import de.symeda.sormas.backend.feature.FeatureConfigurationFacadeEjb.FeatureConfigurationFacadeEjbLocal;
+import de.symeda.sormas.backend.infrastructure.AbstractInfrastructureEjb;
 import de.symeda.sormas.backend.infrastructure.country.Country;
 import de.symeda.sormas.backend.infrastructure.country.CountryService;
 import de.symeda.sormas.backend.infrastructure.subcontinent.Subcontinent;
@@ -59,19 +61,23 @@ import de.symeda.sormas.backend.util.ModelConstants;
 import de.symeda.sormas.backend.util.QueryHelper;
 
 @Stateless(name = "ContinentFacade")
-public class ContinentFacadeEjb implements ContinentFacade {
+public class ContinentFacadeEjb extends AbstractInfrastructureEjb<Continent, ContinentService> implements ContinentFacade {
 
 	@PersistenceContext(unitName = ModelConstants.PERSISTENCE_UNIT_NAME)
 	private EntityManager em;
 
 	@EJB
-	private ContinentService continentService;
-	@EJB
 	private CountryService countryService;
 	@EJB
 	private SubcontinentService subcontinentService;
-	@EJB
-	private FeatureConfigurationFacadeEjbLocal featureConfiguration;
+
+	public ContinentFacadeEjb() {
+	}
+
+	@Inject
+	protected ContinentFacadeEjb(ContinentService service, FeatureConfigurationFacadeEjbLocal featureConfiguration) {
+		super(service, featureConfiguration);
+	}
 
 	public static ContinentReferenceDto toReferenceDto(Continent entity) {
 		if (entity == null) {
@@ -89,15 +95,12 @@ public class ContinentFacadeEjb implements ContinentFacade {
 
 	@Override
 	public List<ContinentReferenceDto> getByDefaultName(String name, boolean includeArchivedEntities) {
-		return continentService.getByDefaultName(name, includeArchivedEntities)
-			.stream()
-			.map(ContinentFacadeEjb::toReferenceDto)
-			.collect(Collectors.toList());
+		return service.getByDefaultName(name, includeArchivedEntities).stream().map(ContinentFacadeEjb::toReferenceDto).collect(Collectors.toList());
 	}
 
 	@Override
 	public boolean isUsedInOtherInfrastructureData(Collection<String> continentUuids) {
-		return continentService.isUsedInInfrastructureData(continentUuids, Subcontinent.CONTINENT, Subcontinent.class);
+		return service.isUsedInInfrastructureData(continentUuids, Subcontinent.CONTINENT, Subcontinent.class);
 	}
 
 	@Override
@@ -121,7 +124,7 @@ public class ContinentFacadeEjb implements ContinentFacade {
 
 	@Override
 	public ContinentDto getByUuid(String uuid) {
-		return toDto(continentService.getByUuid(uuid));
+		return toDto(service.getByUuid(uuid));
 	}
 
 	@Override
@@ -130,7 +133,7 @@ public class ContinentFacadeEjb implements ContinentFacade {
 		CriteriaQuery<Continent> cq = cb.createQuery(Continent.class);
 		Root<Continent> continent = cq.from(Continent.class);
 
-		Predicate filter = continentService.buildCriteriaFilter(criteria, cb, continent);
+		Predicate filter = service.buildCriteriaFilter(criteria, cb, continent);
 
 		if (filter != null) {
 			cq.where(filter).distinct(true);
@@ -163,49 +166,23 @@ public class ContinentFacadeEjb implements ContinentFacade {
 	}
 
 	@Override
-	public void archive(String uuid) {
-		Continent continent = continentService.getByUuid(uuid);
-		if (continent != null) {
-			continent.setArchived(true);
-			continentService.ensurePersisted(continent);
-		}
-	}
-
-	@Override
-	public void dearchive(String uuid) {
-
-		if (!featureConfiguration.isFeatureEnabled(FeatureType.EDIT_INFRASTRUCTURE_DATA)) {
-			throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.infrastructureDataLocked));
-		}
-
-		Continent continent = continentService.getByUuid(uuid);
-		if (continent != null) {
-			continent.setArchived(false);
-			continentService.ensurePersisted(continent);
-		}
-	}
-
-	@Override
 	public List<ContinentDto> getAllAfter(Date date) {
-		return continentService.getAll((cb, root) -> continentService.createChangeDateFilter(cb, root, date))
-			.stream()
-			.map(this::toDto)
-			.collect(Collectors.toList());
+		return service.getAll((cb, root) -> service.createChangeDateFilter(cb, root, date)).stream().map(this::toDto).collect(Collectors.toList());
 	}
 
 	@Override
 	public List<ContinentDto> getByUuids(List<String> uuids) {
-		return continentService.getByUuids(uuids).stream().map(this::toDto).collect(Collectors.toList());
+		return service.getByUuids(uuids).stream().map(this::toDto).collect(Collectors.toList());
 	}
 
 	@Override
 	public List<String> getAllUuids() {
-		return continentService.getAllUuids();
+		return service.getAllUuids();
 	}
 
 	@Override
 	public List<ContinentReferenceDto> getAllActiveAsReference() {
-		return continentService.getAllActive(Continent.DEFAULT_NAME, true)
+		return service.getAllActive(Continent.DEFAULT_NAME, true)
 			.stream()
 			.map(ContinentFacadeEjb::toReferenceDto)
 			.sorted(Comparator.comparing(ContinentReferenceDto::getCaption))
@@ -224,10 +201,10 @@ public class ContinentFacadeEjb implements ContinentFacade {
 			throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.infrastructureDataLocked));
 		}
 
-		Continent continent = continentService.getByUuid(dto.getUuid());
+		Continent continent = service.getByUuid(dto.getUuid());
 
 		if (continent == null) {
-			List<Continent> duplicates = continentService.getByDefaultName(dto.getDefaultName(), true);
+			List<Continent> duplicates = service.getByDefaultName(dto.getDefaultName(), true);
 			if (!duplicates.isEmpty()) {
 				if (allowMerge) {
 					continent = duplicates.get(0);
@@ -240,14 +217,14 @@ public class ContinentFacadeEjb implements ContinentFacade {
 		}
 
 		continent = fillOrBuildEntity(dto, continent, true);
-		continentService.ensurePersisted(continent);
+		service.ensurePersisted(continent);
 
 		return toDto(continent);
 	}
 
 	@Override
 	public long count(ContinentCriteria criteria) {
-		return continentService.count((cb, root) -> continentService.buildCriteriaFilter(criteria, cb, root));
+		return service.count((cb, root) -> service.buildCriteriaFilter(criteria, cb, root));
 	}
 
 	public ContinentDto toDto(Continent entity) {
@@ -282,14 +259,11 @@ public class ContinentFacadeEjb implements ContinentFacade {
 	}
 
 	public List<ContinentReferenceDto> getByExternalId(String externalId, boolean includeArchived) {
-		return continentService.getByExternalId(externalId, includeArchived)
-			.stream()
-			.map(ContinentFacadeEjb::toReferenceDto)
-			.collect(Collectors.toList());
+		return service.getByExternalId(externalId, includeArchived).stream().map(ContinentFacadeEjb::toReferenceDto).collect(Collectors.toList());
 	}
 
 	public List<ContinentReferenceDto> getReferencesByName(String name, boolean includeArchived) {
-		return continentService.getByDefaultName(name, includeArchived).stream().map(ContinentFacadeEjb::toReferenceDto).collect(Collectors.toList());
+		return service.getByDefaultName(name, includeArchived).stream().map(ContinentFacadeEjb::toReferenceDto).collect(Collectors.toList());
 	}
 
 	private Continent fillOrBuildEntity(@NotNull ContinentDto source, Continent target, boolean checkChangeDate) {
@@ -306,5 +280,13 @@ public class ContinentFacadeEjb implements ContinentFacade {
 	@Stateless
 	public static class ContinentFacadeEjbLocal extends ContinentFacadeEjb {
 
+		public ContinentFacadeEjbLocal() {
+
+		}
+
+		@Inject
+		protected ContinentFacadeEjbLocal(ContinentService service, FeatureConfigurationFacadeEjbLocal featureConfiguration) {
+			super(service, featureConfiguration);
+		}
 	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/country/CountryFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/country/CountryFacadeEjb.java
@@ -204,10 +204,8 @@ public class CountryFacadeEjb extends AbstractInfrastructureEjb<Country, Country
 
 	@Override
 	public CountryDto save(@Valid CountryDto dto, boolean allowMerge) throws ValidationRuntimeException {
-
-		if (!featureConfiguration.isFeatureEnabled(FeatureType.EDIT_INFRASTRUCTURE_DATA)) {
-			throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.infrastructureDataLocked));
-		}
+		checkInfraDataLocked();
+		
 		if (StringUtils.isBlank(dto.getIsoCode())) {
 			throw new EmptyValueException(I18nProperties.getValidationError(Validations.importCountryEmptyIso));
 		}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/country/CountryFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/country/CountryFacadeEjb.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import javax.ejb.EJB;
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
+import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.criteria.CriteriaBuilder;
@@ -41,6 +42,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 import de.symeda.sormas.api.feature.FeatureType;
+import de.symeda.sormas.backend.infrastructure.AbstractInfrastructureEjb;
 import org.apache.commons.lang3.StringUtils;
 
 import de.symeda.sormas.api.common.Page;
@@ -68,13 +70,10 @@ import de.symeda.sormas.backend.util.ModelConstants;
 import de.symeda.sormas.backend.util.QueryHelper;
 
 @Stateless(name = "CountryFacade")
-public class CountryFacadeEjb implements CountryFacade {
+public class CountryFacadeEjb extends AbstractInfrastructureEjb<Country, CountryService> implements CountryFacade {
 
 	@PersistenceContext(unitName = ModelConstants.PERSISTENCE_UNIT_NAME)
 	private EntityManager em;
-
-	@EJB
-	private CountryService countryService;
 
 	@EJB
 	private ContinentService continentService;
@@ -87,25 +86,27 @@ public class CountryFacadeEjb implements CountryFacade {
 	@EJB
 	private ConfigFacadeEjb.ConfigFacadeEjbLocal configFacadeEjb;
 
-	@EJB
-	private FeatureConfigurationFacadeEjbLocal featureConfiguration;
+	public CountryFacadeEjb() {
+	}
+
+	@Inject
+	protected CountryFacadeEjb(CountryService service, FeatureConfigurationFacadeEjbLocal featureConfiguration) {
+		super(service, featureConfiguration);
+	}
 
 	@Override
 	public CountryDto getCountryByUuid(String uuid) {
-		return toDto(countryService.getByUuid(uuid));
+		return toDto(service.getByUuid(uuid));
 	}
 
 	@Override
 	public List<CountryReferenceDto> getByDefaultName(String name, boolean includeArchivedEntities) {
-		return countryService.getByDefaultName(name, includeArchivedEntities)
-			.stream()
-			.map(CountryFacadeEjb::toReferenceDto)
-			.collect(Collectors.toList());
+		return service.getByDefaultName(name, includeArchivedEntities).stream().map(CountryFacadeEjb::toReferenceDto).collect(Collectors.toList());
 	}
 
 	@Override
 	public CountryDto getByIsoCode(String isoCode, boolean includeArchivedEntities) {
-		return countryService.getByIsoCode(isoCode, includeArchivedEntities).map(this::toDto).orElse(null);
+		return service.getByIsoCode(isoCode, includeArchivedEntities).map(this::toDto).orElse(null);
 	}
 
 	@Override
@@ -132,7 +133,7 @@ public class CountryFacadeEjb implements CountryFacade {
 
 		Predicate filter = null;
 		if (criteria != null) {
-			filter = countryService.buildCriteriaFilter(criteria, cb, country);
+			filter = service.buildCriteriaFilter(criteria, cb, country);
 		}
 
 		if (filter != null) {
@@ -185,7 +186,7 @@ public class CountryFacadeEjb implements CountryFacade {
 		Predicate filter = null;
 
 		if (criteria != null) {
-			filter = countryService.buildCriteriaFilter(criteria, cb, root);
+			filter = service.buildCriteriaFilter(criteria, cb, root);
 		}
 
 		if (filter != null) {
@@ -211,11 +212,11 @@ public class CountryFacadeEjb implements CountryFacade {
 			throw new EmptyValueException(I18nProperties.getValidationError(Validations.importCountryEmptyIso));
 		}
 
-		Country country = countryService.getByUuid(dto.getUuid());
+		Country country = service.getByUuid(dto.getUuid());
 
 		if (country == null) {
-			Optional<Country> byIsoCode = countryService.getByIsoCode(dto.getIsoCode(), true);
-			Optional<Country> byUnoCode = countryService.getByUnoCode(dto.getUnoCode(), true);
+			Optional<Country> byIsoCode = service.getByIsoCode(dto.getIsoCode(), true);
+			Optional<Country> byUnoCode = service.getByUnoCode(dto.getUnoCode(), true);
 			if (byIsoCode.isPresent() || byUnoCode.isPresent()) {
 				if (allowMerge) {
 					country = byIsoCode.isPresent() ? byIsoCode.get() : byUnoCode.get();
@@ -228,31 +229,8 @@ public class CountryFacadeEjb implements CountryFacade {
 		}
 
 		country = fillOrBuildEntity(dto, country, true);
-		countryService.ensurePersisted(country);
+		service.ensurePersisted(country);
 		return toDto(country);
-	}
-
-	@Override
-	public void archive(String countryUuid) {
-		Country country = countryService.getByUuid(countryUuid);
-		if (country != null) {
-			country.setArchived(true);
-			countryService.ensurePersisted(country);
-		}
-	}
-
-	@Override
-	public void dearchive(String countryUuid) {
-
-		if (!featureConfiguration.isFeatureEnabled(FeatureType.EDIT_INFRASTRUCTURE_DATA)) {
-			throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.infrastructureDataLocked));
-		}
-
-		Country country = countryService.getByUuid(countryUuid);
-		if (country != null) {
-			country.setArchived(false);
-			countryService.ensurePersisted(country);
-		}
 	}
 
 	public static CountryReferenceDto toReferenceDto(Country entity) {
@@ -315,14 +293,11 @@ public class CountryFacadeEjb implements CountryFacade {
 	}
 
 	public List<CountryReferenceDto> getByExternalId(String externalId, boolean includeArchived) {
-		return countryService.getByExternalId(externalId, includeArchived)
-			.stream()
-			.map(CountryFacadeEjb::toReferenceDto)
-			.collect(Collectors.toList());
+		return service.getByExternalId(externalId, includeArchived).stream().map(CountryFacadeEjb::toReferenceDto).collect(Collectors.toList());
 	}
 
 	public List<CountryReferenceDto> getReferencesByName(String caption, boolean includeArchived) {
-		return countryService.getByDefaultName(caption, includeArchived).stream().map(CountryFacadeEjb::toReferenceDto).collect(Collectors.toList());
+		return service.getByDefaultName(caption, includeArchived).stream().map(CountryFacadeEjb::toReferenceDto).collect(Collectors.toList());
 	}
 
 	private Country fillOrBuildEntity(@NotNull CountryDto source, Country target, boolean checkChangeDate) {
@@ -341,12 +316,6 @@ public class CountryFacadeEjb implements CountryFacade {
 		return target;
 	}
 
-	@LocalBean
-	@Stateless
-	public static class CountryFacadeEjbLocal extends CountryFacadeEjb {
-
-	}
-
 	@Override
 	public List<CountryDto> getAllAfter(Date date) {
 		CriteriaBuilder cb = em.getCriteriaBuilder();
@@ -355,7 +324,7 @@ public class CountryFacadeEjb implements CountryFacade {
 
 		selectDtoFields(cq, country);
 
-		Predicate filter = countryService.createChangeDateFilter(cb, country, date);
+		Predicate filter = service.createChangeDateFilter(cb, country, date);
 
 		if (filter != null) {
 			cq.where(filter);
@@ -364,15 +333,14 @@ public class CountryFacadeEjb implements CountryFacade {
 		return em.createQuery(cq).getResultList();
 	}
 
-
 	@Override
 	public CountryDto getByUuid(String uuid) {
-		return toDto(countryService.getByUuid(uuid));
+		return toDto(service.getByUuid(uuid));
 	}
 
 	@Override
 	public List<CountryDto> getByUuids(List<String> uuids) {
-		return countryService.getByUuids(uuids).stream().map(this::toDto).collect(Collectors.toList());
+		return service.getByUuids(uuids).stream().map(this::toDto).collect(Collectors.toList());
 	}
 
 	@Override
@@ -380,12 +348,12 @@ public class CountryFacadeEjb implements CountryFacade {
 		if (userService.getCurrentUser() == null) {
 			return Collections.emptyList();
 		}
-		return countryService.getAllUuids();
+		return service.getAllUuids();
 	}
 
 	@Override
 	public List<CountryReferenceDto> getAllActiveAsReference() {
-		return countryService.getAllActive(Country.ISO_CODE, true)
+		return service.getAllActive(Country.ISO_CODE, true)
 			.stream()
 			.map(CountryFacadeEjb::toReferenceDto)
 			.sorted(Comparator.comparing(CountryReferenceDto::getCaption))
@@ -431,5 +399,18 @@ public class CountryFacadeEjb implements CountryFacade {
 			subcontinent.get(Subcontinent.UUID),
 			subcontinent.get(Subcontinent.DEFAULT_NAME),
 			subcontinent.get(Subcontinent.EXTERNAL_ID));
+	}
+
+	@LocalBean
+	@Stateless
+	public static class CountryFacadeEjbLocal extends CountryFacadeEjb {
+
+		public CountryFacadeEjbLocal() {
+		}
+
+		@Inject
+		protected CountryFacadeEjbLocal(CountryService service, FeatureConfigurationFacadeEjbLocal featureConfiguration) {
+			super(service, featureConfiguration);
+		}
 	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/district/DistrictFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/district/DistrictFacadeEjb.java
@@ -289,10 +289,7 @@ public class DistrictFacadeEjb extends AbstractInfrastructureEjb<District, Distr
 
 	@Override
 	public DistrictDto save(@Valid DistrictDto dto, boolean allowMerge) throws ValidationRuntimeException {
-
-		if (!featureConfiguration.isFeatureEnabled(FeatureType.EDIT_INFRASTRUCTURE_DATA)) {
-			throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.infrastructureDataLocked));
-		}
+		checkInfraDataLocked();
 
 		if (dto.getRegion() == null) {
 			throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.validRegion));

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/district/DistrictFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/district/DistrictFacadeEjb.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import javax.ejb.EJB;
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
+import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.criteria.CriteriaBuilder;
@@ -53,6 +54,7 @@ import de.symeda.sormas.api.infrastructure.region.RegionReferenceDto;
 import de.symeda.sormas.api.utils.SortProperty;
 import de.symeda.sormas.api.utils.ValidationRuntimeException;
 import de.symeda.sormas.backend.feature.FeatureConfigurationFacadeEjb.FeatureConfigurationFacadeEjbLocal;
+import de.symeda.sormas.backend.infrastructure.AbstractInfrastructureEjb;
 import de.symeda.sormas.backend.infrastructure.PopulationDataFacadeEjb.PopulationDataFacadeEjbLocal;
 import de.symeda.sormas.backend.infrastructure.area.Area;
 import de.symeda.sormas.backend.infrastructure.area.AreaService;
@@ -68,13 +70,11 @@ import de.symeda.sormas.backend.util.ModelConstants;
 import de.symeda.sormas.backend.util.QueryHelper;
 
 @Stateless(name = "DistrictFacade")
-public class DistrictFacadeEjb implements DistrictFacade {
+public class DistrictFacadeEjb extends AbstractInfrastructureEjb<District, DistrictService> implements DistrictFacade {
 
 	@PersistenceContext(unitName = ModelConstants.PERSISTENCE_UNIT_NAME)
 	private EntityManager em;
 
-	@EJB
-	private DistrictService districtService;
 	@EJB
 	private UserService userService;
 	@EJB
@@ -83,19 +83,25 @@ public class DistrictFacadeEjb implements DistrictFacade {
 	private RegionService regionService;
 	@EJB
 	private PopulationDataFacadeEjbLocal populationDataFacade;
-	@EJB
-	private FeatureConfigurationFacadeEjbLocal featureConfiguration;
+
+	public DistrictFacadeEjb() {
+	}
+
+	@Inject
+	protected DistrictFacadeEjb(DistrictService service, FeatureConfigurationFacadeEjbLocal featureConfiguration) {
+		super(service, featureConfiguration);
+	}
 
 	@Override
 	public List<DistrictReferenceDto> getAllActiveAsReference() {
-		return districtService.getAllActive(District.NAME, true).stream().map(f -> toReferenceDto(f)).collect(Collectors.toList());
+		return service.getAllActive(District.NAME, true).stream().map(f -> toReferenceDto(f)).collect(Collectors.toList());
 	}
 
 	@Override
 	public List<DistrictReferenceDto> getAllActiveByArea(String areaUuid) {
 
 		Area area = areaService.getByUuid(areaUuid);
-		return districtService.getAllActiveByArea(area).stream().map(f -> toReferenceDto(f)).collect(Collectors.toList());
+		return service.getAllActiveByArea(area).stream().map(f -> toReferenceDto(f)).collect(Collectors.toList());
 	}
 
 	@Override
@@ -114,7 +120,7 @@ public class DistrictFacadeEjb implements DistrictFacade {
 
 		selectDtoFields(cq, district);
 
-		Predicate filter = districtService.createChangeDateFilter(cb, district, date);
+		Predicate filter = service.createChangeDateFilter(cb, district, date);
 
 		if (filter != null) {
 			cq.where(filter);
@@ -144,7 +150,7 @@ public class DistrictFacadeEjb implements DistrictFacade {
 
 	@Override
 	public DistrictDto getByUuid(String uuid) {
-		return toDto(districtService.getByUuid(uuid));
+		return toDto(service.getByUuid(uuid));
 	}
 
 	@Override
@@ -157,7 +163,7 @@ public class DistrictFacadeEjb implements DistrictFacade {
 
 		Predicate filter = null;
 		if (criteria != null) {
-			filter = districtService.buildCriteriaFilter(criteria, cb, district);
+			filter = service.buildCriteriaFilter(criteria, cb, district);
 		}
 
 		if (filter != null) {
@@ -209,7 +215,7 @@ public class DistrictFacadeEjb implements DistrictFacade {
 		Predicate filter = null;
 
 		if (criteria != null) {
-			filter = districtService.buildCriteriaFilter(criteria, cb, root);
+			filter = service.buildCriteriaFilter(criteria, cb, root);
 		}
 
 		if (filter != null) {
@@ -227,34 +233,34 @@ public class DistrictFacadeEjb implements DistrictFacade {
 			return Collections.emptyList();
 		}
 
-		return districtService.getAllUuids();
+		return service.getAllUuids();
 	}
 
 	@Override
 	public int getCountByRegion(String regionUuid) {
 
 		Region region = regionService.getByUuid(regionUuid);
-		return districtService.getCountByRegion(region);
+		return service.getCountByRegion(region);
 	}
 
 	@Override
 	public DistrictDto getDistrictByUuid(String uuid) {
-		return toDto(districtService.getByUuid(uuid));
+		return toDto(service.getByUuid(uuid));
 	}
 
 	@Override
 	public List<DistrictDto> getByUuids(List<String> uuids) {
-		return districtService.getByUuids(uuids).stream().map(c -> toDto(c)).collect(Collectors.toList());
+		return service.getByUuids(uuids).stream().map(c -> toDto(c)).collect(Collectors.toList());
 	}
 
 	@Override
 	public DistrictReferenceDto getDistrictReferenceByUuid(String uuid) {
-		return toReferenceDto(districtService.getByUuid(uuid));
+		return toReferenceDto(service.getByUuid(uuid));
 	}
 
 	@Override
 	public DistrictReferenceDto getDistrictReferenceById(long id) {
-		return toReferenceDto(districtService.getById(id));
+		return toReferenceDto(service.getById(id));
 	}
 
 	@Override
@@ -292,14 +298,14 @@ public class DistrictFacadeEjb implements DistrictFacade {
 			throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.validRegion));
 		}
 
-		District district = districtService.getByUuid(dto.getUuid());
+		District district = service.getByUuid(dto.getUuid());
 
 		if (district == null) {
 			List<DistrictReferenceDto> duplicates = getByName(dto.getName(), dto.getRegion(), true);
 			if (!duplicates.isEmpty()) {
 				if (allowMerge) {
 					String uuid = duplicates.get(0).getUuid();
-					district = districtService.getByUuid(uuid);
+					district = service.getByUuid(uuid);
 					DistrictDto dtoToMerge = getDistrictByUuid(uuid);
 					dto = DtoHelper.copyDtoValues(dtoToMerge, dto, true);
 				} else {
@@ -309,14 +315,14 @@ public class DistrictFacadeEjb implements DistrictFacade {
 		}
 
 		district = fillOrBuildEntity(dto, district, true);
-		districtService.ensurePersisted(district);
+		service.ensurePersisted(district);
 		return toDto(district);
 	}
 
 	@Override
 	public List<DistrictReferenceDto> getByName(String name, RegionReferenceDto regionRef, boolean includeArchivedEntities) {
 
-		return districtService.getByName(name, regionService.getByReferenceDto(regionRef), includeArchivedEntities)
+		return service.getByName(name, regionService.getByReferenceDto(regionRef), includeArchivedEntities)
 			.stream()
 			.map(DistrictFacadeEjb::toReferenceDto)
 			.collect(Collectors.toList());
@@ -325,7 +331,7 @@ public class DistrictFacadeEjb implements DistrictFacade {
 	@Override
 	public List<DistrictReferenceDto> getByExternalId(String externalId, boolean includeArchivedEntities) {
 
-		return districtService.getByExternalId(externalId, includeArchivedEntities)
+		return service.getByExternalId(externalId, includeArchivedEntities)
 			.stream()
 			.map(DistrictFacadeEjb::toReferenceDto)
 			.collect(Collectors.toList());
@@ -350,31 +356,11 @@ public class DistrictFacadeEjb implements DistrictFacade {
 	}
 
 	@Override
-	public void archive(String districtUuid) {
-
-		District district = districtService.getByUuid(districtUuid);
-		district.setArchived(true);
-		districtService.ensurePersisted(district);
-	}
-
-	@Override
-	public void dearchive(String districtUuid) {
-
-		if (!featureConfiguration.isFeatureEnabled(FeatureType.EDIT_INFRASTRUCTURE_DATA)) {
-			throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.infrastructureDataLocked));
-		}
-
-		District district = districtService.getByUuid(districtUuid);
-		district.setArchived(false);
-		districtService.ensurePersisted(district);
-	}
-
-	@Override
 	public boolean isUsedInOtherInfrastructureData(Collection<String> districtUuids) {
 
-		return districtService.isUsedInInfrastructureData(districtUuids, Community.DISTRICT, Community.class)
-			|| districtService.isUsedInInfrastructureData(districtUuids, Facility.DISTRICT, Facility.class)
-			|| districtService.isUsedInInfrastructureData(districtUuids, PointOfEntry.DISTRICT, PointOfEntry.class);
+		return service.isUsedInInfrastructureData(districtUuids, Community.DISTRICT, Community.class)
+			|| service.isUsedInInfrastructureData(districtUuids, Facility.DISTRICT, Facility.class)
+			|| service.isUsedInInfrastructureData(districtUuids, PointOfEntry.DISTRICT, PointOfEntry.class);
 	}
 
 	@Override
@@ -457,7 +443,7 @@ public class DistrictFacadeEjb implements DistrictFacade {
 	@Override
 	public String getFullEpidCodeForDistrict(String districtUuid) {
 
-		District district = districtService.getByUuid(districtUuid);
+		District district = service.getByUuid(districtUuid);
 		return getFullEpidCodeForDistrict(district);
 	}
 
@@ -470,5 +456,12 @@ public class DistrictFacadeEjb implements DistrictFacade {
 	@Stateless
 	public static class DistrictFacadeEjbLocal extends DistrictFacadeEjb {
 
+		public DistrictFacadeEjbLocal() {
+		}
+
+		@Inject
+		protected DistrictFacadeEjbLocal(DistrictService service, FeatureConfigurationFacadeEjbLocal featureConfiguration) {
+			super(service, featureConfiguration);
+		}
 	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/facility/FacilityFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/facility/FacilityFacadeEjb.java
@@ -621,8 +621,8 @@ public class FacilityFacadeEjb extends AbstractInfrastructureEjb<Facility, Facil
 	}
 
 	@Override
-	public void dearchive(String uuid) {
-		super.dearchiveUnchecked(uuid);
+	protected void checkInfraDataLocked() {
+		// facilities are excluded from infra. data locking for now...
 	}
 
 	private void validateFacilityDto(FacilityDto dto) {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/facility/FacilityFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/facility/FacilityFacadeEjb.java
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 import javax.ejb.EJB;
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
+import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.criteria.CriteriaBuilder;
@@ -42,6 +43,8 @@ import javax.persistence.criteria.Root;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
+import de.symeda.sormas.backend.feature.FeatureConfigurationFacadeEjb.FeatureConfigurationFacadeEjbLocal;
+import de.symeda.sormas.backend.infrastructure.AbstractInfrastructureEjb;
 import org.apache.commons.collections.CollectionUtils;
 
 import de.symeda.sormas.api.ReferenceDto;
@@ -75,13 +78,11 @@ import de.symeda.sormas.backend.util.ModelConstants;
 import de.symeda.sormas.backend.util.QueryHelper;
 
 @Stateless(name = "FacilityFacade")
-public class FacilityFacadeEjb implements FacilityFacade {
+public class FacilityFacadeEjb extends AbstractInfrastructureEjb<Facility, FacilityService> implements FacilityFacade {
 
 	@PersistenceContext(unitName = ModelConstants.PERSISTENCE_UNIT_NAME)
 	private EntityManager em;
 
-	@EJB
-	private FacilityService facilityService;
 	@EJB
 	private UserService userService;
 	@EJB
@@ -91,6 +92,14 @@ public class FacilityFacadeEjb implements FacilityFacade {
 	@EJB
 	private RegionService regionService;
 
+	public FacilityFacadeEjb() {
+	}
+
+	@Inject
+	protected FacilityFacadeEjb(FacilityService service, FeatureConfigurationFacadeEjbLocal featureConfiguration) {
+		super(service, featureConfiguration);
+	}
+
 	@Override
 	public List<FacilityReferenceDto> getActiveFacilitiesByCommunityAndType(
 		CommunityReferenceDto communityRef,
@@ -99,7 +108,7 @@ public class FacilityFacadeEjb implements FacilityFacade {
 		boolean includeNoneFacility) {
 
 		Community community = communityService.getByUuid(communityRef.getUuid());
-		List<Facility> facilities = facilityService.getActiveFacilitiesByCommunityAndType(community, type, includeOtherFacility, includeNoneFacility);
+		List<Facility> facilities = service.getActiveFacilitiesByCommunityAndType(community, type, includeOtherFacility, includeNoneFacility);
 		return facilities.stream().map(FacilityFacadeEjb::toReferenceDto).collect(Collectors.toList());
 	}
 
@@ -111,30 +120,28 @@ public class FacilityFacadeEjb implements FacilityFacade {
 		boolean includeNoneFacility) {
 
 		District district = districtService.getByUuid(districtRef.getUuid());
-		List<Facility> facilities = facilityService.getActiveFacilitiesByDistrictAndType(district, type, includeOtherFacility, includeNoneFacility);
+		List<Facility> facilities = service.getActiveFacilitiesByDistrictAndType(district, type, includeOtherFacility, includeNoneFacility);
 		return facilities.stream().map(FacilityFacadeEjb::toReferenceDto).collect(Collectors.toList());
 	}
 
 	@Override
 	public List<FacilityReferenceDto> getActiveHospitalsByCommunity(CommunityReferenceDto communityRef, boolean includeOtherFacility) {
 		Community community = communityService.getByUuid(communityRef.getUuid());
-		List<Facility> facilities =
-			facilityService.getActiveFacilitiesByCommunityAndType(community, FacilityType.HOSPITAL, includeOtherFacility, false);
+		List<Facility> facilities = service.getActiveFacilitiesByCommunityAndType(community, FacilityType.HOSPITAL, includeOtherFacility, false);
 		return facilities.stream().map(FacilityFacadeEjb::toReferenceDto).collect(Collectors.toList());
 	}
 
 	@Override
 	public List<FacilityReferenceDto> getActiveHospitalsByDistrict(DistrictReferenceDto districtRef, boolean includeOtherFacility) {
 		District district = districtService.getByUuid(districtRef.getUuid());
-		List<Facility> facilities =
-			facilityService.getActiveFacilitiesByDistrictAndType(district, FacilityType.HOSPITAL, includeOtherFacility, false);
+		List<Facility> facilities = service.getActiveFacilitiesByDistrictAndType(district, FacilityType.HOSPITAL, includeOtherFacility, false);
 		return facilities.stream().map(FacilityFacadeEjb::toReferenceDto).collect(Collectors.toList());
 	}
 
 	@Override
 	public List<FacilityReferenceDto> getAllActiveLaboratories(boolean includeOtherFacility) {
 
-		List<Facility> laboratories = facilityService.getAllActiveLaboratories(includeOtherFacility);
+		List<Facility> laboratories = service.getAllActiveLaboratories(includeOtherFacility);
 		return laboratories.stream().map(FacilityFacadeEjb::toReferenceDto).collect(Collectors.toList());
 	}
 
@@ -145,7 +152,7 @@ public class FacilityFacadeEjb implements FacilityFacade {
 			return Collections.emptyList();
 		}
 
-		return facilityService.getAllUuids();
+		return service.getAllUuids();
 	}
 
 	@Override
@@ -157,7 +164,7 @@ public class FacilityFacadeEjb implements FacilityFacade {
 
 		selectDtoFields(cq, facility);
 
-		Predicate filter = facilityService.createChangeDateFilter(cb, facility, date);
+		Predicate filter = service.createChangeDateFilter(cb, facility, date);
 
 		if (filter != null) {
 			cq.where(filter);
@@ -175,7 +182,7 @@ public class FacilityFacadeEjb implements FacilityFacade {
 
 		selectDtoFields(cq, facility);
 
-		Predicate filter = facilityService.createChangeDateFilter(cb, facility, date);
+		Predicate filter = service.createChangeDateFilter(cb, facility, date);
 
 		if (regionUuid != null) {
 			Predicate regionFilter = cb.equal(facility.get(Facility.REGION), regionService.getByUuid(regionUuid));
@@ -198,7 +205,7 @@ public class FacilityFacadeEjb implements FacilityFacade {
 
 		selectDtoFields(cq, facility);
 
-		Predicate filter = facilityService.createChangeDateFilter(cb, facility, date);
+		Predicate filter = service.createChangeDateFilter(cb, facility, date);
 
 		Predicate regionFilter = cb.isNull(facility.get(Facility.REGION));
 		filter = CriteriaBuilderHelper.and(cb, filter, regionFilter);
@@ -213,7 +220,7 @@ public class FacilityFacadeEjb implements FacilityFacade {
 	@Override
 	public List<FacilityReferenceDto> getByExternalId(String externalId, boolean includeArchivedEntities) {
 
-		return facilityService.getByExternalId(externalId, includeArchivedEntities)
+		return service.getByExternalId(externalId, includeArchivedEntities)
 			.stream()
 			.map(FacilityFacadeEjb::toReferenceDto)
 			.collect(Collectors.toList());
@@ -260,22 +267,22 @@ public class FacilityFacadeEjb implements FacilityFacade {
 
 	@Override
 	public FacilityDto getByUuid(String uuid) {
-		return toDto(facilityService.getByUuid(uuid));
+		return toDto(service.getByUuid(uuid));
 	}
 
 	@Override
 	public List<FacilityDto> getByUuids(List<String> uuids) {
-		return facilityService.getByUuids(uuids).stream().map(c -> toDto(c)).collect(Collectors.toList());
+		return service.getByUuids(uuids).stream().map(c -> toDto(c)).collect(Collectors.toList());
 	}
 
 	@Override
 	public FacilityReferenceDto getFacilityReferenceByUuid(String uuid) {
-		return toReferenceDto(facilityService.getByUuid(uuid));
+		return toReferenceDto(service.getByUuid(uuid));
 	}
 
 	@Override
 	public FacilityReferenceDto getFacilityReferenceById(long id) {
-		return toReferenceDto(facilityService.getById(id));
+		return toReferenceDto(service.getById(id));
 	}
 
 	@Override
@@ -320,7 +327,7 @@ public class FacilityFacadeEjb implements FacilityFacade {
 
 	@Override
 	public List<FacilityReferenceDto> getByExternalIdAndType(String id, FacilityType type, boolean includeArchivedEntities) {
-		return facilityService.getFacilitiesByExternalIdAndType(id, type, includeArchivedEntities)
+		return service.getFacilitiesByExternalIdAndType(id, type, includeArchivedEntities)
 			.stream()
 			.map(f -> toReferenceDto(f))
 			.collect(Collectors.toList());
@@ -340,7 +347,7 @@ public class FacilityFacadeEjb implements FacilityFacade {
 		FacilityType type,
 		boolean includeArchivedEntities) {
 
-		return facilityService
+		return service
 			.getFacilitiesByNameAndType(
 				name,
 				districtService.getByReferenceDto(districtRef),
@@ -354,26 +361,10 @@ public class FacilityFacadeEjb implements FacilityFacade {
 
 	@Override
 	public List<FacilityReferenceDto> getLaboratoriesByName(String name, boolean includeArchivedEntities) {
-		return facilityService.getFacilitiesByNameAndType(name, null, null, FacilityType.LABORATORY, includeArchivedEntities)
+		return service.getFacilitiesByNameAndType(name, null, null, FacilityType.LABORATORY, includeArchivedEntities)
 			.stream()
 			.map(f -> toReferenceDto(f))
 			.collect(Collectors.toList());
-	}
-
-	@Override
-	public void archive(String facilityUuid) {
-
-		Facility facility = facilityService.getByUuid(facilityUuid);
-		facility.setArchived(true);
-		facilityService.ensurePersisted(facility);
-	}
-
-	@Override
-	public void dearchive(String facilityUuid) {
-
-		Facility facility = facilityService.getByUuid(facilityUuid);
-		facility.setArchived(false);
-		facilityService.ensurePersisted(facility);
 	}
 
 	@Override
@@ -410,8 +401,7 @@ public class FacilityFacadeEjb implements FacilityFacade {
 			return null;
 		}
 
-		FacilityReferenceDto dto = new FacilityReferenceDto(entity.getUuid(), entity.toString(), entity.getExternalID());
-		return dto;
+		return new FacilityReferenceDto(entity.getUuid(), entity.toString(), entity.getExternalID());
 	}
 
 	private FacilityDto toDto(Facility entity) {
@@ -447,12 +437,6 @@ public class FacilityFacadeEjb implements FacilityFacade {
 		return dto;
 	}
 
-	@LocalBean
-	@Stateless
-	public static class FacilityFacadeEjbLocal extends FacilityFacadeEjb {
-
-	}
-
 	@Override
 	public List<FacilityIndexDto> getIndexList(FacilityCriteria facilityCriteria, Integer first, Integer max, List<SortProperty> sortProperties) {
 
@@ -463,7 +447,7 @@ public class FacilityFacadeEjb implements FacilityFacade {
 		Join<Facility, District> district = facility.join(Facility.DISTRICT, JoinType.LEFT);
 		Join<Facility, Community> community = facility.join(Facility.COMMUNITY, JoinType.LEFT);
 
-		Predicate filter = facilityService.buildCriteriaFilter(facilityCriteria, cb, facility);
+		Predicate filter = service.buildCriteriaFilter(facilityCriteria, cb, facility);
 		Predicate excludeFilter = cb.and(
 			cb.notEqual(facility.get(Facility.UUID), FacilityDto.OTHER_FACILITY_UUID),
 			cb.notEqual(facility.get(Facility.UUID), FacilityDto.NONE_FACILITY_UUID));
@@ -566,7 +550,7 @@ public class FacilityFacadeEjb implements FacilityFacade {
 			cb.notEqual(facility.get(Facility.UUID), FacilityDto.NONE_FACILITY_UUID));
 
 		if (facilityCriteria != null) {
-			Predicate criteriaFilter = facilityService.buildCriteriaFilter(facilityCriteria, cb, facility);
+			Predicate criteriaFilter = service.buildCriteriaFilter(facilityCriteria, cb, facility);
 			filter = CriteriaBuilderHelper.and(cb, filter, criteriaFilter);
 		}
 
@@ -587,7 +571,7 @@ public class FacilityFacadeEjb implements FacilityFacade {
 		CriteriaQuery<Long> cq = cb.createQuery(Long.class);
 		Root<Facility> root = cq.from(Facility.class);
 
-		Predicate filter = facilityService.buildCriteriaFilter(criteria, cb, root);
+		Predicate filter = service.buildCriteriaFilter(criteria, cb, root);
 		Predicate excludeFilter = cb.and(
 			cb.notEqual(root.get(Facility.UUID), FacilityDto.OTHER_FACILITY_UUID),
 			cb.notEqual(root.get(Facility.UUID), FacilityDto.NONE_FACILITY_UUID));
@@ -615,14 +599,14 @@ public class FacilityFacadeEjb implements FacilityFacade {
 
 		validateFacilityDto(dto);
 
-		Facility facility = facilityService.getByUuid(dto.getUuid());
+		Facility facility = service.getByUuid(dto.getUuid());
 
 		if (facility == null) {
 			List<FacilityReferenceDto> duplicates = getByNameAndType(dto.getName(), dto.getDistrict(), dto.getCommunity(), dto.getType(), true);
 			if (!duplicates.isEmpty()) {
 				if (allowMerge) {
 					String uuid = duplicates.get(0).getUuid();
-					facility = facilityService.getByUuid(uuid);
+					facility = service.getByUuid(uuid);
 					FacilityDto dtoToMerge = getByUuid(uuid);
 					dto = DtoHelper.copyDtoValues(dtoToMerge, dto, true);
 				} else {
@@ -632,8 +616,13 @@ public class FacilityFacadeEjb implements FacilityFacade {
 		}
 
 		facility = fillOrBuildEntity(dto, facility, true);
-		facilityService.ensurePersisted(facility);
+		service.ensurePersisted(facility);
 		return toDto(facility);
+	}
+
+	@Override
+	public void dearchive(String uuid) {
+		super.dearchiveUnchecked(uuid);
 	}
 
 	private void validateFacilityDto(FacilityDto dto) {
@@ -681,5 +670,18 @@ public class FacilityFacadeEjb implements FacilityFacade {
 		target.setExternalID(source.getExternalID());
 
 		return target;
+	}
+
+	@LocalBean
+	@Stateless
+	public static class FacilityFacadeEjbLocal extends FacilityFacadeEjb {
+
+		public FacilityFacadeEjbLocal() {
+		}
+
+		@Inject
+		protected FacilityFacadeEjbLocal(FacilityService service, FeatureConfigurationFacadeEjbLocal featureConfiguration) {
+			super(service, featureConfiguration);
+		}
 	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/pointofentry/PointOfEntryFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/pointofentry/PointOfEntryFacadeEjb.java
@@ -215,9 +215,10 @@ public class PointOfEntryFacadeEjb extends AbstractInfrastructureEjb<PointOfEntr
 	}
 
 	@Override
-	public void dearchive(String uuid) {
-		super.dearchiveUnchecked(uuid);
+	protected void checkInfraDataLocked() {
+		// poe are excluded from infra. data locking for now...
 	}
+
 
 	@Override
 	public void validate(PointOfEntryDto pointOfEntry) throws ValidationRuntimeException {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/pointofentry/PointOfEntryFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/pointofentry/PointOfEntryFacadeEjb.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 import javax.ejb.EJB;
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
+import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.criteria.CriteriaBuilder;
@@ -23,6 +24,8 @@ import javax.persistence.criteria.Root;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
+import de.symeda.sormas.backend.feature.FeatureConfigurationFacadeEjb.FeatureConfigurationFacadeEjbLocal;
+import de.symeda.sormas.backend.infrastructure.AbstractInfrastructureEjb;
 import org.apache.commons.lang3.StringUtils;
 
 import de.symeda.sormas.api.common.Page;
@@ -50,13 +53,11 @@ import de.symeda.sormas.backend.util.ModelConstants;
 import de.symeda.sormas.backend.util.QueryHelper;
 
 @Stateless(name = "PointOfEntryFacade")
-public class PointOfEntryFacadeEjb implements PointOfEntryFacade {
+public class PointOfEntryFacadeEjb extends AbstractInfrastructureEjb<PointOfEntry, PointOfEntryService> implements PointOfEntryFacade {
 
 	@PersistenceContext(unitName = ModelConstants.PERSISTENCE_UNIT_NAME)
 	private EntityManager em;
 
-	@EJB
-	private PointOfEntryService service;
 	@EJB
 	private RegionService regionService;
 	@EJB
@@ -65,6 +66,14 @@ public class PointOfEntryFacadeEjb implements PointOfEntryFacade {
 	private DistrictFacadeEjbLocal districtFacade;
 	@EJB
 	private UserService userService;
+
+	public PointOfEntryFacadeEjb() {
+	}
+
+	@Inject
+	protected PointOfEntryFacadeEjb(PointOfEntryService service, FeatureConfigurationFacadeEjbLocal featureConfiguration) {
+		super(service, featureConfiguration);
+	}
 
 	public static PointOfEntryReferenceDto toReferenceDto(PointOfEntry entity) {
 
@@ -206,6 +215,11 @@ public class PointOfEntryFacadeEjb implements PointOfEntryFacade {
 	}
 
 	@Override
+	public void dearchive(String uuid) {
+		super.dearchiveUnchecked(uuid);
+	}
+
+	@Override
 	public void validate(PointOfEntryDto pointOfEntry) throws ValidationRuntimeException {
 
 		if (StringUtils.isEmpty(pointOfEntry.getName())) {
@@ -319,22 +333,6 @@ public class PointOfEntryFacadeEjb implements PointOfEntryFacade {
 	}
 
 	@Override
-	public void archive(String pointOfEntryUuid) {
-
-		PointOfEntry pointOfEntry = service.getByUuid(pointOfEntryUuid);
-		pointOfEntry.setArchived(true);
-		service.ensurePersisted(pointOfEntry);
-	}
-
-	@Override
-	public void dearchive(String pointOfEntryUuid) {
-
-		PointOfEntry pointOfEntry = service.getByUuid(pointOfEntryUuid);
-		pointOfEntry.setArchived(false);
-		service.ensurePersisted(pointOfEntry);
-	}
-
-	@Override
 	public boolean hasArchivedParentInfrastructure(Collection<String> pointOfEntryUuids) {
 
 		CriteriaBuilder cb = em.getCriteriaBuilder();
@@ -395,5 +393,12 @@ public class PointOfEntryFacadeEjb implements PointOfEntryFacade {
 	@Stateless
 	public static class PointOfEntryFacadeEjbLocal extends PointOfEntryFacadeEjb {
 
+		public PointOfEntryFacadeEjbLocal() {
+		}
+
+		@Inject
+		protected PointOfEntryFacadeEjbLocal(PointOfEntryService service, FeatureConfigurationFacadeEjbLocal featureConfiguration) {
+			super(service, featureConfiguration);
+		}
 	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/region/RegionFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/region/RegionFacadeEjb.java
@@ -344,10 +344,7 @@ public class RegionFacadeEjb extends AbstractInfrastructureEjb<Region, RegionSer
 
 	@Override
 	public RegionDto save(@Valid RegionDto dto, boolean allowMerge) throws ValidationRuntimeException {
-
-		if (!featureConfiguration.isFeatureEnabled(FeatureType.EDIT_INFRASTRUCTURE_DATA)) {
-			throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.infrastructureDataLocked));
-		}
+		checkInfraDataLocked();
 
 		Region region = service.getByUuid(dto.getUuid());
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/region/RegionFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/region/RegionFacadeEjb.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 import javax.ejb.EJB;
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
+import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.criteria.CriteriaBuilder;
@@ -53,6 +54,7 @@ import de.symeda.sormas.api.utils.SortProperty;
 import de.symeda.sormas.api.utils.ValidationRuntimeException;
 import de.symeda.sormas.backend.common.CriteriaBuilderHelper;
 import de.symeda.sormas.backend.feature.FeatureConfigurationFacadeEjb.FeatureConfigurationFacadeEjbLocal;
+import de.symeda.sormas.backend.infrastructure.AbstractInfrastructureEjb;
 import de.symeda.sormas.backend.infrastructure.PopulationDataFacadeEjb.PopulationDataFacadeEjbLocal;
 import de.symeda.sormas.backend.infrastructure.area.Area;
 import de.symeda.sormas.backend.infrastructure.area.AreaFacadeEjb;
@@ -70,13 +72,11 @@ import de.symeda.sormas.backend.util.ModelConstants;
 import de.symeda.sormas.backend.util.QueryHelper;
 
 @Stateless(name = "RegionFacade")
-public class RegionFacadeEjb implements RegionFacade {
+public class RegionFacadeEjb extends AbstractInfrastructureEjb<Region, RegionService> implements RegionFacade {
 
 	@PersistenceContext(unitName = ModelConstants.PERSISTENCE_UNIT_NAME)
 	private EntityManager em;
 
-	@EJB
-	private RegionService regionService;
 	@EJB
 	private UserService userService;
 	@EJB
@@ -87,8 +87,14 @@ public class RegionFacadeEjb implements RegionFacade {
 	private CountryService countryService;
 	@EJB
 	private CountryFacadeEjbLocal countryFacade;
-	@EJB
-	private FeatureConfigurationFacadeEjbLocal featureConfiguration;
+
+	public RegionFacadeEjb() {
+	}
+
+	@Inject
+	protected RegionFacadeEjb(RegionService service, FeatureConfigurationFacadeEjbLocal featureConfiguration) {
+		super(service, featureConfiguration);
+	}
 
 	@Override
 	public List<RegionReferenceDto> getAllActiveByServerCountry() {
@@ -116,7 +122,7 @@ public class RegionFacadeEjb implements RegionFacade {
 
 	@Override
 	public List<RegionReferenceDto> getAllActiveAsReference() {
-		return regionService.getAllActive(Region.NAME, true).stream().map(f -> toReferenceDto(f)).collect(Collectors.toList());
+		return service.getAllActive(Region.NAME, true).stream().map(f -> toReferenceDto(f)).collect(Collectors.toList());
 	}
 
 	@Override
@@ -128,7 +134,7 @@ public class RegionFacadeEjb implements RegionFacade {
 
 		selectDtoFields(cq, region);
 
-		Predicate filter = regionService.createChangeDateFilter(cb, region, date);
+		Predicate filter = service.createChangeDateFilter(cb, region, date);
 
 		if (filter != null) {
 			cq.where(filter);
@@ -169,7 +175,7 @@ public class RegionFacadeEjb implements RegionFacade {
 
 		Predicate filter = null;
 		if (criteria != null) {
-			filter = regionService.buildCriteriaFilter(criteria, cb, region);
+			filter = service.buildCriteriaFilter(criteria, cb, region);
 		}
 		if (filter != null) {
 			cq.where(filter);
@@ -223,7 +229,7 @@ public class RegionFacadeEjb implements RegionFacade {
 		Predicate filter = null;
 
 		if (criteria != null) {
-			filter = regionService.buildCriteriaFilter(criteria, cb, root);
+			filter = service.buildCriteriaFilter(criteria, cb, root);
 		}
 
 		if (filter != null) {
@@ -241,27 +247,27 @@ public class RegionFacadeEjb implements RegionFacade {
 			return Collections.emptyList();
 		}
 
-		return regionService.getAllUuids();
+		return service.getAllUuids();
 	}
 
 	@Override
 	public RegionDto getByUuid(String uuid) {
-		return toDto(regionService.getByUuid(uuid));
+		return toDto(service.getByUuid(uuid));
 	}
 
 	@Override
 	public List<RegionDto> getByUuids(List<String> uuids) {
-		return regionService.getByUuids(uuids).stream().map(this::toDto).collect(Collectors.toList());
+		return service.getByUuids(uuids).stream().map(this::toDto).collect(Collectors.toList());
 	}
 
 	@Override
 	public RegionReferenceDto getRegionReferenceByUuid(String uuid) {
-		return toReferenceDto(regionService.getByUuid(uuid));
+		return toReferenceDto(service.getByUuid(uuid));
 	}
 
 	@Override
 	public RegionReferenceDto getRegionReferenceById(int id) {
-		return toReferenceDto(regionService.getById(id));
+		return toReferenceDto(service.getById(id));
 	}
 
 	@Override
@@ -278,30 +284,11 @@ public class RegionFacadeEjb implements RegionFacade {
 	}
 
 	@Override
-	public void archive(String regionUuid) {
-		Region region = regionService.getByUuid(regionUuid);
-		region.setArchived(true);
-		regionService.ensurePersisted(region);
-	}
-
-	@Override
-	public void dearchive(String regionUuid) {
-
-		if (!featureConfiguration.isFeatureEnabled(FeatureType.EDIT_INFRASTRUCTURE_DATA)) {
-			throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.infrastructureDataLocked));
-		}
-
-		Region region = regionService.getByUuid(regionUuid);
-		region.setArchived(false);
-		regionService.ensurePersisted(region);
-	}
-
-	@Override
 	public boolean isUsedInOtherInfrastructureData(Collection<String> regionUuids) {
 
-		return regionService.isUsedInInfrastructureData(regionUuids, District.REGION, District.class)
-			|| regionService.isUsedInInfrastructureData(regionUuids, Facility.REGION, Facility.class)
-			|| regionService.isUsedInInfrastructureData(regionUuids, PointOfEntry.REGION, PointOfEntry.class);
+		return service.isUsedInInfrastructureData(regionUuids, District.REGION, District.class)
+			|| service.isUsedInInfrastructureData(regionUuids, Facility.REGION, Facility.class)
+			|| service.isUsedInInfrastructureData(regionUuids, PointOfEntry.REGION, PointOfEntry.class);
 	}
 
 	public static RegionReferenceDto toReferenceDto(Region entity) {
@@ -362,10 +349,10 @@ public class RegionFacadeEjb implements RegionFacade {
 			throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.infrastructureDataLocked));
 		}
 
-		Region region = regionService.getByUuid(dto.getUuid());
+		Region region = service.getByUuid(dto.getUuid());
 
 		if (region == null) {
-			List<Region> duplicates = regionService.getByName(dto.getName(), true);
+			List<Region> duplicates = service.getByName(dto.getName(), true);
 			if (!duplicates.isEmpty()) {
 				if (allowMerge) {
 					region = duplicates.get(0);
@@ -378,22 +365,22 @@ public class RegionFacadeEjb implements RegionFacade {
 		}
 
 		region = fillOrBuildEntity(dto, region, true);
-		regionService.ensurePersisted(region);
+		service.ensurePersisted(region);
 		return toDto(region);
 	}
 
 	@Override
 	public List<RegionReferenceDto> getReferencesByName(String name, boolean includeArchivedEntities) {
-		return regionService.getByName(name, includeArchivedEntities).stream().map(RegionFacadeEjb::toReferenceDto).collect(Collectors.toList());
+		return service.getByName(name, includeArchivedEntities).stream().map(RegionFacadeEjb::toReferenceDto).collect(Collectors.toList());
 	}
 
 	public List<RegionDto> getByName(String name, boolean includeArchivedEntities) {
-		return regionService.getByName(name, includeArchivedEntities).stream().map(this::toDto).collect(Collectors.toList());
+		return service.getByName(name, includeArchivedEntities).stream().map(this::toDto).collect(Collectors.toList());
 	}
 
 	@Override
 	public List<RegionReferenceDto> getByExternalId(String externalId, boolean includeArchivedEntities) {
-		return regionService.getByExternalId(externalId, includeArchivedEntities)
+		return service.getByExternalId(externalId, includeArchivedEntities)
 			.stream()
 			.map(RegionFacadeEjb::toReferenceDto)
 			.collect(Collectors.toList());
@@ -404,7 +391,7 @@ public class RegionFacadeEjb implements RegionFacade {
 		CriteriaQuery<Region> cq = cb.createQuery(Region.class);
 		Root<Region> root = cq.from(Region.class);
 
-		Predicate basicFilter = regionService.createBasicFilter(cb, root);
+		Predicate basicFilter = service.createBasicFilter(cb, root);
 		cq.where(CriteriaBuilderHelper.and(cb, basicFilter, buildPredicate.apply(cb, root)));
 
 		cq.orderBy(cb.asc(root.get(Region.NAME)));
@@ -431,5 +418,12 @@ public class RegionFacadeEjb implements RegionFacade {
 	@Stateless
 	public static class RegionFacadeEjbLocal extends RegionFacadeEjb {
 
+		public RegionFacadeEjbLocal() {
+		}
+
+		@Inject
+		protected RegionFacadeEjbLocal(RegionService service, FeatureConfigurationFacadeEjbLocal featureConfiguration) {
+			super(service, featureConfiguration);
+		}
 	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/subcontinent/SubcontinentFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/subcontinent/SubcontinentFacadeEjb.java
@@ -111,7 +111,11 @@ public class SubcontinentFacadeEjb extends AbstractInfrastructureEjb<Subcontinen
 	@Override
 	public List<SubcontinentReferenceDto> getAllActiveByContinent(String uuid) {
 		Continent continent = continentService.getByUuid(uuid);
-		return continent.getSubcontinents().stream().filter(d -> !d.isArchived()).map(SubcontinentFacadeEjb::toReferenceDto).collect(Collectors.toList());
+		return continent.getSubcontinents()
+			.stream()
+			.filter(d -> !d.isArchived())
+			.map(SubcontinentFacadeEjb::toReferenceDto)
+			.collect(Collectors.toList());
 	}
 
 	@Override
@@ -222,10 +226,7 @@ public class SubcontinentFacadeEjb extends AbstractInfrastructureEjb<Subcontinen
 
 	@Override
 	public SubcontinentDto save(@Valid SubcontinentDto dto, boolean allowMerge) {
-
-		if (!featureConfiguration.isFeatureEnabled(FeatureType.EDIT_INFRASTRUCTURE_DATA)) {
-			throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.infrastructureDataLocked));
-		}
+		checkInfraDataLocked();
 
 		Subcontinent subcontinent = service.getByUuid(dto.getUuid());
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/subcontinent/SubcontinentFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/subcontinent/SubcontinentFacadeEjb.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 import javax.ejb.EJB;
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
+import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.criteria.CriteriaBuilder;
@@ -51,6 +52,7 @@ import de.symeda.sormas.api.infrastructure.subcontinent.SubcontinentReferenceDto
 import de.symeda.sormas.api.utils.SortProperty;
 import de.symeda.sormas.api.utils.ValidationRuntimeException;
 import de.symeda.sormas.backend.feature.FeatureConfigurationFacadeEjb.FeatureConfigurationFacadeEjbLocal;
+import de.symeda.sormas.backend.infrastructure.AbstractInfrastructureEjb;
 import de.symeda.sormas.backend.infrastructure.continent.Continent;
 import de.symeda.sormas.backend.infrastructure.continent.ContinentFacadeEjb;
 import de.symeda.sormas.backend.infrastructure.continent.ContinentService;
@@ -61,19 +63,23 @@ import de.symeda.sormas.backend.util.ModelConstants;
 import de.symeda.sormas.backend.util.QueryHelper;
 
 @Stateless(name = "SubcontinentFacade")
-public class SubcontinentFacadeEjb implements SubcontinentFacade {
+public class SubcontinentFacadeEjb extends AbstractInfrastructureEjb<Subcontinent, SubcontinentService> implements SubcontinentFacade {
 
 	@PersistenceContext(unitName = ModelConstants.PERSISTENCE_UNIT_NAME)
 	private EntityManager em;
 
 	@EJB
-	private SubcontinentService subcontinentService;
-	@EJB
 	private ContinentService continentService;
 	@EJB
 	private CountryService countryService;
-	@EJB
-	private FeatureConfigurationFacadeEjbLocal featureConfiguration;
+
+	public SubcontinentFacadeEjb() {
+	}
+
+	@Inject
+	protected SubcontinentFacadeEjb(SubcontinentService service, FeatureConfigurationFacadeEjbLocal featureConfiguration) {
+		super(service, featureConfiguration);
+	}
 
 	public static SubcontinentReferenceDto toReferenceDto(Subcontinent entity) {
 		if (entity == null) {
@@ -91,7 +97,7 @@ public class SubcontinentFacadeEjb implements SubcontinentFacade {
 
 	@Override
 	public List<SubcontinentReferenceDto> getByDefaultName(String name, boolean includeArchivedEntities) {
-		return subcontinentService.getByDefaultName(name, includeArchivedEntities)
+		return service.getByDefaultName(name, includeArchivedEntities)
 			.stream()
 			.map(SubcontinentFacadeEjb::toReferenceDto)
 			.collect(Collectors.toList());
@@ -105,12 +111,12 @@ public class SubcontinentFacadeEjb implements SubcontinentFacade {
 	@Override
 	public List<SubcontinentReferenceDto> getAllActiveByContinent(String uuid) {
 		Continent continent = continentService.getByUuid(uuid);
-		return continent.getSubcontinents().stream().filter(d -> !d.isArchived()).map(f -> toReferenceDto(f)).collect(Collectors.toList());
+		return continent.getSubcontinents().stream().filter(d -> !d.isArchived()).map(SubcontinentFacadeEjb::toReferenceDto).collect(Collectors.toList());
 	}
 
 	@Override
 	public boolean isUsedInOtherInfrastructureData(Collection<String> subcontinentUuids) {
-		return subcontinentService.isUsedInInfrastructureData(subcontinentUuids, Country.SUBCONTINENT, Country.class);
+		return service.isUsedInInfrastructureData(subcontinentUuids, Country.SUBCONTINENT, Country.class);
 	}
 
 	@Override
@@ -130,7 +136,7 @@ public class SubcontinentFacadeEjb implements SubcontinentFacade {
 
 	@Override
 	public SubcontinentDto getByUuid(String uuid) {
-		return toDto(subcontinentService.getByUuid(uuid));
+		return toDto(service.getByUuid(uuid));
 	}
 
 	@Override
@@ -142,7 +148,7 @@ public class SubcontinentFacadeEjb implements SubcontinentFacade {
 
 		Predicate filter = null;
 		if (criteria != null) {
-			filter = subcontinentService.buildCriteriaFilter(criteria, cb, subcontinent);
+			filter = service.buildCriteriaFilter(criteria, cb, subcontinent);
 		}
 
 		if (filter != null) {
@@ -179,44 +185,18 @@ public class SubcontinentFacadeEjb implements SubcontinentFacade {
 	}
 
 	@Override
-	public void archive(String uuid) {
-		Subcontinent subcontinent = subcontinentService.getByUuid(uuid);
-		if (subcontinent != null) {
-			subcontinent.setArchived(true);
-			subcontinentService.ensurePersisted(subcontinent);
-		}
-	}
-
-	@Override
-	public void dearchive(String uuid) {
-
-		if (!featureConfiguration.isFeatureEnabled(FeatureType.EDIT_INFRASTRUCTURE_DATA)) {
-			throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.infrastructureDataLocked));
-		}
-
-		Subcontinent subcontinent = subcontinentService.getByUuid(uuid);
-		if (subcontinent != null) {
-			subcontinent.setArchived(false);
-			subcontinentService.ensurePersisted(subcontinent);
-		}
-	}
-
-	@Override
 	public List<SubcontinentDto> getAllAfter(Date date) {
-		return subcontinentService.getAll((cb, root) -> subcontinentService.createChangeDateFilter(cb, root, date))
-			.stream()
-			.map(this::toDto)
-			.collect(Collectors.toList());
+		return service.getAll((cb, root) -> service.createChangeDateFilter(cb, root, date)).stream().map(this::toDto).collect(Collectors.toList());
 	}
 
 	@Override
 	public List<SubcontinentDto> getByUuids(List<String> uuids) {
-		return subcontinentService.getByUuids(uuids).stream().map(this::toDto).collect(Collectors.toList());
+		return service.getByUuids(uuids).stream().map(this::toDto).collect(Collectors.toList());
 	}
 
 	@Override
 	public List<String> getAllUuids() {
-		return subcontinentService.getAllUuids();
+		return service.getAllUuids();
 	}
 
 	@Override
@@ -228,7 +208,7 @@ public class SubcontinentFacadeEjb implements SubcontinentFacade {
 
 	@Override
 	public List<SubcontinentReferenceDto> getAllActiveAsReference() {
-		return subcontinentService.getAllActive(Subcontinent.DEFAULT_NAME, true)
+		return service.getAllActive(Subcontinent.DEFAULT_NAME, true)
 			.stream()
 			.map(SubcontinentFacadeEjb::toReferenceDto)
 			.sorted(Comparator.comparing(SubcontinentReferenceDto::getCaption))
@@ -247,14 +227,14 @@ public class SubcontinentFacadeEjb implements SubcontinentFacade {
 			throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.infrastructureDataLocked));
 		}
 
-		Subcontinent subcontinent = subcontinentService.getByUuid(dto.getUuid());
+		Subcontinent subcontinent = service.getByUuid(dto.getUuid());
 
 		if (subcontinent == null) {
 			List<SubcontinentReferenceDto> duplicates = getByDefaultName(dto.getDefaultName(), true);
 			if (!duplicates.isEmpty()) {
 				if (allowMerge) {
 					String uuid = duplicates.get(0).getUuid();
-					subcontinent = subcontinentService.getByUuid(uuid);
+					subcontinent = service.getByUuid(uuid);
 					SubcontinentDto dtoToMerge = getByUuid(uuid);
 					dto = DtoHelper.copyDtoValues(dtoToMerge, dto, true);
 				} else {
@@ -264,14 +244,14 @@ public class SubcontinentFacadeEjb implements SubcontinentFacade {
 		}
 
 		subcontinent = fillOrBuildEntity(dto, subcontinent, true);
-		subcontinentService.ensurePersisted(subcontinent);
+		service.ensurePersisted(subcontinent);
 
 		return toDto(subcontinent);
 	}
 
 	@Override
 	public long count(SubcontinentCriteria criteria) {
-		return subcontinentService.count((cb, root) -> subcontinentService.buildCriteriaFilter(criteria, cb, root));
+		return service.count((cb, root) -> service.buildCriteriaFilter(criteria, cb, root));
 	}
 
 	public SubcontinentDto toDto(Subcontinent entity) {
@@ -308,17 +288,11 @@ public class SubcontinentFacadeEjb implements SubcontinentFacade {
 	}
 
 	public List<SubcontinentReferenceDto> getByExternalId(String externalId, boolean includeArchived) {
-		return subcontinentService.getByExternalId(externalId, includeArchived)
-			.stream()
-			.map(SubcontinentFacadeEjb::toReferenceDto)
-			.collect(Collectors.toList());
+		return service.getByExternalId(externalId, includeArchived).stream().map(SubcontinentFacadeEjb::toReferenceDto).collect(Collectors.toList());
 	}
 
 	public List<SubcontinentReferenceDto> getReferencesByName(String caption, boolean includeArchived) {
-		return subcontinentService.getByDefaultName(caption, includeArchived)
-			.stream()
-			.map(SubcontinentFacadeEjb::toReferenceDto)
-			.collect(Collectors.toList());
+		return service.getByDefaultName(caption, includeArchived).stream().map(SubcontinentFacadeEjb::toReferenceDto).collect(Collectors.toList());
 	}
 
 	private Subcontinent fillOrBuildEntity(@NotNull SubcontinentDto source, Subcontinent target, boolean checkChangeDate) {
@@ -336,5 +310,13 @@ public class SubcontinentFacadeEjb implements SubcontinentFacade {
 	@Stateless
 	public static class SubcontinentFacadeEjbLocal extends SubcontinentFacadeEjb {
 
+		public SubcontinentFacadeEjbLocal() {
+
+		}
+
+		@Inject
+		protected SubcontinentFacadeEjbLocal(SubcontinentService service, FeatureConfigurationFacadeEjbLocal featureConfiguration) {
+			super(service, featureConfiguration);
+		}
 	}
 }


### PR DESCRIPTION
Fixes #6587 
@MateStrysewske @MartinWahnschaffe @StefanKock you might want to take a look at this :)

What I did is the following:

I created an abstract class `AbstractBaseEjb` which in the future should implement default versions for all methods in `BaseFacade`. There is also `AbstractInfrastructureEjb` which currently works around some issue `AbstractBaseEjb` has. Every infrastructure ejb now extends the `AbstractInfrastructureEjb` and uses constructor injection to instantiate the used service.

In this PR, I only cleanup up (de)archiving, but you can do the same for e.g., `save` as well as, at least in the infra facades, its just copy pasted. Prospectively, I think we should apply this to more facades/ejbs and let them extend `BaseFacade` and `AbstractBaseEjb` respectively. 

Doing this will help us to enforce clear data processing flows and validation. Right now there is a lot of inconsistency in the ejbs where methods are named differently, but do roughly the same across the system. I see the chance to greatly reduce LOC here by introducing more generic code. 