### PR TITLE
7103 replace deprecated calls get color

### DIFF
--- a/sormas-app/app/build.gradle
+++ b/sormas-app/app/build.gradle
@@ -76,8 +76,7 @@ android {
 repositories {
     mavenLocal()
     google()
-    maven { url "https://maven.repository.redhat.com/ga/" }
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {
@@ -112,7 +111,7 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3:3.11'
     implementation 'org.apache.commons:commons-text:1.9'
     implementation 'org.jsoup:jsoup:1.13.1'
-    implementation 'com.googlecode:openbeans:1.0'
+    implementation 'me.champeau.openbeans:openbeans:1.0.2'
     implementation files('libs/MPAndroidChart-v3.0.2.jar')
     implementation(name: 'CircleProgress-v1.2.1', ext: 'aar')
     implementation 'io.reactivex:rxandroid:1.0.1'
@@ -131,7 +130,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
-    implementation 'me.dm7.barcodescanner:zxing:1.9.13'
+    implementation 'me.dm7.barcodescanner:zxing:1.9.8'
     implementation 'io.crowdcode.sormas.lbds:lbds-http-android:1.2.9'
     implementation 'io.crowdcode.sormas.lbds:lbds-android-messaging:1.4.6'
 }

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/BaseActivity.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/BaseActivity.java
@@ -36,7 +36,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBarDrawerToggle;
 import androidx.appcompat.widget.Toolbar;
-import androidx.core.content.ContextCompat;
 import androidx.drawerlayout.widget.DrawerLayout;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
@@ -75,6 +74,7 @@ import de.symeda.sormas.app.util.Bundler;
 import de.symeda.sormas.app.util.Callback;
 import de.symeda.sormas.app.util.LocationService;
 import de.symeda.sormas.app.util.NavigationHelper;
+import de.symeda.sormas.app.util.ResourceUtils;
 
 import static de.symeda.sormas.app.core.notification.NotificationType.ERROR;
 
@@ -173,7 +173,7 @@ public abstract class BaseActivity extends BaseLocalizedActivity implements Noti
 			pageMenu.setPageMenuItemClickCallback(this::setActivePage);
 		}
 
-		Drawable drawable = ContextCompat.getDrawable(this, R.drawable.selector_actionbar_back_button);
+		Drawable drawable = ResourceUtils.getDrawable(this, R.drawable.selector_actionbar_back_button);
 
 		final Toolbar toolbar = findViewById(R.id.applicationToolbar);
 		if (toolbar != null) {
@@ -227,8 +227,8 @@ public abstract class BaseActivity extends BaseLocalizedActivity implements Noti
 			if (getPageStatus() != null) {
 				Context statusFrameContext = statusFrame.getContext();
 
-				Drawable drw = (Drawable) ContextCompat.getDrawable(statusFrameContext, R.drawable.indicator_status_circle);
-				drw.setColorFilter(statusFrameContext.getResources().getColor(getStatusColorResource()), PorterDuff.Mode.SRC);
+				Drawable drw = (Drawable) ResourceUtils.getDrawable(statusFrameContext, R.drawable.indicator_status_circle);
+				drw.setColorFilter(ResourceUtils.getColor(statusFrameContext, getStatusColorResource()), PorterDuff.Mode.SRC);
 
 				TextView txtStatusName = (TextView) statusFrame.findViewById(R.id.txtStatusName);
 				ImageView imgStatus = (ImageView) statusFrame.findViewById(R.id.statusIcon);

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/caze/list/CaseListAdapter.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/caze/list/CaseListAdapter.java
@@ -24,17 +24,15 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
-import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.RecyclerView;
 
 import de.symeda.sormas.api.caze.CaseClassification;
-import de.symeda.sormas.api.i18n.Captions;
-import de.symeda.sormas.api.i18n.I18nProperties;
 import de.symeda.sormas.app.R;
 import de.symeda.sormas.app.backend.caze.Case;
 import de.symeda.sormas.app.core.adapter.databinding.BindingPagedListAdapter;
 import de.symeda.sormas.app.core.adapter.databinding.BindingViewHolder;
 import de.symeda.sormas.app.databinding.RowCaseListItemLayoutBinding;
+import de.symeda.sormas.app.util.ResourceUtils;
 
 public class CaseListAdapter extends BindingPagedListAdapter<Case, RowCaseListItemLayoutBinding> {
 
@@ -106,20 +104,19 @@ public class CaseListAdapter extends BindingPagedListAdapter<Case, RowCaseListIt
 //        }
 //    }
 
-	public void indicateCaseClassification(ImageView imgCaseClassificationIcon, Case item) {
-		Resources resources = imgCaseClassificationIcon.getContext().getResources();
-		Drawable drw = ContextCompat.getDrawable(imgCaseClassificationIcon.getContext(), R.drawable.indicator_status_circle);
-
+	public void indicateCaseClassification(@NonNull ImageView imgCaseClassificationIcon, @NonNull Case item) {
+		Drawable drw = ResourceUtils.getDrawable(imgCaseClassificationIcon.getContext(), R.drawable.indicator_status_circle);
+		assert drw != null;
 		if (item.getCaseClassification() == CaseClassification.NOT_CLASSIFIED) {
-			drw.setColorFilter(resources.getColor(R.color.indicatorCaseNotYetClassified), PorterDuff.Mode.SRC_OVER);
+			drw.setColorFilter(ResourceUtils.getColor(imgCaseClassificationIcon.getContext(), R.color.indicatorCaseNotYetClassified), PorterDuff.Mode.SRC_OVER);
 		} else if (item.getCaseClassification() == CaseClassification.SUSPECT) {
-			drw.setColorFilter(resources.getColor(R.color.indicatorCaseSuspect), PorterDuff.Mode.SRC_OVER);
+			drw.setColorFilter(ResourceUtils.getColor(imgCaseClassificationIcon.getContext(), R.color.indicatorCaseSuspect), PorterDuff.Mode.SRC_OVER);
 		} else if (item.getCaseClassification() == CaseClassification.PROBABLE) {
-			drw.setColorFilter(resources.getColor(R.color.indicatorCaseProbable), PorterDuff.Mode.SRC_OVER);
+			drw.setColorFilter(ResourceUtils.getColor(imgCaseClassificationIcon.getContext(), R.color.indicatorCaseProbable), PorterDuff.Mode.SRC_OVER);
 		} else if (item.getCaseClassification() == CaseClassification.CONFIRMED) {
-			drw.setColorFilter(resources.getColor(R.color.indicatorCaseConfirmed), PorterDuff.Mode.SRC_OVER);
+			drw.setColorFilter(ResourceUtils.getColor(imgCaseClassificationIcon.getContext(), R.color.indicatorCaseConfirmed), PorterDuff.Mode.SRC_OVER);
 		} else if (item.getCaseClassification() == CaseClassification.NO_CASE) {
-			drw.setColorFilter(resources.getColor(R.color.indicatorNotACase), PorterDuff.Mode.SRC_OVER);
+			drw.setColorFilter(ResourceUtils.getColor(imgCaseClassificationIcon.getContext(), R.color.indicatorNotACase), PorterDuff.Mode.SRC_OVER);
 		}
 
 		imgCaseClassificationIcon.setBackground(drw);

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/component/controls/ControlCheckBoxField.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/component/controls/ControlCheckBoxField.java
@@ -24,6 +24,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.CheckBox;
 
+import androidx.annotation.NonNull;
 import androidx.databinding.BindingAdapter;
 import androidx.databinding.InverseBindingAdapter;
 import androidx.databinding.InverseBindingListener;
@@ -31,6 +32,7 @@ import androidx.databinding.InverseBindingListener;
 import de.symeda.sormas.app.R;
 import de.symeda.sormas.app.backend.config.ConfigProvider;
 import de.symeda.sormas.app.component.VisualState;
+import de.symeda.sormas.app.util.ResourceUtils;
 
 public class ControlCheckBoxField extends ControlPropertyEditField<Boolean> {
 
@@ -198,7 +200,7 @@ public class ControlCheckBoxField extends ControlPropertyEditField<Boolean> {
 
 		visualState = state;
 
-		int labelColor = getResources().getColor(state.getLabelColor());
+		int labelColor = ResourceUtils.getColor(getContext(), state.getLabelColor());
 		label.setTextColor(labelColor);
 
 		if (state == VisualState.DISABLED) {
@@ -222,17 +224,17 @@ public class ControlCheckBoxField extends ControlPropertyEditField<Boolean> {
 	// Data binding, getters & setters
 
 	@BindingAdapter("value")
-	public static void setValue(ControlCheckBoxField view, Boolean value) {
+	public static void setValue(@NonNull ControlCheckBoxField view, Boolean value) {
 		view.setFieldValue(value);
 	}
 
 	@InverseBindingAdapter(attribute = "value", event = "valueAttrChanged")
-	public static Boolean getValue(ControlCheckBoxField view) {
+	public static Boolean getValue(@NonNull ControlCheckBoxField view) {
 		return view.getFieldValue();
 	}
 
 	@BindingAdapter("valueAttrChanged")
-	public static void setListener(ControlCheckBoxField view, InverseBindingListener listener) {
+	public static void setListener(@NonNull ControlCheckBoxField view, InverseBindingListener listener) {
 		view.inverseBindingListener = listener;
 	}
 }

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/component/controls/ControlDateField.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/component/controls/ControlDateField.java
@@ -31,6 +31,7 @@ import android.view.View;
 import android.widget.DatePicker;
 import android.widget.EditText;
 
+import androidx.annotation.NonNull;
 import androidx.databinding.BindingAdapter;
 import androidx.databinding.InverseBindingAdapter;
 import androidx.databinding.InverseBindingListener;
@@ -50,6 +51,7 @@ import de.symeda.sormas.app.backend.config.ConfigProvider;
 import de.symeda.sormas.app.component.VisualState;
 import de.symeda.sormas.app.component.VisualStateControlType;
 import de.symeda.sormas.app.util.DateFormatHelper;
+import de.symeda.sormas.app.util.ResourceUtils;
 
 public class ControlDateField extends ControlPropertyEditField<Date> {
 
@@ -260,7 +262,7 @@ public class ControlDateField extends ControlPropertyEditField<Date> {
 	}
 
 	@Override
-	protected void inflateView(Context context, AttributeSet attrs, int defStyle) {
+	protected void inflateView(@NonNull Context context, AttributeSet attrs, int defStyle) {
 		LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
 
 		if (inflater != null) {
@@ -344,10 +346,10 @@ public class ControlDateField extends ControlPropertyEditField<Date> {
 
 		visualState = state;
 
-		int labelColor = getResources().getColor(state.getLabelColor());
-		Drawable drawable = getResources().getDrawable(state.getBackground(VisualStateControlType.TEXT_FIELD));
-		int textColor = getResources().getColor(state.getTextColor());
-		int hintColor = getResources().getColor(state.getHintColor());
+		int labelColor = ResourceUtils.getColor(getContext(), state.getLabelColor());
+		Drawable drawable = ResourceUtils.getDrawable(getContext(), state.getBackground(VisualStateControlType.TEXT_FIELD));
+		int textColor = ResourceUtils.getColor(getContext(), state.getTextColor());
+		int hintColor = ResourceUtils.getColor(getContext(), state.getHintColor());
 
 		if (drawable != null) {
 			drawable = drawable.mutate();
@@ -377,22 +379,22 @@ public class ControlDateField extends ControlPropertyEditField<Date> {
 	// Data binding, getters & setters
 
 	@BindingAdapter("value")
-	public static void setValue(ControlDateField view, Date date) {
+	public static void setValue(@NonNull ControlDateField view, Date date) {
 		view.setFieldValue(date);
 	}
 
 	@InverseBindingAdapter(attribute = "value", event = "valueAttrChanged")
-	public static Date getValue(ControlDateField view) {
+	public static Date getValue(@NonNull ControlDateField view) {
 		return view.getFieldValue();
 	}
 
 	@BindingAdapter("valueAttrChanged")
-	public static void setListener(ControlDateField view, InverseBindingListener listener) {
+	public static void setListener(@NonNull ControlDateField view, InverseBindingListener listener) {
 		view.inverseBindingListener = listener;
 	}
 
 	@BindingAdapter("dateFormat")
-	public static void setDateFormat(ControlDateField field, SimpleDateFormat dateFormat) {
+	public static void setDateFormat(@NonNull ControlDateField field, SimpleDateFormat dateFormat) {
 		field.dateFormat = dateFormat;
 	}
 }

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/component/controls/ControlDateTimeField.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/component/controls/ControlDateTimeField.java
@@ -42,6 +42,7 @@ import android.widget.DatePicker;
 import android.widget.EditText;
 import android.widget.TimePicker;
 
+import androidx.annotation.NonNull;
 import androidx.databinding.BindingAdapter;
 import androidx.databinding.InverseBindingAdapter;
 import androidx.databinding.InverseBindingListener;
@@ -55,6 +56,7 @@ import de.symeda.sormas.app.backend.config.ConfigProvider;
 import de.symeda.sormas.app.component.VisualState;
 import de.symeda.sormas.app.component.VisualStateControlType;
 import de.symeda.sormas.app.util.DateFormatHelper;
+import de.symeda.sormas.app.util.ResourceUtils;
 
 public class ControlDateTimeField extends ControlPropertyEditField<Date> {
 
@@ -201,7 +203,7 @@ public class ControlDateTimeField extends ControlPropertyEditField<Date> {
 //        });
 //    }
 
-	private void setUpOnClickListener(final EditText input) {
+	private void setUpOnClickListener(@NonNull final EditText input) {
 		input.setOnClickListener(new OnClickListener() {
 
 			@Override
@@ -290,7 +292,7 @@ public class ControlDateTimeField extends ControlPropertyEditField<Date> {
 	}
 
 	@Override
-	protected void inflateView(Context context, AttributeSet attrs, int defStyle) {
+	protected void inflateView(@NonNull Context context, AttributeSet attrs, int defStyle) {
 		LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
 
 		if (inflater != null) {
@@ -389,10 +391,10 @@ public class ControlDateTimeField extends ControlPropertyEditField<Date> {
 
 		visualState = state;
 
-		int labelColor = getResources().getColor(state.getLabelColor());
-		Drawable drawable = getResources().getDrawable(state.getBackground(VisualStateControlType.TEXT_FIELD));
-		int textColor = getResources().getColor(state.getTextColor());
-		int hintColor = getResources().getColor(state.getHintColor());
+		int labelColor = ResourceUtils.getColor(getContext(), state.getLabelColor());
+		Drawable drawable = ResourceUtils.getDrawable(getContext(), state.getBackground(VisualStateControlType.TEXT_FIELD));
+		int textColor = ResourceUtils.getColor(getContext(), state.getTextColor());
+		int hintColor = ResourceUtils.getColor(getContext(), state.getHintColor());
 
 		if (drawable != null) {
 			drawable = drawable.mutate();
@@ -426,22 +428,22 @@ public class ControlDateTimeField extends ControlPropertyEditField<Date> {
 	// Data binding, getters & setters
 
 	@BindingAdapter("value")
-	public static void setValue(ControlDateTimeField view, Date date) {
+	public static void setValue(@NonNull ControlDateTimeField view, Date date) {
 		view.setFieldValue(date);
 	}
 
 	@InverseBindingAdapter(attribute = "value", event = "valueAttrChanged")
-	public static Date getValue(ControlDateTimeField view) {
+	public static Date getValue(@NonNull ControlDateTimeField view) {
 		return view.getFieldValue();
 	}
 
 	@BindingAdapter("valueAttrChanged")
-	public static void setListener(ControlDateTimeField view, InverseBindingListener listener) {
+	public static void setListener(@NonNull ControlDateTimeField view, InverseBindingListener listener) {
 		view.inverseBindingListener = listener;
 	}
 
 	@BindingAdapter("dateFormat")
-	public static void setDateFormat(ControlDateTimeField field, SimpleDateFormat dateFormat) {
+	public static void setDateFormat(@NonNull ControlDateTimeField field, SimpleDateFormat dateFormat) {
 		field.dateFormat = dateFormat;
 	}
 

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/component/controls/ControlRadioGroupField.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/component/controls/ControlRadioGroupField.java
@@ -32,6 +32,7 @@ import android.widget.RadioButton;
 import android.widget.RadioGroup;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
 import androidx.databinding.BindingAdapter;
 import androidx.databinding.InverseBindingAdapter;
 import androidx.databinding.InverseBindingListener;
@@ -42,6 +43,7 @@ import de.symeda.sormas.app.component.Item;
 import de.symeda.sormas.app.component.VisualState;
 import de.symeda.sormas.app.util.DataUtils;
 import de.symeda.sormas.app.util.DisplayMetricsHelper;
+import de.symeda.sormas.app.util.ResourceUtils;
 
 public class ControlRadioGroupField extends ControlPropertyEditField<Object> {
 
@@ -84,13 +86,13 @@ public class ControlRadioGroupField extends ControlPropertyEditField<Object> {
 
 	// Instance methods
 
-	public void setItems(List<Item> items) {
+	public void setItems(@NonNull List<Item> items) {
 		for (int i = 0; i < items.size(); i++) {
 			this.addItem(i, items.get(i));
 		}
 	}
 
-	public void addItem(int index, Item item) {
+	public void addItem(int index, @NonNull Item item) {
 		if (item.getValue() == null) {
 			return;
 		}
@@ -111,6 +113,7 @@ public class ControlRadioGroupField extends ControlPropertyEditField<Object> {
 		radioGroupElements.clear();
 	}
 
+	@NonNull
 	private RadioButton createRadioButton(int index) {
 		RadioButton button = new RadioButton(getContext());
 		button.setId(index);
@@ -149,6 +152,7 @@ public class ControlRadioGroupField extends ControlPropertyEditField<Object> {
 		return button;
 	}
 
+	@NonNull
 	private LinearLayout createRadioButtonFrame() {
 		LinearLayout frame = new LinearLayout(getContext());
 		frame.setOrientation(HORIZONTAL);
@@ -160,13 +164,14 @@ public class ControlRadioGroupField extends ControlPropertyEditField<Object> {
 		return frame;
 	}
 
+	@NonNull
 	private View createRadioButtonLabel(String caption) {
 		TextView buttonLabel = new TextView(new ContextThemeWrapper(getContext(), R.style.CheckBoxLabelStyle), null, 0);
 
 		ViewGroup.LayoutParams params = new LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT);
 
 		buttonLabel.setText(caption);
-		buttonLabel.setTextColor(getResources().getColor(R.color.controlTextColor));
+		buttonLabel.setTextColor(ResourceUtils.getColor(getContext(), R.color.controlTextColor));
 		buttonLabel.setLayoutParams(params);
 
 		return buttonLabel;
@@ -228,7 +233,7 @@ public class ControlRadioGroupField extends ControlPropertyEditField<Object> {
 		}
 	}
 
-	private void setChildViewEnabledState(RadioButton button) {
+	private void setChildViewEnabledState(@NonNull RadioButton button) {
 		button.setEnabled(input.isEnabled());
 		button.setClickable(input.isEnabled());
 	}
@@ -266,7 +271,7 @@ public class ControlRadioGroupField extends ControlPropertyEditField<Object> {
 	}
 
 	@Override
-	protected void inflateView(Context context, AttributeSet attrs, int defStyle) {
+	protected void inflateView(@NonNull Context context, AttributeSet attrs, int defStyle) {
 		LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
 
 		if (inflater != null) {
@@ -324,7 +329,7 @@ public class ControlRadioGroupField extends ControlPropertyEditField<Object> {
 
 		visualState = state;
 
-		int labelColor = getResources().getColor(state.getLabelColor());
+		int labelColor = ResourceUtils.getColor(getContext(), state.getLabelColor());
 		label.setTextColor(labelColor);
 
 		if (state == VisualState.DISABLED) {
@@ -340,8 +345,8 @@ public class ControlRadioGroupField extends ControlPropertyEditField<Object> {
 			return;
 		}
 
-		int uncheckedStateColor = getResources().getColor(R.color.colorControlNormal);
-		int checkedStateColor = getResources().getColor(R.color.colorControlActivated);
+		int uncheckedStateColor = ResourceUtils.getColor(getContext(), R.color.colorControlNormal);
+		int checkedStateColor = ResourceUtils.getColor(getContext(), R.color.colorControlActivated);
 
 		if (state == VisualState.FOCUSED || state == VisualState.NORMAL) {
 			setStateColor(checkedStateColor, uncheckedStateColor);
@@ -356,17 +361,17 @@ public class ControlRadioGroupField extends ControlPropertyEditField<Object> {
 	// Data binding, getters & setters
 
 	@BindingAdapter("value")
-	public static void setValue(ControlRadioGroupField view, RadioButton value) {
+	public static void setValue(@NonNull ControlRadioGroupField view, RadioButton value) {
 		view.setFieldValue(value);
 	}
 
 	@InverseBindingAdapter(attribute = "value", event = "valueAttrChanged")
-	public static Object getValue(ControlRadioGroupField view) {
+	public static Object getValue(@NonNull ControlRadioGroupField view) {
 		return view.getFieldValue();
 	}
 
 	@BindingAdapter("valueAttrChanged")
-	public static void setListener(final ControlRadioGroupField view, InverseBindingListener listener) {
+	public static void setListener(@NonNull final ControlRadioGroupField view, InverseBindingListener listener) {
 		view.inverseBindingListener = listener;
 	}
 
@@ -381,7 +386,7 @@ public class ControlRadioGroupField extends ControlPropertyEditField<Object> {
 	@BindingAdapter(value = {
 		"value",
 		"enumClass" })
-	public static void setValue(ControlRadioGroupField view, Object value, Class c) {
+	public static void setValue(@NonNull ControlRadioGroupField view, Object value, Class c) {
 		view.setEnumClass(c);
 		view.setFieldValue(value);
 	}

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/component/controls/ControlSpinnerAdapter.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/component/controls/ControlSpinnerAdapter.java
@@ -31,6 +31,7 @@ import androidx.annotation.NonNull;
 
 import de.symeda.sormas.app.R;
 import de.symeda.sormas.app.component.Item;
+import de.symeda.sormas.app.util.ResourceUtils;
 
 public class ControlSpinnerAdapter extends ArrayAdapter<Item> {
 
@@ -105,7 +106,7 @@ public class ControlSpinnerAdapter extends ArrayAdapter<Item> {
 			} else {
 				textView.setHint(getContext().getResources().getString(R.string.hint_select_entry));
 			}
-			textView.setTextColor(getContext().getResources().getColor(R.color.hintText));
+			textView.setTextColor(ResourceUtils.getColor(getContext(), R.color.hintText));
 		}
 
 		return view;
@@ -147,11 +148,11 @@ public class ControlSpinnerAdapter extends ArrayAdapter<Item> {
 			int selectedPosition = spinner.getPositionOf(spinner.getSelectedItem());
 			if (selectedPosition >= 0) {
 				if (position == selectedPosition) {
-					textView.setTextColor(getContext().getResources().getColor(R.color.spinnerDropdownItemTextActive));
-					view.setBackgroundColor(getContext().getResources().getColor(R.color.spinnerDropdownItemBackgroundActive));
+					textView.setTextColor(ResourceUtils.getColor(getContext(), R.color.spinnerDropdownItemTextActive));
+					view.setBackgroundColor(ResourceUtils.getColor(getContext(), R.color.spinnerDropdownItemBackgroundActive));
 				} else {
-					textView.setTextColor(getContext().getResources().getColor(R.color.controlTextColor));
-					view.setBackground(getContext().getResources().getDrawable(R.drawable.background_spinner_item));
+					textView.setTextColor(ResourceUtils.getColor(getContext(), R.color.controlTextColor));
+					view.setBackground(ResourceUtils.getDrawable(getContext(), R.drawable.background_spinner_item));
 				}
 			}
 		}

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/component/controls/ControlSpinnerField.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/component/controls/ControlSpinnerField.java
@@ -26,6 +26,7 @@ import android.widget.ArrayAdapter;
 import android.widget.Spinner;
 import android.widget.SpinnerAdapter;
 
+import androidx.annotation.NonNull;
 import androidx.databinding.BindingAdapter;
 import androidx.databinding.InverseBindingAdapter;
 import androidx.databinding.InverseBindingListener;
@@ -39,6 +40,7 @@ import de.symeda.sormas.app.component.Item;
 import de.symeda.sormas.app.component.VisualState;
 import de.symeda.sormas.app.component.VisualStateControlType;
 import de.symeda.sormas.app.util.DataUtils;
+import de.symeda.sormas.app.util.ResourceUtils;
 
 public class ControlSpinnerField extends ControlPropertyEditField<Object> {
 
@@ -209,7 +211,7 @@ public class ControlSpinnerField extends ControlPropertyEditField<Object> {
 	}
 
 	@Override
-	protected void inflateView(Context context, AttributeSet attrs, int defStyle) {
+	protected void inflateView(@NonNull Context context, AttributeSet attrs, int defStyle) {
 		LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
 
 		if (inflater != null) {
@@ -309,8 +311,8 @@ public class ControlSpinnerField extends ControlPropertyEditField<Object> {
 
 		visualState = state;
 
-		int labelColor = getResources().getColor(state.getLabelColor());
-		Drawable drawable = getResources().getDrawable(state.getBackground(VisualStateControlType.SPINNER));
+		int labelColor = ResourceUtils.getColor(getContext(), state.getLabelColor());
+		Drawable drawable = ResourceUtils.getDrawable(getContext(), state.getBackground(VisualStateControlType.SPINNER));
 
 		if (drawable != null) {
 			drawable = drawable.mutate();
@@ -340,17 +342,17 @@ public class ControlSpinnerField extends ControlPropertyEditField<Object> {
 	// Data binding, getters & setters
 
 	@BindingAdapter("value")
-	public static void setValue(ControlSpinnerField view, Object value) {
+	public static void setValue(@NonNull ControlSpinnerField view, Object value) {
 		view.setFieldValue(value);
 	}
 
 	@InverseBindingAdapter(attribute = "value", event = "valueAttrChanged")
-	public static Object getValue(ControlSpinnerField view) {
+	public static Object getValue(@NonNull ControlSpinnerField view) {
 		return view.getFieldValue();
 	}
 
 	@BindingAdapter("valueAttrChanged")
-	public static void setListener(ControlSpinnerField view, InverseBindingListener listener) {
+	public static void setListener(@NonNull ControlSpinnerField view, InverseBindingListener listener) {
 		view.inverseBindingListener = listener;
 	}
 }

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/component/controls/ControlSwitchField.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/component/controls/ControlSwitchField.java
@@ -32,6 +32,8 @@ import android.view.ViewGroup;
 import android.widget.RadioButton;
 import android.widget.RadioGroup;
 
+import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 import androidx.databinding.BindingAdapter;
 import androidx.databinding.InverseBindingAdapter;
 import androidx.databinding.InverseBindingListener;
@@ -45,6 +47,7 @@ import de.symeda.sormas.app.component.Item;
 import de.symeda.sormas.app.component.VisualState;
 import de.symeda.sormas.app.core.StateDrawableBuilder;
 import de.symeda.sormas.app.util.DataUtils;
+import de.symeda.sormas.app.util.ResourceUtils;
 
 public class ControlSwitchField extends ControlPropertyEditField<Object> {
 
@@ -98,7 +101,7 @@ public class ControlSwitchField extends ControlPropertyEditField<Object> {
 		}
 	}
 
-	private void setChildViewEnabledState(RadioButton button) {
+	private void setChildViewEnabledState(@NonNull RadioButton button) {
 		button.setEnabled(input.isEnabled());
 		button.setClickable(input.isEnabled());
 	}
@@ -146,6 +149,7 @@ public class ControlSwitchField extends ControlPropertyEditField<Object> {
 		radioGroupElements.clear();
 	}
 
+	@NonNull
 	private RadioButton createRadioButton(int index, int lastIndex, Item item) {
 		RadioButton button = new RadioButton(getContext());
 		button.setId(index);
@@ -213,7 +217,7 @@ public class ControlSwitchField extends ControlPropertyEditField<Object> {
 			.build();
 	}
 
-	private void setUpOnClickListener(RadioButton button, ControlSwitchField field) {
+	private void setUpOnClickListener(@NonNull RadioButton button, ControlSwitchField field) {
 		button.setOnClickListener(v -> {
 			if (!v.isEnabled()) {
 				return;
@@ -249,7 +253,7 @@ public class ControlSwitchField extends ControlPropertyEditField<Object> {
 	}
 
 	@Override
-	protected void inflateView(Context context, AttributeSet attrs, int defStyle) {
+	protected void inflateView(@NonNull Context context, AttributeSet attrs, int defStyle) {
 		LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
 
 		if (inflater != null) {
@@ -269,8 +273,8 @@ public class ControlSwitchField extends ControlPropertyEditField<Object> {
 
 		input = (RadioGroup) this.findViewById(R.id.switch_input);
 		input.setOrientation(HORIZONTAL);
-		background = getResources().getDrawable(R.drawable.control_switch_background_border);
-		textColor = getResources().getColorStateList(R.color.control_switch_color_selector);
+		background = ResourceUtils.getDrawable(getContext(), R.drawable.control_switch_background_border);
+		textColor = ContextCompat.getColorStateList(getContext(), R.color.control_switch_color_selector);
 		input.setBackground(background.mutate());
 
 		if (useBoolean) {
@@ -361,11 +365,11 @@ public class ControlSwitchField extends ControlPropertyEditField<Object> {
 
 		visualState = state;
 
-		int labelColor = getResources().getColor(state.getLabelColor());
+		int labelColor = ResourceUtils.getColor(getContext(), state.getLabelColor());
 		label.setTextColor(labelColor);
 
 		if (state == VisualState.DISABLED) {
-			Drawable disabledStateDrawable = getResources().getDrawable(R.drawable.control_switch_background_border_disabled);
+			Drawable disabledStateDrawable = ResourceUtils.getDrawable(getContext(), R.drawable.control_switch_background_border_disabled);
 			disabledStateDrawable = disabledStateDrawable.mutate();
 			input.setBackground(disabledStateDrawable);
 			setEnabled(false);
@@ -380,7 +384,7 @@ public class ControlSwitchField extends ControlPropertyEditField<Object> {
 		}
 
 		if (state == VisualState.ERROR) {
-			Drawable errorStateDrawable = getResources().getDrawable(R.drawable.control_switch_background_border_error);
+			Drawable errorStateDrawable = ResourceUtils.getDrawable(getContext(), R.drawable.control_switch_background_border_error);
 			errorStateDrawable = errorStateDrawable.mutate();
 			input.setBackground(errorStateDrawable);
 			return;
@@ -395,17 +399,17 @@ public class ControlSwitchField extends ControlPropertyEditField<Object> {
 	// Data binding, getters & setters
 
 	@BindingAdapter("value")
-	public static void setValue(ControlSwitchField view, Object value) {
+	public static void setValue(@NonNull ControlSwitchField view, Object value) {
 		view.setFieldValue(value);
 	}
 
 	@InverseBindingAdapter(attribute = "value", event = "valueAttrChanged")
-	public static Object getValue(ControlSwitchField view) {
+	public static Object getValue(@NonNull ControlSwitchField view) {
 		return view.getFieldValue();
 	}
 
 	@BindingAdapter("valueAttrChanged")
-	public static void setListener(final ControlSwitchField view, InverseBindingListener listener) {
+	public static void setListener(@NonNull final ControlSwitchField view, InverseBindingListener listener) {
 		view.inverseBindingListener = listener;
 	}
 

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/component/controls/ControlTagViewField.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/component/controls/ControlTagViewField.java
@@ -33,10 +33,12 @@ import android.view.ViewTreeObserver;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
 import androidx.databinding.DataBindingUtil;
 import androidx.databinding.ViewDataBinding;
 
 import de.symeda.sormas.app.R;
+import de.symeda.sormas.app.util.ResourceUtils;
 
 public class ControlTagViewField extends ControlPropertyField<String> {
 
@@ -140,17 +142,18 @@ public class ControlTagViewField extends ControlPropertyField<String> {
 		}
 	}
 
+	@NonNull
 	private Drawable getBackgroundDrawable() {
 		StateListDrawable stateListDrawable = new StateListDrawable();
 		GradientDrawable drawableNormal = new GradientDrawable();
-		drawableNormal.setColor(getResources().getColor(LAYOUT_COLOR));
+		drawableNormal.setColor(ResourceUtils.getColor(getContext(),LAYOUT_COLOR));
 		drawableNormal.setCornerRadius(getResources().getDimension(RADIUS));
 		if (getResources().getDimension(LAYOUT_BORDER_SIZE) > 0) {
 			drawableNormal
-				.setStroke(dipToPx(getContext(), getResources().getDimension(LAYOUT_BORDER_SIZE)), getResources().getColor(LAYOUT_BORDER_COLOR));
+				.setStroke(dipToPx(getContext(), getResources().getDimension(LAYOUT_BORDER_SIZE)), ResourceUtils.getColor(getContext(), LAYOUT_BORDER_COLOR));
 		}
 		GradientDrawable drawablePressed = new GradientDrawable();
-		drawablePressed.setColor(getResources().getColor(LAYOUT_COLOR_PRESSED));
+		drawablePressed.setColor(ResourceUtils.getColor(getContext(), LAYOUT_COLOR_PRESSED));
 		drawablePressed.setCornerRadius(getResources().getDimension(RADIUS));
 		stateListDrawable.addState(
 			new int[] {
@@ -168,7 +171,7 @@ public class ControlTagViewField extends ControlPropertyField<String> {
 		}
 	}
 
-	private int dipToPx(Context c, float dipValue) {
+	private int dipToPx(@NonNull Context c, float dipValue) {
 		DisplayMetrics metrics = c.getResources().getDisplayMetrics();
 		return (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, dipValue, metrics);
 	}
@@ -191,7 +194,7 @@ public class ControlTagViewField extends ControlPropertyField<String> {
 	}
 
 	@Override
-	protected void inflateView(Context context, AttributeSet attrs, int defStyle) {
+	protected void inflateView(@NonNull Context context, AttributeSet attrs, int defStyle) {
 		layoutInflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
 
 		if (layoutInflater != null) {

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/component/controls/ControlTextEditField.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/component/controls/ControlTextEditField.java
@@ -31,6 +31,8 @@ import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.databinding.BindingAdapter;
 import androidx.databinding.InverseBindingAdapter;
 import androidx.databinding.InverseBindingListener;
@@ -40,6 +42,7 @@ import de.symeda.sormas.app.R;
 import de.symeda.sormas.app.backend.config.ConfigProvider;
 import de.symeda.sormas.app.component.VisualState;
 import de.symeda.sormas.app.component.VisualStateControlType;
+import de.symeda.sormas.app.util.ResourceUtils;
 
 public class ControlTextEditField extends ControlPropertyEditField<String> {
 
@@ -330,10 +333,10 @@ public class ControlTextEditField extends ControlPropertyEditField<String> {
 
 		visualState = state;
 
-		int labelColor = getResources().getColor(state.getLabelColor());
-		Drawable drawable = getResources().getDrawable(state.getBackground(VisualStateControlType.TEXT_FIELD));
-		int textColor = getResources().getColor(state.getTextColor());
-		int hintColor = getResources().getColor(state.getHintColor());
+		int labelColor = ResourceUtils.getColor(getContext(),state.getLabelColor());
+		Drawable drawable = ResourceUtils.getDrawable(getContext(), state.getBackground(VisualStateControlType.TEXT_FIELD));
+		int textColor = ResourceUtils.getColor(getContext(), state.getTextColor());
+		int hintColor = ResourceUtils.getColor(getContext(), state.getHintColor());
 
 		if (drawable != null) {
 			drawable = drawable.mutate();
@@ -403,12 +406,13 @@ public class ControlTextEditField extends ControlPropertyEditField<String> {
 	}
 
 	@InverseBindingAdapter(attribute = "value", event = "valueAttrChanged")
-	public static String getValue(ControlTextEditField view) {
+	public static String getValue(@NonNull ControlTextEditField view) {
 		return view.getFieldValue();
 	}
 
+	@Nullable
 	@InverseBindingAdapter(attribute = "value", event = "valueAttrChanged")
-	public static Integer getIntegerValue(ControlTextEditField view) {
+	public static Integer getIntegerValue(@NonNull ControlTextEditField view) {
 		if (view.getFieldValue() != null && !view.getFieldValue().isEmpty()) {
 			return Integer.valueOf(view.getFieldValue());
 		} else {
@@ -416,8 +420,9 @@ public class ControlTextEditField extends ControlPropertyEditField<String> {
 		}
 	}
 
+	@Nullable
 	@InverseBindingAdapter(attribute = "value", event = "valueAttrChanged")
-	public static Float getFloatValue(ControlTextEditField view) {
+	public static Float getFloatValue(@NonNull ControlTextEditField view) {
 		if (view.getFieldValue() != null && !view.getFieldValue().isEmpty()) {
 			return Float.valueOf(view.getFieldValue());
 		} else {
@@ -425,8 +430,9 @@ public class ControlTextEditField extends ControlPropertyEditField<String> {
 		}
 	}
 
+	@Nullable
 	@InverseBindingAdapter(attribute = "value", event = "valueAttrChanged")
-	public static Double getDoubleValue(ControlTextEditField view) {
+	public static Double getDoubleValue(@NonNull ControlTextEditField view) {
 		if (view.getFieldValue() != null && !view.getFieldValue().isEmpty()) {
 			return Double.valueOf(view.getFieldValue());
 		} else {
@@ -435,7 +441,7 @@ public class ControlTextEditField extends ControlPropertyEditField<String> {
 	}
 
 	@BindingAdapter("valueAttrChanged")
-	public static void setListener(ControlTextEditField view, InverseBindingListener listener) {
+	public static void setListener(@NonNull ControlTextEditField view, InverseBindingListener listener) {
 		view.inverseBindingListener = listener;
 	}
 

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/component/controls/ControlTextImageField.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/component/controls/ControlTextImageField.java
@@ -23,7 +23,7 @@ import android.view.LayoutInflater;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 
-import androidx.core.content.ContextCompat;
+import androidx.annotation.NonNull;
 import androidx.databinding.BindingAdapter;
 
 import de.symeda.sormas.api.task.TaskPriority;
@@ -31,6 +31,7 @@ import de.symeda.sormas.api.task.TaskStatus;
 import de.symeda.sormas.app.R;
 import de.symeda.sormas.app.backend.sample.Sample;
 import de.symeda.sormas.app.util.DateFormatHelper;
+import de.symeda.sormas.app.util.ResourceUtils;
 
 public class ControlTextImageField extends ControlTextReadField {
 
@@ -71,7 +72,7 @@ public class ControlTextImageField extends ControlTextReadField {
 	public void setImageBackground(int imageResource, int tintResource) {
 		if (imageView != null) {
 			Context context = imageView.getContext();
-			Drawable background = ContextCompat.getDrawable(context, imageResource);
+			Drawable background = ResourceUtils.getDrawable(context, imageResource);
 
 			applyBackground(background, tintResource, context);
 		}
@@ -80,7 +81,7 @@ public class ControlTextImageField extends ControlTextReadField {
 	public void setImageBackground(int tintResource) {
 		if (imageView != null) {
 			Context context = imageView.getContext();
-			Drawable background = ContextCompat.getDrawable(context, getImage());
+			Drawable background = ResourceUtils.getDrawable(context, getImage());
 
 			applyBackground(background, tintResource, context);
 		}
@@ -88,7 +89,7 @@ public class ControlTextImageField extends ControlTextReadField {
 
 	private void applyBackground(Drawable background, int tintResource, Context context) {
 		if (background != null) {
-			background.setTint(context.getResources().getColor(tintResource));
+			background.setTint(ResourceUtils.getColor(context,tintResource));
 		}
 
 		imageView.setBackground(background);
@@ -117,7 +118,7 @@ public class ControlTextImageField extends ControlTextReadField {
 	}
 
 	@Override
-	protected void inflateView(Context context, AttributeSet attrs, int defStyle) {
+	protected void inflateView(@NonNull Context context, AttributeSet attrs, int defStyle) {
 		LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
 
 		if (inflater != null) {
@@ -260,7 +261,7 @@ public class ControlTextImageField extends ControlTextReadField {
 		"value",
 		"valueFormat",
 		"defaultValue" }, requireAll = false)
-	public static void setValue(ControlTextImageField textImageField, Boolean booleanValue, String valueFormat, String defaultValue) {
+	public static void setValue(ControlTextImageField textImageField, @NonNull Boolean booleanValue, String valueFormat, String defaultValue) {
 		if (booleanValue) {
 			textImageField.setImageBackground(R.drawable.ic_check_circle_24dp, R.color.green);
 		} else {

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/component/controls/ControlTextPopupField.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/component/controls/ControlTextPopupField.java
@@ -25,6 +25,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
 import androidx.databinding.BindingAdapter;
 import androidx.databinding.InverseBindingAdapter;
 import androidx.databinding.InverseBindingListener;
@@ -36,6 +37,7 @@ import de.symeda.sormas.app.backend.config.ConfigProvider;
 import de.symeda.sormas.app.backend.location.Location;
 import de.symeda.sormas.app.component.VisualState;
 import de.symeda.sormas.app.component.VisualStateControlType;
+import de.symeda.sormas.app.util.ResourceUtils;
 
 public class ControlTextPopupField extends ControlPropertyEditField<String> {
 
@@ -166,7 +168,7 @@ public class ControlTextPopupField extends ControlPropertyEditField<String> {
 	}
 
 	@Override
-	protected void inflateView(Context context, AttributeSet attrs, int defStyle) {
+	protected void inflateView(@NonNull Context context, AttributeSet attrs, int defStyle) {
 		LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
 
 		if (inflater != null) {
@@ -193,10 +195,10 @@ public class ControlTextPopupField extends ControlPropertyEditField<String> {
 
 		input.setCompoundDrawablesWithIntrinsicBounds(iconStart, null, iconEnd, null);
 		if (iconStart != null) {
-			iconStart.setTint(getResources().getColor(R.color.control_link_edittextview_color_selector));
+			iconStart.setTint(ResourceUtils.getColor(getContext(), R.color.control_link_edittextview_color_selector));
 		}
 		if (iconEnd != null) {
-			iconEnd.setTint(getResources().getColor(R.color.control_link_edittextview_color_selector));
+			iconEnd.setTint(ResourceUtils.getColor(getContext(), R.color.control_link_edittextview_color_selector));
 		}
 
 		input.addTextChangedListener(new TextWatcher() {
@@ -243,8 +245,8 @@ public class ControlTextPopupField extends ControlPropertyEditField<String> {
 
 		visualState = state;
 
-		int labelColor = getResources().getColor(state.getLabelColor());
-		Drawable drawable = getResources().getDrawable(state.getBackground(VisualStateControlType.TEXT_FIELD));
+		int labelColor = ResourceUtils.getColor(getContext(), state.getLabelColor());
+		Drawable drawable = ResourceUtils.getDrawable(getContext(), state.getBackground(VisualStateControlType.TEXT_FIELD));
 
 		if (drawable != null) {
 			drawable = drawable.mutate();
@@ -275,27 +277,27 @@ public class ControlTextPopupField extends ControlPropertyEditField<String> {
 	// Data binding, getters & setters
 
 	@BindingAdapter("value")
-	public static void setValue(ControlTextPopupField view, String text) {
+	public static void setValue(@NonNull ControlTextPopupField view, String text) {
 		view.setValue(text);
 	}
 
 	@InverseBindingAdapter(attribute = "value", event = "valueAttrChanged")
-	public static String getValue(ControlTextPopupField view) {
+	public static String getValue(@NonNull ControlTextPopupField view) {
 		return view.getFieldValue();
 	}
 
 	@BindingAdapter("valueAttrChanged")
-	public static void setListener(ControlTextPopupField view, InverseBindingListener listener) {
+	public static void setListener(@NonNull ControlTextPopupField view, InverseBindingListener listener) {
 		view.inverseBindingListener = listener;
 	}
 
 	@BindingAdapter("locationValue")
-	public static void setLocationValue(ControlTextPopupField textPopupField, Location location) {
+	public static void setLocationValue(@NonNull ControlTextPopupField textPopupField, Location location) {
 		textPopupField.setValue(location);
 	}
 
 	@InverseBindingAdapter(attribute = "locationValue", event = "valueAttrChanged")
-	public static Location getLocationValue(ControlTextPopupField textPopupField) {
+	public static Location getLocationValue(@NonNull ControlTextPopupField textPopupField) {
 		return (Location) textPopupField.getValue();
 	}
 }

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/component/controls/FilterSpinnerField.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/component/controls/FilterSpinnerField.java
@@ -20,10 +20,13 @@ import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
 
+import androidx.annotation.NonNull;
+
 import de.symeda.sormas.app.R;
 import de.symeda.sormas.app.backend.config.ConfigProvider;
 import de.symeda.sormas.app.component.VisualState;
 import de.symeda.sormas.app.component.VisualStateControlType;
+import de.symeda.sormas.app.util.ResourceUtils;
 
 public class FilterSpinnerField extends ControlSpinnerField {
 
@@ -44,7 +47,7 @@ public class FilterSpinnerField extends ControlSpinnerField {
 	// Overrides
 
 	@Override
-	protected void inflateView(Context context, AttributeSet attrs, int defStyle) {
+	protected void inflateView(@NonNull Context context, AttributeSet attrs, int defStyle) {
 		LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
 
 		if (inflater != null) {
@@ -72,8 +75,8 @@ public class FilterSpinnerField extends ControlSpinnerField {
 
 		visualState = state;
 
-		int labelColor = getResources().getColor(state.getLabelColor());
-		Drawable drawable = getResources().getDrawable(state.getBackground(VisualStateControlType.SPINNER_FILTER));
+		int labelColor = ResourceUtils.getColor(getContext(), state.getLabelColor());
+		Drawable drawable = ResourceUtils.getDrawable(getContext(),state.getBackground(VisualStateControlType.SPINNER_FILTER));
 
 		if (drawable != null) {
 			drawable = drawable.mutate();

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/component/controls/FilterTextField.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/component/controls/FilterTextField.java
@@ -20,10 +20,13 @@ import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
 
+import androidx.annotation.NonNull;
+
 import de.symeda.sormas.app.R;
 import de.symeda.sormas.app.backend.config.ConfigProvider;
 import de.symeda.sormas.app.component.VisualState;
 import de.symeda.sormas.app.component.VisualStateControlType;
+import de.symeda.sormas.app.util.ResourceUtils;
 
 public class FilterTextField extends ControlTextEditField {
 
@@ -44,7 +47,7 @@ public class FilterTextField extends ControlTextEditField {
 	// Overrides
 
 	@Override
-	protected void inflateView(Context context, AttributeSet attrs, int defStyle) {
+	protected void inflateView(@NonNull Context context, AttributeSet attrs, int defStyle) {
 		LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
 
 		if (inflater != null) {
@@ -72,10 +75,10 @@ public class FilterTextField extends ControlTextEditField {
 
 		visualState = state;
 
-		int labelColor = getResources().getColor(state.getLabelColor());
-		Drawable drawable = getResources().getDrawable(state.getBackground(VisualStateControlType.TEXT_FILTER));
-		int textColor = getResources().getColor(state.getTextColor());
-		int hintColor = getResources().getColor(state.getHintColor());
+		int labelColor = ResourceUtils.getColor(getContext(), state.getLabelColor());
+		Drawable drawable = ResourceUtils.getDrawable(getContext(), state.getBackground(VisualStateControlType.TEXT_FILTER));
+		int textColor = ResourceUtils.getColor(getContext(), state.getTextColor());
+		int hintColor = ResourceUtils.getColor(getContext(), state.getHintColor());
 
 		if (drawable != null) {
 			drawable = drawable.mutate();

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/component/menu/PageMenuAdapter.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/component/menu/PageMenuAdapter.java
@@ -27,6 +27,7 @@ import android.widget.TextView;
 import java.util.List;
 
 import de.symeda.sormas.app.R;
+import de.symeda.sormas.app.util.ResourceUtils;
 
 import static android.view.View.GONE;
 
@@ -111,12 +112,12 @@ public class PageMenuAdapter extends BaseAdapter {
 			}
 
 			if (pageMenuItem.getIconResourceId() > 0) {
-				Drawable icon = context.getDrawable(pageMenuItem.getIconResourceId());
+				Drawable icon = ResourceUtils.getDrawable(context, pageMenuItem.getIconResourceId());
 				if (pageMenuItem.isActive()) {
-					icon.setTint(context.getResources().getColor(this.iconActiveColor));
+					icon.setTint(ResourceUtils.getColor(context, this.iconActiveColor));
 					icon.setAlpha(255);
 				} else {
-					icon.setTint(context.getResources().getColor(this.iconColor));
+					icon.setTint(ResourceUtils.getColor(context, this.iconColor));
 					icon.setAlpha(128);
 				}
 				iconView.setImageDrawable(icon);
@@ -124,9 +125,9 @@ public class PageMenuAdapter extends BaseAdapter {
 
 			titleView.setText(pageMenuItem.getTitle());
 			if (pageMenuItem.isActive()) {
-				titleView.setTextColor(context.getResources().getColor(this.titleActiveColor));
+				titleView.setTextColor(ResourceUtils.getColor(context, this.titleActiveColor));
 			} else {
-				titleView.setTextColor(context.getResources().getColor(this.titleColor));
+				titleView.setTextColor(ResourceUtils.getColor(context, this.titleColor));
 			}
 		}
 

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/component/menu/PageMenuControl.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/component/menu/PageMenuControl.java
@@ -38,12 +38,12 @@ import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.ScrollView;
 
-import androidx.core.content.ContextCompat;
 import androidx.percentlayout.widget.PercentFrameLayout;
 
 import de.symeda.sormas.app.R;
 import de.symeda.sormas.app.core.OnSwipeTouchListener;
 import de.symeda.sormas.app.util.Consumer;
+import de.symeda.sormas.app.util.ResourceUtils;
 
 public class PageMenuControl extends LinearLayout {
 
@@ -461,12 +461,12 @@ public class PageMenuControl extends LinearLayout {
 
 	private void updateFabDrawable() {
 		if (isVisible()) {
-			Drawable drw = ContextCompat.getDrawable(fab.getContext(), R.drawable.ic_landing_menu_close_black_24dp);
-			drw.setTint(fab.getContext().getResources().getColor(R.color.fabIcon));
+			Drawable drw = ResourceUtils.getDrawable(fab.getContext(), R.drawable.ic_landing_menu_close_black_24dp);
+			drw.setTint(ResourceUtils.getColor(fab.getContext(), R.color.fabIcon));
 			fab.setImageDrawable(drw);
 		} else {
-			Drawable drw = ContextCompat.getDrawable(fab.getContext(), R.drawable.ic_landing_menu_open_black_24dp);
-			drw.setTint(fab.getContext().getResources().getColor(R.color.fabIcon));
+			Drawable drw = ResourceUtils.getDrawable(fab.getContext(), R.drawable.ic_landing_menu_open_black_24dp);
+			drw.setTint(ResourceUtils.getColor(fab.getContext(), R.color.fabIcon));
 			fab.setImageDrawable(drw);
 		}
 	}

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/component/visualization/SummaryCircularProgressBinder.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/component/visualization/SummaryCircularProgressBinder.java
@@ -25,12 +25,14 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
 import de.symeda.sormas.app.R;
 import de.symeda.sormas.app.component.visualization.data.SummaryCircularData;
 import de.symeda.sormas.app.core.adapter.multiview.DataBinder;
 import de.symeda.sormas.app.core.adapter.multiview.RecyclerViewDataBinderAdapter;
+import de.symeda.sormas.app.util.ResourceUtils;
 
 /**
  * Created by Orson on 27/11/2017.
@@ -53,7 +55,7 @@ public class SummaryCircularProgressBinder extends DataBinder<SummaryCircularPro
 	}
 
 	@Override
-	public SummaryCircularProgressBinder.ViewHolder createViewHolder(ViewGroup parent) {
+	public SummaryCircularProgressBinder.ViewHolder createViewHolder(@NonNull ViewGroup parent) {
 		View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.summary_circular_progress_layout, parent, false);
 		return new SummaryCircularProgressBinder.ViewHolder(view);
 	}
@@ -61,14 +63,14 @@ public class SummaryCircularProgressBinder extends DataBinder<SummaryCircularPro
 	@Override
 	public void bindToViewHolder(SummaryCircularProgressBinder.ViewHolder holder, int position) {
 		if (position == PositionHelper.REMOVED_TASKS)
-			holder.layout.setBackground(this.getContext().getResources().getDrawable(R.drawable.background_summary_cell_last));
+			holder.layout.setBackground(ResourceUtils.getDrawable(getContext(), R.drawable.background_summary_cell_last));
 
 		double percentage = data.get(position).getPercentage();
 
 		holder.circularProgress.setDonut_progress(String.valueOf(Math.round(percentage)));
 		holder.circularProgress.setShowText(false);
-		holder.circularProgress.setUnfinishedStrokeColor(getContext().getResources().getColor(data.get(position).getUnfinishedColor()));
-		holder.circularProgress.setFinishedStrokeColor(getContext().getResources().getColor(data.get(position).getFinishedColor()));
+		holder.circularProgress.setUnfinishedStrokeColor(ResourceUtils.getColor(getContext(), data.get(position).getUnfinishedColor()));
+		holder.circularProgress.setFinishedStrokeColor(ResourceUtils.getColor(getContext(), data.get(position).getFinishedColor()));
 		holder.txtTitle.setText(data.get(position).getTitle());
 		holder.txtValue.setText(String.valueOf((int) Math.round(data.get(position).getValue())));
 		holder.txtPercentage.setText(String.valueOf(percentage) + "%");

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/contact/list/ContactListAdapter.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/contact/list/ContactListAdapter.java
@@ -22,7 +22,6 @@ import android.view.View;
 import android.widget.ImageView;
 
 import androidx.annotation.NonNull;
-import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.RecyclerView;
 
 import de.symeda.sormas.api.contact.FollowUpStatus;
@@ -36,6 +35,7 @@ import de.symeda.sormas.app.core.enumeration.StatusElaborator;
 import de.symeda.sormas.app.core.enumeration.StatusElaboratorFactory;
 import de.symeda.sormas.app.databinding.RowReadContactListItemLayoutBinding;
 import de.symeda.sormas.app.util.DiseaseConfigurationCache;
+import de.symeda.sormas.app.util.ResourceUtils;
 
 public class ContactListAdapter extends BindingPagedListAdapter<Contact, RowReadContactListItemLayoutBinding> {
 
@@ -102,11 +102,11 @@ public class ContactListAdapter extends BindingPagedListAdapter<Contact, RowRead
 //        }
 //    }
 
-	public void indicateContactClassification(ImageView img, Contact record) {
-		Resources resources = img.getContext().getResources();
-		Drawable drw = ContextCompat.getDrawable(img.getContext(), R.drawable.indicator_status_circle);
+	public void indicateContactClassification(@NonNull ImageView img, @NonNull Contact record) {
+		Drawable drw = ResourceUtils.getDrawable(img.getContext(), R.drawable.indicator_status_circle);
+		assert drw != null;
 		StatusElaborator elaborator = StatusElaboratorFactory.getElaborator(record.getContactClassification());
-		drw.setColorFilter(resources.getColor(elaborator.getColorIndicatorResource()), PorterDuff.Mode.SRC_OVER);
+		drw.setColorFilter(ResourceUtils.getColor(img.getContext(), elaborator.getColorIndicatorResource()), PorterDuff.Mode.SRC_OVER);
 		img.setBackground(drw);
 	}
 

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/dashboard/task/TaskSummaryFragment.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/dashboard/task/TaskSummaryFragment.java
@@ -17,6 +17,7 @@ package de.symeda.sormas.app.dashboard.task;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Random;
 
 import android.os.Bundle;
@@ -183,11 +184,11 @@ public class TaskSummaryFragment extends BaseSummaryFragment<ViewTypeHelper.View
 																		.setPercentage(PercentageUtils.percentageOf(entry.getValue(), valueList)));
 
 																if (i == 0) {
-																	item.addColor(getContext().getResources().getColor(R.color.normalPriority));
+																	item.addColor(ResourceUtils.getColor(requireContext(), R.color.normalPriority));
 																} else if (i == 1) {
-																	item.addColor(getContext().getResources().getColor(R.color.lowPriority));
+																	item.addColor(ResourceUtils.getColor(requireContext(), R.color.lowPriority));
 																} else {
-																	item.addColor(getContext().getResources().getColor(R.color.highPriority));
+																	item.addColor(ResourceUtils.getColor(requireContext(), R.color.highPriority));
 																}
 
 																i = i + 1;

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/event/list/EventListAdapter.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/event/list/EventListAdapter.java
@@ -22,7 +22,6 @@ import android.view.View;
 import android.widget.ImageView;
 
 import androidx.annotation.NonNull;
-import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.RecyclerView;
 
 import de.symeda.sormas.app.R;
@@ -30,6 +29,7 @@ import de.symeda.sormas.app.backend.event.Event;
 import de.symeda.sormas.app.core.adapter.databinding.BindingPagedListAdapter;
 import de.symeda.sormas.app.core.adapter.databinding.BindingViewHolder;
 import de.symeda.sormas.app.databinding.RowEventListItemLayoutBinding;
+import de.symeda.sormas.app.util.ResourceUtils;
 
 public class EventListAdapter extends BindingPagedListAdapter<Event, RowEventListItemLayoutBinding> {
 
@@ -74,20 +74,20 @@ public class EventListAdapter extends BindingPagedListAdapter<Event, RowEventLis
 //        }
 //    }
 
-	public void indicateEventStatus(ImageView imgEventStatusIcon, Event eventRecord) {
-		Resources resources = imgEventStatusIcon.getContext().getResources();
-		Drawable drw = ContextCompat.getDrawable(imgEventStatusIcon.getContext(), R.drawable.indicator_status_circle);
+	public void indicateEventStatus(@NonNull ImageView imgEventStatusIcon, @NonNull Event eventRecord) {
+		Drawable drw = ResourceUtils.getDrawable(imgEventStatusIcon.getContext(), R.drawable.indicator_status_circle);
+		assert drw != null;
 		switch (eventRecord.getEventStatus()) {
 		case SIGNAL:
-			drw.setColorFilter(resources.getColor(R.color.indicatorSignal), PorterDuff.Mode.SRC_OVER);
+			drw.setColorFilter(ResourceUtils.getColor(imgEventStatusIcon.getContext(), R.color.indicatorSignal), PorterDuff.Mode.SRC_OVER);
 			break;
 		case EVENT:
 		case CLUSTER:
 		case SCREENING:
-			drw.setColorFilter(resources.getColor(R.color.indicatorEvent), PorterDuff.Mode.SRC_OVER);
+			drw.setColorFilter(ResourceUtils.getColor(imgEventStatusIcon.getContext(), R.color.indicatorEvent), PorterDuff.Mode.SRC_OVER);
 			break;
 		case DROPPED:
-			drw.setColorFilter(resources.getColor(R.color.indicatorDroppedEvent), PorterDuff.Mode.SRC_OVER);
+			drw.setColorFilter(ResourceUtils.getColor(imgEventStatusIcon.getContext(), R.color.indicatorDroppedEvent), PorterDuff.Mode.SRC_OVER);
 			break;
 		}
 

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/task/landing/SummaryPieChartWithLegendBinder.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/task/landing/SummaryPieChartWithLegendBinder.java
@@ -37,6 +37,7 @@ import de.symeda.sormas.app.component.visualization.data.SummaryPieData;
 import de.symeda.sormas.app.component.visualization.data.SummaryPieEntry;
 import de.symeda.sormas.app.core.adapter.multiview.DataBinder;
 import de.symeda.sormas.app.core.adapter.multiview.RecyclerViewDataBinderAdapter;
+import de.symeda.sormas.app.util.ResourceUtils;
 
 /**
  * Created by Orson on 27/11/2017.
@@ -65,7 +66,7 @@ public class SummaryPieChartWithLegendBinder extends DataBinder<SummaryPieChartW
 		List<PieEntry> entries = new ArrayList<PieEntry>();
 
 		if (position == PositionHelper.TASK_PRIORITY)
-			holder.layout.setBackground(this.getContext().getResources().getDrawable(R.drawable.background_summary_cell_last));
+			holder.layout.setBackground(ResourceUtils.getDrawable(getContext(), R.drawable.background_summary_cell_last));
 
 		holder.txtTitle.setText(data.get(position).getTitle());
 

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/task/list/TaskListAdapter.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/task/list/TaskListAdapter.java
@@ -22,7 +22,6 @@ import android.view.View;
 import android.widget.ImageView;
 
 import androidx.annotation.NonNull;
-import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.RecyclerView;
 
 import de.symeda.sormas.api.task.TaskPriority;
@@ -32,6 +31,7 @@ import de.symeda.sormas.app.backend.task.Task;
 import de.symeda.sormas.app.core.adapter.databinding.BindingPagedListAdapter;
 import de.symeda.sormas.app.core.adapter.databinding.BindingViewHolder;
 import de.symeda.sormas.app.databinding.RowTaskListItemLayoutBinding;
+import de.symeda.sormas.app.util.ResourceUtils;
 
 public class TaskListAdapter extends BindingPagedListAdapter<Task, RowTaskListItemLayoutBinding> {
 
@@ -77,31 +77,31 @@ public class TaskListAdapter extends BindingPagedListAdapter<Task, RowTaskListIt
 //        }
 //    }
 
-	public void indicatePriority(ImageView imgTaskPriorityIcon, Task task) {
-		Resources resources = imgTaskPriorityIcon.getContext().getResources();
-		Drawable drw = (Drawable) ContextCompat.getDrawable(imgTaskPriorityIcon.getContext(), R.drawable.indicator_status_circle);
+	public void indicatePriority(@NonNull ImageView imgTaskPriorityIcon, @NonNull Task task) {
+		Drawable drw = (Drawable) ResourceUtils.getDrawable(imgTaskPriorityIcon.getContext(), R.drawable.indicator_status_circle);
+		assert drw != null;
 		if (task.getPriority() == TaskPriority.HIGH) {
-			drw.setColorFilter(resources.getColor(R.color.indicatorTaskPriorityHigh), PorterDuff.Mode.SRC_OVER);
+			drw.setColorFilter(ResourceUtils.getColor(imgTaskPriorityIcon.getContext(), R.color.indicatorTaskPriorityHigh), PorterDuff.Mode.SRC_OVER);
 		} else if (task.getPriority() == TaskPriority.LOW) {
-			drw.setColorFilter(resources.getColor(R.color.indicatorTaskPriorityLow), PorterDuff.Mode.SRC_OVER);
+			drw.setColorFilter(ResourceUtils.getColor(imgTaskPriorityIcon.getContext(), R.color.indicatorTaskPriorityLow), PorterDuff.Mode.SRC_OVER);
 		} else if (task.getPriority() == TaskPriority.NORMAL) {
-			drw.setColorFilter(resources.getColor(R.color.indicatorTaskPriorityNormal), PorterDuff.Mode.SRC_OVER);
+			drw.setColorFilter(ResourceUtils.getColor(imgTaskPriorityIcon.getContext(), R.color.indicatorTaskPriorityNormal), PorterDuff.Mode.SRC_OVER);
 		}
 
 		imgTaskPriorityIcon.setBackground(drw);
 	}
 
-	public void indicateStatus(ImageView imgTaskStatusIcon, Task task) {
-		Resources resources = imgTaskStatusIcon.getContext().getResources();
-		Drawable drw = (Drawable) ContextCompat.getDrawable(imgTaskStatusIcon.getContext(), R.drawable.indicator_status_circle);
+	public void indicateStatus(@NonNull ImageView imgTaskStatusIcon, @NonNull Task task) {
+		Drawable drw = (Drawable) ResourceUtils.getDrawable(imgTaskStatusIcon.getContext(), R.drawable.indicator_status_circle);
+		assert drw != null;
 		if (task.getTaskStatus() == TaskStatus.PENDING) {
-			drw.setColorFilter(resources.getColor(R.color.indicatorTaskPending), PorterDuff.Mode.SRC_OVER);
+			drw.setColorFilter(ResourceUtils.getColor(imgTaskStatusIcon.getContext(), R.color.indicatorTaskPending), PorterDuff.Mode.SRC_OVER);
 		} else if (task.getTaskStatus() == TaskStatus.DONE) {
-			drw.setColorFilter(resources.getColor(R.color.indicatorTaskDone), PorterDuff.Mode.SRC_OVER);
+			drw.setColorFilter(ResourceUtils.getColor(imgTaskStatusIcon.getContext(), R.color.indicatorTaskDone), PorterDuff.Mode.SRC_OVER);
 		} else if (task.getTaskStatus() == TaskStatus.REMOVED) {
-			drw.setColorFilter(resources.getColor(R.color.indicatorTaskRemoved), PorterDuff.Mode.SRC_OVER);
+			drw.setColorFilter(ResourceUtils.getColor(imgTaskStatusIcon.getContext(), R.color.indicatorTaskRemoved), PorterDuff.Mode.SRC_OVER);
 		} else if (task.getTaskStatus() == TaskStatus.NOT_EXECUTABLE) {
-			drw.setColorFilter(resources.getColor(R.color.indicatorTaskNotExecutable), PorterDuff.Mode.SRC_OVER);
+			drw.setColorFilter(ResourceUtils.getColor(imgTaskStatusIcon.getContext(), R.color.indicatorTaskNotExecutable), PorterDuff.Mode.SRC_OVER);
 		}
 
 		imgTaskStatusIcon.setBackground(drw);

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/util/FormBindingAdapters.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/util/FormBindingAdapters.java
@@ -26,7 +26,7 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 
-import androidx.core.content.ContextCompat;
+import androidx.annotation.NonNull;
 import androidx.databinding.BindingAdapter;
 
 import de.symeda.sormas.api.sample.PathogenTestResultType;
@@ -52,8 +52,8 @@ public class FormBindingAdapters {
 			PathogenTestResultTypeElaborator elaborator = (PathogenTestResultTypeElaborator) StatusElaboratorFactory.getElaborator(resultType);
 
 			int iconResource = elaborator.getIconResourceId();
-			Drawable drawable = ContextCompat.getDrawable(context, iconResource).mutate();
-			drawable.setTint(context.getResources().getColor(elaborator.getColorIndicatorResource()));
+			Drawable drawable = ResourceUtils.getDrawable(context, iconResource).mutate();
+			drawable.setTint(ResourceUtils.getColor(context, elaborator.getColorIndicatorResource()));
 			imageView.setBackground(drawable);
 		}
 	}
@@ -74,7 +74,7 @@ public class FormBindingAdapters {
 			}
 			val = caze.toString() + location;
 
-			if (valueFormat != null && valueFormat.trim() != "") {
+			if (valueFormat != null && !valueFormat.trim().equals("")) {
 				control.setValue(String.format(valueFormat, val));
 			} else {
 				control.setValue(val);
@@ -122,7 +122,7 @@ public class FormBindingAdapters {
 			}
 			val = event.toString() + location;
 
-			if (valueFormat != null && valueFormat.trim() != "") {
+			if (valueFormat != null && !valueFormat.trim().equals("")) {
 				control.setValue(String.format(valueFormat, val));
 			} else {
 				control.setValue(val);
@@ -185,10 +185,10 @@ public class FormBindingAdapters {
 		"emptyBottomMargin",
 		"nonEmptyBottomMargin" }, requireAll = true)
 	public static <T> void setAlternateBottomMarginIfEmpty(
-		RelativeLayout viewGroup,
-		List<T> list,
-		float emptyBottomMargin,
-		float nonEmptyBottomMargin) {
+			@NonNull RelativeLayout viewGroup,
+			List<T> list,
+			float emptyBottomMargin,
+			float nonEmptyBottomMargin) {
 		LinearLayout.LayoutParams params = (LinearLayout.LayoutParams) viewGroup.getLayoutParams();
 
 		if (list == null || list.size() <= 0) {
@@ -212,7 +212,7 @@ public class FormBindingAdapters {
 		} else {
 			val = location.toString();
 
-			if (valueFormat != null && valueFormat.trim() != "") {
+			if (valueFormat != null && !valueFormat.trim().equals("")) {
 				textField.setValue(String.format(valueFormat, val));
 			} else {
 				textField.setValue(val);

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/util/ResourceUtils.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/util/ResourceUtils.java
@@ -19,53 +19,65 @@ import android.content.Context;
 import android.content.res.Configuration;
 import android.graphics.drawable.Drawable;
 
+import androidx.annotation.BoolRes;
+import androidx.annotation.ColorInt;
+import androidx.annotation.ColorRes;
+import androidx.annotation.DimenRes;
+import androidx.annotation.DrawableRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
+import androidx.core.content.ContextCompat;
+
 /**
  * Created by Orson on 01/12/2017.
  */
 
 public class ResourceUtils {
 
-	public static String getString(Context context, int resourceId) {
+	public static String getString(@NonNull Context context, @StringRes int resourceId) {
 		return context.getResources().getString(resourceId);
 	}
 
-	public static int getColor(Context context, int resourceId) {
-		return context.getResources().getColor(resourceId);
+	@ColorInt
+	public static int getColor(@NonNull Context context, @ColorRes int resourceId) {
+		return ContextCompat.getColor(context, resourceId);
 	}
 
-	public static Drawable getDrawable(Context context, int resourceId) {
-		return context.getResources().getDrawable(resourceId);
+	@Nullable
+	public static Drawable getDrawable(@NonNull Context context, @DrawableRes int resourceId) {
+		return ContextCompat.getDrawable(context, resourceId);
 	}
 
-	public static float getDimension(Context context, int resourceId) {
+	public static float getDimension(@NonNull Context context, @DimenRes int resourceId) {
 		return context.getResources().getDimension(resourceId);
 	}
 
-	public static String[] getStringArray(Context context, int resourceId) {
+	public static String[] getStringArray(@NonNull Context context, int resourceId) {
 		return context.getResources().getStringArray(resourceId);
 	}
 
-	public static int[] getIntArray(Context context, int resourceId) {
+	public static int[] getIntArray(@NonNull Context context, int resourceId) {
 		return context.getResources().getIntArray(resourceId);
 	}
 
-	public static boolean getBoolean(Context context, int resourceId) {
+	public static boolean getBoolean(@NonNull Context context, @BoolRes int resourceId) {
 		return context.getResources().getBoolean(resourceId);
 	}
 
-	public static int getIdentifier(Context context, String name, String defType, String defPackage) {
+	public static int getIdentifier(@NonNull Context context, String name, String defType, String defPackage) {
 		return context.getResources().getIdentifier(name, defType, defPackage);
 	}
 
-	public static float getFraction(Context context, int resourceId, int base, int pbase) {
+	public static float getFraction(@NonNull Context context, int resourceId, int base, int pbase) {
 		return context.getResources().getFraction(resourceId, base, pbase);
 	}
 
-	public static int getInteger(Context context, int resourceId) {
+	public static int getInteger(@NonNull Context context, int resourceId) {
 		return context.getResources().getInteger(resourceId);
 	}
 
-	public static Configuration getConfiguration(Context context) {
+	public static Configuration getConfiguration(@NonNull Context context) {
 		return context.getResources().getConfiguration();
 	}
 }

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/util/TextViewBindingAdapters.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/util/TextViewBindingAdapters.java
@@ -26,6 +26,7 @@ import android.text.Html;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
 import androidx.databinding.BindingAdapter;
 import androidx.databinding.ObservableList;
 
@@ -143,7 +144,7 @@ public class TextViewBindingAdapters {
 
 	@BindingAdapter(value = {
 		"htmlValue" })
-	public static void setHtmlValue(TextView view, String value) {
+	public static void setHtmlValue(@NonNull TextView view, String value) {
 		view.setText(!StringUtils.isBlank(value) ? Html.fromHtml(value) : "");
 	}
 
@@ -189,7 +190,7 @@ public class TextViewBindingAdapters {
 		"ageDateValue",
 		"valueCaption",
 		"defaultValue" })
-	public static void setAgeDateValueWithCaption(TextView view, Person person, String valueCaption, String defaultValue) {
+	public static void setAgeDateValueWithCaption(TextView view, @NonNull Person person, String valueCaption, String defaultValue) {
 		setValueWithCaption(
 			view,
 			DateFormatHelper.getAgeAndBirthdateString(
@@ -359,7 +360,7 @@ public class TextViewBindingAdapters {
 			val = stringValue;
 			//textField.setText(val);
 
-			if (valueFormat != null && valueFormat.trim() != "") {
+			if (valueFormat != null && !valueFormat.trim().equals("")) {
 				textField.setText(String.format(valueFormat, stringValue, append1, append2));
 			} else {
 				textField.setText(val);
@@ -736,7 +737,7 @@ public class TextViewBindingAdapters {
 
 			Integer dueDateColor = null;
 			if (task.getDueDate().compareTo(new Date()) <= 0 && !TaskStatus.DONE.equals(task.getTaskStatus())) {
-				dueDateColor = textField.getContext().getResources().getColor(R.color.watchOut);
+				dueDateColor = ResourceUtils.getColor(textField.getContext(), R.color.watchOut);
 				textField.setTypeface(textField.getTypeface(), Typeface.BOLD);
 				textField.setTextColor(dueDateColor);
 			}
@@ -766,7 +767,7 @@ public class TextViewBindingAdapters {
 			Integer dueDateColor = null;
 			TaskStatus kkk = task.getTaskStatus();
 			if (task.getDueDate().compareTo(new Date()) <= 0 && !TaskStatus.DONE.equals(task.getTaskStatus())) {
-				dueDateColor = textField.getContext().getResources().getColor(R.color.watchOut);
+				dueDateColor = ResourceUtils.getColor(textField.getContext(), R.color.watchOut);
 				//textField.setTypeface(textField.getTypeface(), Typeface.BOLD);
 				textField.setTextColor(dueDateColor);
 			} else {
@@ -1000,7 +1001,7 @@ public class TextViewBindingAdapters {
 		"facilityDetailsValue",
 		"prependValue",
 		"valueFormat" })
-	public static void setFacilityValue(TextView textField, Facility facility, String facilityDetails, String prependValue, String valueFormat) {
+	public static void setFacilityValue(TextView textField, @NonNull Facility facility, String facilityDetails, String prependValue, String valueFormat) {
 		String value;
 		if (FacilityHelper.isOtherOrNoneHealthFacility(facility.getUuid())) {
 			value = facility.getName() + " (" + facilityDetails + ")";
@@ -1051,7 +1052,7 @@ public class TextViewBindingAdapters {
 	@BindingAdapter(value = {
 		"removeBottomMarginIfEmpty",
 		"bottomMargin" })
-	public static void setRemoveBottomMarginIfEmpty(LinearLayout viewGroup, ObservableList list, float bottomMargin) {
+	public static void setRemoveBottomMarginIfEmpty(@NonNull LinearLayout viewGroup, ObservableList list, float bottomMargin) {
 		LinearLayout.LayoutParams params = (LinearLayout.LayoutParams) viewGroup.getLayoutParams();
 
 		if (list == null || list.size() <= 0) {
@@ -1064,7 +1065,7 @@ public class TextViewBindingAdapters {
 	}
 
 	@BindingAdapter("hasValue")
-	public static void setHasValue(TextView textView, ObservableList list) {
+	public static void setHasValue(@NonNull TextView textView, ObservableList list) {
 		Resources resources = textView.getContext().getResources();
 
 		String yes = resources.getString(R.string.yes);
@@ -1083,11 +1084,11 @@ public class TextViewBindingAdapters {
 			Context context = textView.getContext();
 			PathogenTestResultTypeElaborator elaborator = (PathogenTestResultTypeElaborator) StatusElaboratorFactory.getElaborator(resultType);
 			textView.setText(resultType.name());
-			textView.setTextColor(context.getResources().getColor(elaborator.getColorIndicatorResource()));
+			textView.setTextColor(ResourceUtils.getColor(context, elaborator.getColorIndicatorResource()));
 		}
 	}
 
-	private static String getDisease(Task record) {
+	private static String getDisease(@NonNull Task record) {
 		if (record.getCaze() != null && record.getCaze().getDisease() != null) {
 			return record.getCaze().getDisease().toShortString();
 		} else if (record.getContact() != null && record.getContact().getDisease() != null) {
@@ -1119,7 +1120,7 @@ public class TextViewBindingAdapters {
 		return record.getDisease().toShortString();
 	}
 
-	private static String getDisease(Sample sample) {
+	private static String getDisease(@NonNull Sample sample) {
 		String result = "";
 		Case assocCase = sample.getAssociatedCase();
 
@@ -1140,7 +1141,8 @@ public class TextViewBindingAdapters {
 		return result;
 	}
 
-	private static String getPersonInfo(Sample sample) {
+	@NonNull
+	private static String getPersonInfo(@NonNull Sample sample) {
 		String result = "";
 		Case assocCase = sample.getAssociatedCase();
 
@@ -1155,7 +1157,7 @@ public class TextViewBindingAdapters {
 		return person.toString();
 	}
 
-	private static String getPersonInfo(Task record) {
+	private static String getPersonInfo(@NonNull Task record) {
 		String result = null;
 
 		if (record.getCaze() != null) {

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/util/ViewHelper.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/util/ViewHelper.java
@@ -22,6 +22,8 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+
 import de.symeda.sormas.api.i18n.Captions;
 import de.symeda.sormas.api.i18n.I18nProperties;
 import de.symeda.sormas.app.R;
@@ -32,7 +34,8 @@ import de.symeda.sormas.app.R;
 
 public class ViewHelper {
 
-	public static ArrayList<View> getViewsByTag(ViewGroup root, String tag) {
+	@NonNull
+	public static ArrayList<View> getViewsByTag(@NonNull ViewGroup root, String tag) {
 		ArrayList<View> views = new ArrayList<View>();
 		final int childCount = root.getChildCount();
 		for (int i = 0; i < childCount; i++) {
@@ -55,14 +58,14 @@ public class ViewHelper {
 		return views;
 	}
 
-	public static void formatInaccessibleTextView(TextView textField) {
+	public static void formatInaccessibleTextView(@NonNull TextView textField) {
 		textField.setText(I18nProperties.getCaption(Captions.inaccessibleValue));
-		textField.setTextColor(textField.getContext().getResources().getColor(R.color.disabled));
+		textField.setTextColor(ResourceUtils.getColor(textField.getContext(),R.color.disabled));
 		textField.setTypeface(null, Typeface.ITALIC);
 	}
 
-	public static void removeInaccessibleTextViewFormat(TextView textField) {
-		textField.setTextColor(textField.getContext().getResources().getColor(R.color.listActivityRowPrimaryText));
+	public static void removeInaccessibleTextViewFormat(@NonNull TextView textField) {
+		textField.setTextColor(ResourceUtils.getColor(textField.getContext(), R.color.listActivityRowPrimaryText));
 		textField.setTypeface(null, Typeface.NORMAL);
 	}
 }

--- a/sormas-app/build.gradle
+++ b/sormas-app/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.3'
@@ -21,8 +21,8 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
         mavenLocal()
+        mavenCentral()
         flatDir {
             dirs 'libs'
         }


### PR DESCRIPTION
This PR fixes deprecated calls to getResources().getColor and getResourses.getDrawable in ResourceUtils and uses ResourceUtils if possible. ContextCompat.getColor is also replaced by ResourceUtils.getColor


Fixes #7103 