### PR TITLE
#7131-fix-flaky-UI-tests

### DIFF
--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/helpers/WebDriverHelpers.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/helpers/WebDriverHelpers.java
@@ -220,7 +220,8 @@ public class WebDriverHelpers {
             .getDriver()
             .findElement(selector)
             .findElement(By.xpath("preceding-sibling::input"));
-    comboboxInput.sendKeys(Keys.chord(Keys.BACK_SPACE));
+    // TODO check in Jenkins if this is a fix for flaky situations when option is selected twice
+    // comboboxInput.sendKeys(Keys.chord(Keys.BACK_SPACE));
     String comboBoxItemWithText =
         "//td[@role='listitem']/span[ contains(text(), '"
             + text
@@ -534,7 +535,12 @@ public class WebDriverHelpers {
 
   public void waitUntilIdentifiedElementIsPresent(final Object selector) {
     if (selector instanceof WebElement) {
-      assertHelpers.assertWithPoll20Second(() -> assertThat(selector).isNotNull());
+      WebElement element = (WebElement) selector;
+      assertHelpers.assertWithPoll20Second(
+          () ->
+              assertWithMessage("Webelement: %s is not displayed within 20s", element)
+                  .that(element.isDisplayed())
+                  .isTrue());
     } else {
       assertHelpers.assertWithPoll20Second(
           () -> assertThat(getNumberOfElements((By) selector) > 0).isTrue());
@@ -624,7 +630,7 @@ public class WebDriverHelpers {
     waitUntilIdentifiedElementIsPresent(header);
     scrollToElement(header);
     String style = getAttributeFromWebElement(header, "style");
-    By selector = By.cssSelector("[style*='" + style.substring(style.length() - 17) + "']");
+    By selector = By.cssSelector("td[style*='" + style.substring(style.length() - 17) + "']");
     waitUntilIdentifiedElementIsPresent(selector);
     return baseSteps.getDriver().findElements(selector).get(rowIndex).getText();
   }

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/cases/CaseLineListingSteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/cases/CaseLineListingSteps.java
@@ -63,7 +63,10 @@ public class CaseLineListingSteps implements En {
 
     When(
         "^I save the new case using line listing feature$",
-        () -> webDriverHelpers.clickOnWebElementBySelector(LINE_LISTING_SAVE_BUTTON));
+        () -> {
+          webDriverHelpers.clickOnWebElementBySelector(LINE_LISTING_SAVE_BUTTON);
+          webDriverHelpers.waitForPageLoadingSpinnerToDisappear(15);
+        });
 
     When(
         "I am checking all data created from Case Line Listing option is saved and displayed",

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/cases/EditContactsSteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/cases/EditContactsSteps.java
@@ -157,22 +157,22 @@ public class EditContactsSteps implements En {
     Then(
         "I check the linked contact information is correctly displayed",
         () -> {
-          String contactId = webDriverHelpers.getValueFromTableRowUsingTheHeader("Contact ID", 1);
+          String contactId = webDriverHelpers.getValueFromTableRowUsingTheHeader("Contact ID", 0);
           String contactDisease =
-              (webDriverHelpers.getValueFromTableRowUsingTheHeader("Disease", 1).equals("COVID-19"))
+              (webDriverHelpers.getValueFromTableRowUsingTheHeader("Disease", 0).equals("COVID-19"))
                   ? "CORONAVIRUS"
                   : "Not expected string!";
           String contactClassification =
               (webDriverHelpers
-                      .getValueFromTableRowUsingTheHeader("Contact classification", 1)
+                      .getValueFromTableRowUsingTheHeader("Contact classification", 0)
                       .equals("Unconfirmed contact"))
                   ? "UNCONFIRMED"
                   : "Not expected string!";
           String firstName =
               webDriverHelpers.getValueFromTableRowUsingTheHeader(
-                  "First name of contact person", 1);
+                  "First name of contact person", 0);
           String lastName =
-              webDriverHelpers.getValueFromTableRowUsingTheHeader("Last name of contact person", 1);
+              webDriverHelpers.getValueFromTableRowUsingTheHeader("Last name of contact person", 0);
 
           softly
               .assertThat(apiState.getCreatedContact().getUuid().substring(0, 6))

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/contacts/CreateNewVisitSteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/contacts/CreateNewVisitSteps.java
@@ -135,6 +135,7 @@ public class CreateNewVisitSteps implements En {
         () -> {
           webDriverHelpers.waitForPageLoaded();
           String uuid = apiState.getCreatedContact().getUuid();
+          webDriverHelpers.waitUntilIdentifiedElementIsPresent(MULTIPLE_OPTIONS_SEARCH_INPUT);
           webDriverHelpers.clearAndFillInWebElement(MULTIPLE_OPTIONS_SEARCH_INPUT, uuid);
           fillDateFrom(followUpVisitService.buildGeneratedFollowUpVisit().getDateOfVisit());
           fillDateTo(followUpVisitService.buildGeneratedFollowUpVisit().getDateOfVisit());

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/contacts/EditContactPersonSteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/contacts/EditContactPersonSteps.java
@@ -26,7 +26,9 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.TextStyle;
 import java.util.Locale;
+import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
+import lombok.SneakyThrows;
 import org.assertj.core.api.SoftAssertions;
 import org.sormas.e2etests.helpers.WebDriverHelpers;
 import org.sormas.e2etests.pojo.web.Person;
@@ -170,8 +172,12 @@ public class EditContactPersonSteps implements En {
     webDriverHelpers.fillInWebElement(EXTERNAL_ID_INPUT, id);
   }
 
+  @SneakyThrows
   private void fillExternalToken(String token) {
     webDriverHelpers.fillInWebElement(EXTERNAL_TOKEN_INPUT, token);
+    // TODO validate if this fix is stable in Jenkins run
+    TimeUnit.SECONDS.sleep(1);
+    webDriverHelpers.waitForPageLoadingSpinnerToDisappear(10);
   }
 
   private void selectTypeOfOccupation(String occupation) {

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/events/EventActionsTableSteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/events/EventActionsTableSteps.java
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javax.inject.Inject;
 import org.apache.commons.lang3.StringUtils;
 import org.assertj.core.api.SoftAssertions;
+import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.sormas.e2etests.helpers.WebDriverHelpers;
 import org.sormas.e2etests.pojo.web.EventActionTableEntry;
@@ -179,7 +180,13 @@ public class EventActionsTableSteps implements En {
 
   private LocalDateTime getLocalDateTimeFromColumns(String date) {
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("M/dd/yyyy h:mm a");
-    return LocalDateTime.parse(date, formatter);
+    try {
+      return LocalDateTime.parse(date, formatter);
+    } catch (Exception e) {
+      throw new WebDriverException(
+          String.format(
+              "Unable to parse date: %s due to caught exception: %s", date, e.getMessage()));
+    }
   }
 
   private String getPartialUuidFromAssociatedLink(String associatedLink) {

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/events/EventDirectorySteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/events/EventDirectorySteps.java
@@ -22,6 +22,7 @@ import static org.sormas.e2etests.pages.application.events.EditEventPage.*;
 import static org.sormas.e2etests.pages.application.events.EventDirectoryPage.*;
 
 import cucumber.api.java8.En;
+import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.sormas.e2etests.helpers.WebDriverHelpers;
@@ -47,8 +48,12 @@ public class EventDirectorySteps implements En {
         "^I check if it appears under ([^\"]*) filter in event directory",
         (String eventStatus) -> {
           final String eventUuid = CreateNewEventSteps.newEvent.getUuid();
+          if (eventStatus.equalsIgnoreCase("Signal") || eventStatus.equalsIgnoreCase("Event")) {
+            System.out.println("a");
+          }
           webDriverHelpers.waitUntilElementIsVisibleAndClickable(getByEventUuid(eventUuid));
           webDriverHelpers.clickWebElementByText(EVENT_STATUS_FILTER_BUTTONS, eventStatus);
+          TimeUnit.SECONDS.sleep(3); // TODO check in Jenkins if is a stable fix
           webDriverHelpers.waitUntilElementIsVisibleAndClickable(EVENT_STATUS_FILTER_BUTTONS);
           webDriverHelpers.clickOnWebElementBySelector(getByEventUuid(eventUuid));
           webDriverHelpers.waitUntilElementIsVisibleAndClickable(EVENT_PARTICIPANTS_TAB);

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/persons/EditPersonSteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/persons/EditPersonSteps.java
@@ -28,6 +28,7 @@ import java.time.format.TextStyle;
 import java.util.Locale;
 import javax.inject.Inject;
 import javax.inject.Named;
+import org.openqa.selenium.ElementClickInterceptedException;
 import org.sormas.e2etests.comparators.PersonComparator;
 import org.sormas.e2etests.helpers.WebDriverHelpers;
 import org.sormas.e2etests.pojo.web.Person;
@@ -140,7 +141,12 @@ public class EditPersonSteps implements En {
   }
 
   private void fillFirstName(String firstName) {
-    webDriverHelpers.clearAndFillInWebElement(FIRST_NAME_INPUT, firstName);
+    try {
+      webDriverHelpers.clearAndFillInWebElement(FIRST_NAME_INPUT, firstName);
+    } catch (ElementClickInterceptedException elementClickInterceptedException) {
+      webDriverHelpers.waitForPageLoadingSpinnerToDisappear(20);
+      webDriverHelpers.clearAndFillInWebElement(FIRST_NAME_INPUT, firstName);
+    }
   }
 
   private void fillLastName(String lastName) {

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/persons/PersonDirectorySteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/persons/PersonDirectorySteps.java
@@ -24,6 +24,7 @@ import static org.sormas.e2etests.pages.application.persons.PersonDirectoryPage.
 
 import cucumber.api.java8.En;
 import javax.inject.Inject;
+import javax.inject.Named;
 import org.openqa.selenium.By;
 import org.sormas.e2etests.helpers.WebDriverHelpers;
 import org.sormas.e2etests.pojo.web.Person;
@@ -35,26 +36,38 @@ public class PersonDirectorySteps implements En {
   protected Person createdPerson;
 
   @Inject
-  public PersonDirectorySteps(WebDriverHelpers webDriverHelpers) {
+  public PersonDirectorySteps(
+      WebDriverHelpers webDriverHelpers, @Named("ENVIRONMENT_URL") String environmentUrl) {
     this.webDriverHelpers = webDriverHelpers;
 
+    /** Avoid using this method until Person's performance is fixed */
     Then(
         "I open the last created person",
         () -> {
-          createdPerson = EditContactPersonSteps.fullyDetailedPerson;
-          String createdPersonUUID = createdPerson.getUuid();
+          String createdPersonUUID = EditContactPersonSteps.fullyDetailedPerson.getUuid();
           webDriverHelpers.waitUntilElementIsVisibleAndClickable(APPLY_FILTERS_BUTTON);
+          webDriverHelpers.clickOnWebElementBySelector(ALL_BUTTON);
+          webDriverHelpers.waitForPageLoadingSpinnerToDisappear(150);
+
           webDriverHelpers.fillInWebElement(MULTIPLE_OPTIONS_SEARCH_INPUT, createdPersonUUID);
           webDriverHelpers.clickOnWebElementBySelector(APPLY_FILTERS_BUTTON);
           By uuidLocator =
               By.cssSelector(String.format(PERSON_RESULTS_UUID_LOCATOR, createdPersonUUID));
-          if (!webDriverHelpers.isElementVisibleWithTimeout(uuidLocator, 20)) {
-            webDriverHelpers.clickOnWebElementBySelector(ALL_BUTTON);
-            webDriverHelpers.waitForPageLoadingSpinnerToDisappear(120);
-          }
+          webDriverHelpers.isElementVisibleWithTimeout(uuidLocator, 150);
           webDriverHelpers.clickOnWebElementBySelector(uuidLocator);
           webDriverHelpers.waitForPageLoadingSpinnerToDisappear(120);
           webDriverHelpers.isElementVisibleWithTimeout(UUID_INPUT, 20);
+        });
+
+    When(
+        "I navigate to the last created Person page via URL",
+        () -> {
+          String createdPersonUUID = EditContactPersonSteps.fullyDetailedPerson.getUuid();
+          String LAST_CREATED_PERSON_PAGE_URL =
+              environmentUrl + "/sormas-ui/#!persons/data/" + createdPersonUUID;
+          webDriverHelpers.accessWebSite(LAST_CREATED_PERSON_PAGE_URL);
+          webDriverHelpers.waitForPageLoaded();
+          webDriverHelpers.waitUntilIdentifiedElementIsVisibleAndClickable(UUID_INPUT, 50);
         });
 
     When(

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/tasks/TaskManagementSteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/tasks/TaskManagementSteps.java
@@ -230,9 +230,11 @@ public class TaskManagementSteps implements En {
   private LocalDateTime getLocalDateTimeFromColumns(String date) {
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("M/d/yyyy h:mm a");
     try {
-      return LocalDateTime.parse(date, formatter);
+      return LocalDateTime.parse(date.trim(), formatter);
     } catch (Exception e) {
-      throw new WebDriverException(String.format("Unable to parse date: %s", date));
+      throw new WebDriverException(
+          String.format(
+              "Unable to parse date: %s due to caught exception: %s", date, e.getMessage()));
     }
   }
 

--- a/sormas-e2e-tests/src/test/resources/features/sanity/web/Persons.feature
+++ b/sormas-e2e-tests/src/test/resources/features/sanity/web/Persons.feature
@@ -11,8 +11,7 @@ Feature: Edit Persons
     When I click on new entry button from Contact Information section
     Then I complete all fields from Person Contact Details popup and save
     Then I click on save button from Contact Person tab
-    And I click on the Persons button from navbar
-    When I open the last created person
+    Then I navigate to the last created Person page via URL
     Then I check that previous created person is correctly displayed in Edit Person page
     And While on Person edit page, I will edit all fields with new values
     And I edit all Person primary contact details and save


### PR DESCRIPTION
1. Added a potentially fix for combobox select where values can be selected twice due to selenium speed.
2. Added logs to investigate Date parsing issue on jenkins
3. Updated Edit person test by changing UI navigation to edited Person with URL navigation, due to environment's performance issues
4. Added fix for Create a new event and change its status multiple times
5. Added logger to investigate time parsing issue for: Add a New action for an Event and verify the Action in EventActions table
6. Added a small fix to check in jenkins for table row data parsing for: Change the source case contact and then delete
7. Added some small fixes for: Edit all fields from Follow-up visits tab
8. Added small fix for Create cases using Line Listing feature and validate the entries to check if is stable in jenkins
