### PR TITLE
[#6885] clear inheritance to enable argument validation

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/InfrastructureBaseFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/InfrastructureBaseFacade.java
@@ -17,9 +17,8 @@ import de.symeda.sormas.api.utils.criteria.BaseCriteria;
 public interface InfrastructureBaseFacade<DTO extends EntityDto, INDEX_DTO extends Serializable, REF_DTO extends InfrastructureDataReferenceDto, CRITERIA extends BaseCriteria>
 	extends BaseFacade<DTO, INDEX_DTO, REF_DTO, CRITERIA> {
 
-
 	// todo investigate if we can move the save function up the hierarchy
-	DTO save(@Valid DTO dto, boolean allowMerge);
+	DTO save(DTO dto, boolean allowMerge);
 
 	List<REF_DTO> getByExternalId(String externalId, boolean includeArchivedEntities);
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/AbstractBaseEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/AbstractBaseEjb.java
@@ -1,13 +1,18 @@
 package de.symeda.sormas.backend.common;
 
+import de.symeda.sormas.api.BaseFacade;
 import de.symeda.sormas.api.EntityDto;
+import de.symeda.sormas.api.ReferenceDto;
+import de.symeda.sormas.api.utils.criteria.BaseCriteria;
 import de.symeda.sormas.backend.util.DtoHelper;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import java.io.Serializable;
 import java.util.List;
 
-public abstract class AbstractBaseEjb<ADO extends AbstractDomainObject, DTO extends EntityDto, SRV extends AdoServiceWithUserFilter<ADO>> {
+public abstract class AbstractBaseEjb<ADO extends AbstractDomainObject, DTO extends EntityDto, INDEX_DTO extends Serializable, REF_DTO extends ReferenceDto, SRV extends AdoServiceWithUserFilter<ADO>, CRITERIA extends BaseCriteria>
+	implements BaseFacade<DTO, INDEX_DTO, REF_DTO, CRITERIA> {
 
 	protected SRV service;
 
@@ -26,7 +31,8 @@ public abstract class AbstractBaseEjb<ADO extends AbstractDomainObject, DTO exte
 
 	// FIXME(@JonasCir) #6821: Add missing functions like save, getByUuid etc
 
-	public DTO save(@Valid DTO dtoToSave) {
+	@Override
+	public DTO save(DTO dtoToSave) {
 		return save(dtoToSave, false);
 	}
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/immunization/ImmunizationFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/immunization/ImmunizationFacadeEjb.java
@@ -246,7 +246,7 @@ public class ImmunizationFacadeEjb implements ImmunizationFacade {
 	}
 
 	@Override
-	public ImmunizationDto save(@Valid ImmunizationDto dto) {
+	public ImmunizationDto save(ImmunizationDto dto) {
 		Immunization existingImmunization = immunizationService.getByUuid(dto.getUuid());
 		ImmunizationDto existingDto = toDto(existingImmunization);
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/AbstractInfrastructureEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/AbstractInfrastructureEjb.java
@@ -1,6 +1,7 @@
 package de.symeda.sormas.backend.infrastructure;
 
 import de.symeda.sormas.api.EntityDto;
+import de.symeda.sormas.api.ReferenceDto;
 import de.symeda.sormas.api.feature.FeatureType;
 import de.symeda.sormas.api.i18n.I18nProperties;
 import de.symeda.sormas.api.i18n.Validations;
@@ -11,10 +12,11 @@ import de.symeda.sormas.backend.common.AbstractInfrastructureAdoService;
 import de.symeda.sormas.backend.common.InfrastructureAdo;
 import de.symeda.sormas.backend.feature.FeatureConfigurationFacadeEjb;
 
+import java.io.Serializable;
 import java.util.List;
 
-public abstract class AbstractInfrastructureEjb<ADO extends InfrastructureAdo, DTO extends EntityDto, SRV extends AbstractInfrastructureAdoService<ADO, CRITERIA>, CRITERIA extends BaseCriteria>
-	extends AbstractBaseEjb<ADO, DTO, SRV> {
+public abstract class AbstractInfrastructureEjb<ADO extends InfrastructureAdo, DTO extends EntityDto, INDEX_DTO extends Serializable, REF_DTO extends ReferenceDto, SRV extends AbstractInfrastructureAdoService<ADO, CRITERIA>, CRITERIA extends BaseCriteria>
+	extends AbstractBaseEjb<ADO, DTO, INDEX_DTO, REF_DTO, SRV, CRITERIA> {
 
 	protected FeatureConfigurationFacadeEjb featureConfiguration;
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/area/AreaFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/area/AreaFacadeEjb.java
@@ -35,7 +35,8 @@ import de.symeda.sormas.backend.util.QueryHelper;
 import org.apache.commons.collections.CollectionUtils;
 
 @Stateless(name = "AreaFacade")
-public class AreaFacadeEjb extends AbstractInfrastructureEjb<Area, AreaDto, AreaService, AreaCriteria> implements AreaFacade {
+public class AreaFacadeEjb extends AbstractInfrastructureEjb<Area, AreaDto, AreaDto, AreaReferenceDto, AreaService, AreaCriteria>
+	implements AreaFacade {
 
 	@PersistenceContext(unitName = ModelConstants.PERSISTENCE_UNIT_NAME)
 	private EntityManager em;
@@ -104,7 +105,7 @@ public class AreaFacadeEjb extends AbstractInfrastructureEjb<Area, AreaDto, Area
 	}
 
 	@Override
-	public AreaDto save(@Valid AreaDto dtoToSave, boolean allowMerge) {
+	public AreaDto save(AreaDto dtoToSave, boolean allowMerge) {
 		return save(dtoToSave, allowMerge, Validations.importAreaAlreadyExists);
 	}
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/community/CommunityFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/community/CommunityFacadeEjb.java
@@ -66,7 +66,8 @@ import de.symeda.sormas.backend.util.ModelConstants;
 import de.symeda.sormas.backend.util.QueryHelper;
 
 @Stateless(name = "CommunityFacade")
-public class CommunityFacadeEjb extends AbstractInfrastructureEjb<Community, CommunityDto, CommunityService, CommunityCriteria>
+public class CommunityFacadeEjb
+	extends AbstractInfrastructureEjb<Community, CommunityDto, CommunityDto, CommunityReferenceDto, CommunityService, CommunityCriteria>
 	implements CommunityFacade {
 
 	@PersistenceContext(unitName = ModelConstants.PERSISTENCE_UNIT_NAME)
@@ -258,7 +259,7 @@ public class CommunityFacadeEjb extends AbstractInfrastructureEjb<Community, Com
 	}
 
 	@Override
-	public CommunityDto save(@Valid CommunityDto dtoToSave, boolean allowMerge) throws ValidationRuntimeException {
+	public CommunityDto save(CommunityDto dtoToSave, boolean allowMerge) throws ValidationRuntimeException {
 		return save(dtoToSave, allowMerge, Validations.importCommunityAlreadyExists);
 	}
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/continent/ContinentFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/continent/ContinentFacadeEjb.java
@@ -60,7 +60,8 @@ import de.symeda.sormas.backend.util.ModelConstants;
 import de.symeda.sormas.backend.util.QueryHelper;
 
 @Stateless(name = "ContinentFacade")
-public class ContinentFacadeEjb extends AbstractInfrastructureEjb<Continent, ContinentDto, ContinentService, ContinentCriteria>
+public class ContinentFacadeEjb
+	extends AbstractInfrastructureEjb<Continent, ContinentDto, ContinentIndexDto, ContinentReferenceDto, ContinentService, ContinentCriteria>
 	implements ContinentFacade {
 
 	@PersistenceContext(unitName = ModelConstants.PERSISTENCE_UNIT_NAME)
@@ -185,7 +186,7 @@ public class ContinentFacadeEjb extends AbstractInfrastructureEjb<Continent, Con
 	}
 
 	@Override
-	public ContinentDto save(@Valid ContinentDto dtoToSave, boolean allowMerge) {
+	public ContinentDto save(ContinentDto dtoToSave, boolean allowMerge) {
 		return save(dtoToSave, allowMerge, Validations.importContinentAlreadyExists);
 	}
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/country/CountryFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/country/CountryFacadeEjb.java
@@ -70,7 +70,9 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 
 @Stateless(name = "CountryFacade")
-public class CountryFacadeEjb extends AbstractInfrastructureEjb<Country, CountryDto, CountryService, CountryCriteria> implements CountryFacade {
+public class CountryFacadeEjb
+	extends AbstractInfrastructureEjb<Country, CountryDto, CountryIndexDto, CountryReferenceDto, CountryService, CountryCriteria>
+	implements CountryFacade {
 
 	@PersistenceContext(unitName = ModelConstants.PERSISTENCE_UNIT_NAME)
 	private EntityManager em;
@@ -194,7 +196,7 @@ public class CountryFacadeEjb extends AbstractInfrastructureEjb<Country, Country
 	}
 
 	@Override
-	public CountryDto save(@Valid CountryDto dtoToSave, boolean allowMerge) throws ValidationRuntimeException {
+	public CountryDto save(CountryDto dtoToSave, boolean allowMerge) throws ValidationRuntimeException {
 		checkInfraDataLocked();
 
 		if (StringUtils.isBlank(dtoToSave.getIsoCode())) {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/district/DistrictFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/district/DistrictFacadeEjb.java
@@ -71,7 +71,9 @@ import de.symeda.sormas.backend.util.QueryHelper;
 import org.apache.commons.collections.CollectionUtils;
 
 @Stateless(name = "DistrictFacade")
-public class DistrictFacadeEjb extends AbstractInfrastructureEjb<District, DistrictDto, DistrictService, DistrictCriteria> implements DistrictFacade {
+public class DistrictFacadeEjb
+	extends AbstractInfrastructureEjb<District, DistrictDto, DistrictIndexDto, DistrictReferenceDto, DistrictService, DistrictCriteria>
+	implements DistrictFacade {
 
 	@PersistenceContext(unitName = ModelConstants.PERSISTENCE_UNIT_NAME)
 	private EntityManager em;
@@ -279,7 +281,7 @@ public class DistrictFacadeEjb extends AbstractInfrastructureEjb<District, Distr
 	}
 
 	@Override
-	public DistrictDto save(@Valid DistrictDto dtoToSave, boolean allowMerge) throws ValidationRuntimeException {
+	public DistrictDto save(DistrictDto dtoToSave, boolean allowMerge) throws ValidationRuntimeException {
 		return save(dtoToSave, allowMerge, Validations.importDistrictAlreadyExists);
 	}
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/facility/FacilityFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/facility/FacilityFacadeEjb.java
@@ -78,7 +78,9 @@ import de.symeda.sormas.backend.util.ModelConstants;
 import de.symeda.sormas.backend.util.QueryHelper;
 
 @Stateless(name = "FacilityFacade")
-public class FacilityFacadeEjb extends AbstractInfrastructureEjb<Facility, FacilityDto, FacilityService, FacilityCriteria> implements FacilityFacade {
+public class FacilityFacadeEjb
+	extends AbstractInfrastructureEjb<Facility, FacilityDto, FacilityIndexDto, FacilityReferenceDto, FacilityService, FacilityCriteria>
+	implements FacilityFacade {
 
 	@PersistenceContext(unitName = ModelConstants.PERSISTENCE_UNIT_NAME)
 	private EntityManager em;
@@ -587,7 +589,7 @@ public class FacilityFacadeEjb extends AbstractInfrastructureEjb<Facility, Facil
 	}
 
 	@Override
-	public FacilityDto save(@Valid FacilityDto dtoToSave, boolean allowMerge) throws ValidationRuntimeException {
+	public FacilityDto save(FacilityDto dtoToSave, boolean allowMerge) throws ValidationRuntimeException {
 		validateFacilityDto(dtoToSave);
 		return save(dtoToSave, allowMerge, Validations.importFacilityAlreadyExists);
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/pointofentry/PointOfEntryFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/pointofentry/PointOfEntryFacadeEjb.java
@@ -54,7 +54,9 @@ import de.symeda.sormas.backend.util.ModelConstants;
 import de.symeda.sormas.backend.util.QueryHelper;
 
 @Stateless(name = "PointOfEntryFacade")
-public class PointOfEntryFacadeEjb extends AbstractInfrastructureEjb<PointOfEntry, PointOfEntryDto, PointOfEntryService, PointOfEntryCriteria>
+public class PointOfEntryFacadeEjb
+	extends
+	AbstractInfrastructureEjb<PointOfEntry, PointOfEntryDto, PointOfEntryDto, PointOfEntryReferenceDto, PointOfEntryService, PointOfEntryCriteria>
 	implements PointOfEntryFacade {
 
 	@PersistenceContext(unitName = ModelConstants.PERSISTENCE_UNIT_NAME)
@@ -178,7 +180,7 @@ public class PointOfEntryFacadeEjb extends AbstractInfrastructureEjb<PointOfEntr
 	}
 
 	@Override
-	public PointOfEntryDto save(@Valid PointOfEntryDto dtoToSave, boolean allowMerge) throws ValidationRuntimeException {
+	public PointOfEntryDto save(PointOfEntryDto dtoToSave, boolean allowMerge) throws ValidationRuntimeException {
 		validate(dtoToSave);
 		return save(dtoToSave, allowMerge, Validations.importPointOfEntryAlreadyExists);
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/region/RegionFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/region/RegionFacadeEjb.java
@@ -71,7 +71,8 @@ import de.symeda.sormas.backend.util.QueryHelper;
 import org.apache.commons.collections.CollectionUtils;
 
 @Stateless(name = "RegionFacade")
-public class RegionFacadeEjb extends AbstractInfrastructureEjb<Region, RegionDto, RegionService, RegionCriteria> implements RegionFacade {
+public class RegionFacadeEjb extends AbstractInfrastructureEjb<Region, RegionDto, RegionIndexDto, RegionReferenceDto, RegionService, RegionCriteria>
+	implements RegionFacade {
 
 	@PersistenceContext(unitName = ModelConstants.PERSISTENCE_UNIT_NAME)
 	private EntityManager em;
@@ -332,7 +333,7 @@ public class RegionFacadeEjb extends AbstractInfrastructureEjb<Region, RegionDto
 	}
 
 	@Override
-	public RegionDto save(@Valid RegionDto dtoToSave, boolean allowMerge) throws ValidationRuntimeException {
+	public RegionDto save(RegionDto dtoToSave, boolean allowMerge) throws ValidationRuntimeException {
 		return save(dtoToSave, allowMerge, Validations.importRegionAlreadyExists);
 	}
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/subcontinent/SubcontinentFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/subcontinent/SubcontinentFacadeEjb.java
@@ -62,7 +62,9 @@ import de.symeda.sormas.backend.util.QueryHelper;
 import org.apache.commons.collections.CollectionUtils;
 
 @Stateless(name = "SubcontinentFacade")
-public class SubcontinentFacadeEjb extends AbstractInfrastructureEjb<Subcontinent, SubcontinentDto, SubcontinentService, SubcontinentCriteria>
+public class SubcontinentFacadeEjb
+	extends
+	AbstractInfrastructureEjb<Subcontinent, SubcontinentDto, SubcontinentIndexDto, SubcontinentReferenceDto, SubcontinentService, SubcontinentCriteria>
 	implements SubcontinentFacade {
 
 	@PersistenceContext(unitName = ModelConstants.PERSISTENCE_UNIT_NAME)
@@ -215,7 +217,7 @@ public class SubcontinentFacadeEjb extends AbstractInfrastructureEjb<Subcontinen
 	}
 
 	@Override
-	public SubcontinentDto save(@Valid SubcontinentDto dtoToSave, boolean allowMerge) {
+	public SubcontinentDto save(SubcontinentDto dtoToSave, boolean allowMerge) {
 		checkInfraDataLocked();
 		return save(dtoToSave, allowMerge, Validations.importSubcontinentAlreadyExists);
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/travelentry/TravelEntryFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/travelentry/TravelEntryFacadeEjb.java
@@ -187,7 +187,7 @@ public class TravelEntryFacadeEjb implements TravelEntryFacade {
 	}
 
 	@Override
-	public TravelEntryDto save(@Valid TravelEntryDto dto) {
+	public TravelEntryDto save(TravelEntryDto dto) {
 		TravelEntry existingTravelEntry = dto.getUuid() != null ? travelEntryService.getByUuid(dto.getUuid()) : null;
 		TravelEntryDto existingDto = toDto(existingTravelEntry);
 


### PR DESCRIPTION
Fixes #6885 

Apparently, CDI did not like that there  were two methods with the same name in parallel types that did validation on the parameters. 
> If a sub type overrides/implements a method originally defined in several parallel types of the hierarchy (e.g. two interfaces not extending each other, or a class and an interface not implemented by said class), no parameter constraints may be declared for that method at all nor parameters be marked for cascaded validation.

See offical docs [here](https://beanvalidation.org/1.1/spec/#constraintdeclarationvalidationprocess-methodlevelconstraints-inheritance)

The resolution to this introduce a clear hierarchy in the object tree.

Tested the application as well, a long string exceeding 255 chars will not be accepted as region name.

 