### PR TITLE
5065 replace jcenter by mavenCentral

### DIFF
--- a/sormas-app/app/build.gradle
+++ b/sormas-app/app/build.gradle
@@ -76,8 +76,7 @@ android {
 repositories {
     mavenLocal()
     google()
-    maven { url "https://maven.repository.redhat.com/ga/" }
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {
@@ -112,7 +111,7 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3:3.11'
     implementation 'org.apache.commons:commons-text:1.9'
     implementation 'org.jsoup:jsoup:1.13.1'
-    implementation 'com.googlecode:openbeans:1.0'
+    implementation 'me.champeau.openbeans:openbeans:1.0.2'
     implementation files('libs/MPAndroidChart-v3.0.2.jar')
     implementation(name: 'CircleProgress-v1.2.1', ext: 'aar')
     implementation 'io.reactivex:rxandroid:1.0.1'
@@ -131,7 +130,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
-    implementation 'me.dm7.barcodescanner:zxing:1.9.13'
+    implementation 'me.dm7.barcodescanner:zxing:1.9.8'
     implementation 'io.crowdcode.sormas.lbds:lbds-http-android:1.2.9'
     implementation 'io.crowdcode.sormas.lbds:lbds-android-messaging:1.4.6'
 }

--- a/sormas-app/build.gradle
+++ b/sormas-app/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.3'
@@ -21,8 +21,8 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
         mavenLocal()
+        mavenCentral()
         flatDir {
             dirs 'libs'
         }


### PR DESCRIPTION
Signed-off-by: Axel Nennker <axel.nennker@telekom.de>

Remove jcenter()
Replace openbeans 1.0 by openbeans 1.0.2 because that is in mavenCentral()
Downgrade me.dm7.barcodescanner:zxing from 1.9.13 (jcenter) to 1.9.8 (mavenCentral)

Fixes #5065 