### PR TITLE
#5144 Fix sormas rest deploy inconsistency

### DIFF
--- a/sormas-rest/src/main/java/de/symeda/sormas/rest/security/KeycloakFilter.java
+++ b/sormas-rest/src/main/java/de/symeda/sormas/rest/security/KeycloakFilter.java
@@ -1,6 +1,6 @@
 /*
  * SORMAS® - Surveillance Outbreak Response Management & Analysis System
- * Copyright © 2016-2020 Helmholtz-Zentrum für Infektionsforschung GmbH (HZI)
+ * Copyright © 2016-2021 Helmholtz-Zentrum für Infektionsforschung GmbH (HZI)
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -14,24 +14,20 @@
  */
 package de.symeda.sormas.rest.security;
 
-import de.symeda.sormas.api.AuthProvider;
-import de.symeda.sormas.api.FacadeProvider;
-import de.symeda.sormas.api.sormastosormas.SormasToSormasApiConstants;
-import de.symeda.sormas.rest.security.config.KeycloakConfigResolver;
-import org.keycloak.adapters.servlet.KeycloakOIDCFilter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.io.IOException;
+import java.net.URL;
 
 import javax.inject.Inject;
 import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
-import javax.servlet.annotation.WebFilter;
 import javax.servlet.http.HttpServletRequest;
-import java.io.IOException;
-import java.net.URL;
+
+import org.keycloak.adapters.servlet.KeycloakOIDCFilter;
+
+import de.symeda.sormas.api.sormastosormas.SormasToSormasApiConstants;
+import de.symeda.sormas.rest.security.config.KeycloakConfigResolver;
 
 /**
  * Filter which takes care of validating the Authorization header based on the configuration provided by {@link KeycloakConfigResolver}.
@@ -40,12 +36,7 @@ import java.net.URL;
  * @see KeycloakConfigResolver
  * @since 07-Aug-20
  */
-@WebFilter(asyncSupported = true, urlPatterns = "/*")
 public class KeycloakFilter extends KeycloakOIDCFilter {
-
-	private final Logger logger = LoggerFactory.getLogger(getClass());
-
-	private boolean enabled = false;
 
 	@Inject
 	private KeycloakFilter(KeycloakConfigResolver keycloakConfigResolver) {
@@ -53,41 +44,23 @@ public class KeycloakFilter extends KeycloakOIDCFilter {
 	}
 
 	@Override
-	public void init(FilterConfig filterConfig) throws ServletException {
-		try {
-			String authenticationProvider = FacadeProvider.getConfigFacade().getAuthenticationProvider();
-			enabled = authenticationProvider.equalsIgnoreCase(AuthProvider.KEYCLOAK);
-		} catch (Exception e) {
-			logger.warn("Cannot determine authentication provider from settings. {}", e.getMessage());
-			throw new ServletException(e);
-		}
-		if (enabled) {
-			super.init(filterConfig);
-		}
-	}
-
-	@Override
 	public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException, ServletException {
-		if (enabled) {
-			boolean s2sRequest = false;
-			if (req instanceof HttpServletRequest) {
-				final String urlString = ((HttpServletRequest) req).getRequestURL().toString();
-				final URL url = new URL(urlString);
-				// S2S auth will be handled by S2SAuthFilter
-				String s2sResourcePath = SormasToSormasApiConstants.SORMAS_REST_PATH + SormasToSormasApiConstants.RESOURCE_PATH;
-				if (url.getPath().startsWith(s2sResourcePath)) {
-					s2sRequest = true;
-				}
+		boolean s2sRequest = false;
+		if (req instanceof HttpServletRequest) {
+			final String urlString = ((HttpServletRequest) req).getRequestURL().toString();
+			final URL url = new URL(urlString);
+			// S2S auth will be handled by S2SAuthFilter
+			String s2sResourcePath = SormasToSormasApiConstants.SORMAS_REST_PATH + SormasToSormasApiConstants.RESOURCE_PATH;
+			if (url.getPath().startsWith(s2sResourcePath)) {
+				s2sRequest = true;
 			}
-			// if we received an S2S request we skip the local Keycloak auth and
-			// resort to central Keycloak via S2SAuthFilter later on
-			if (s2sRequest) {
-				chain.doFilter(req, res);
-			} else {
-				super.doFilter(req, res, chain);
-			}
-		} else {
+		}
+		// if we received an S2S request we skip the local Keycloak auth and
+		// resort to central Keycloak via S2SAuthFilter later on
+		if (s2sRequest) {
 			chain.doFilter(req, res);
+		} else {
+			super.doFilter(req, res, chain);
 		}
 	}
 }


### PR DESCRIPTION
With this change the `sormas-rest` artifact cannot be deployed without having the `sormas-ear` deployed first.
I chose this instead of falling back to the legacy login because that might introduce more uncertainty that simply failing with an error message.


Fixes #5144