### PR TITLE
#7131-FixFlakyUITests

### DIFF
--- a/sormas-e2e-tests/src/main/java/org/sormas/e2etests/pages/application/events/EventParticipantsPage.java
+++ b/sormas-e2e-tests/src/main/java/org/sormas/e2etests/pages/application/events/EventParticipantsPage.java
@@ -24,6 +24,9 @@ public class EventParticipantsPage {
   public static final By ADD_PARTICIPANT_BUTTON = By.cssSelector("div#eventParticipantAddPerson");
   public static final By PARTICIPANT_FIRST_NAME_INPUT = By.cssSelector(".popupContent #firstName");
   public static final By PARTICIPANT_LAST_NAME_INPUT = By.cssSelector(".popupContent #lastName");
+  public static final By PARTICIPANT_REGION_COMBOBOX = By.cssSelector(".popupContent #region div");
+  public static final By PARTICIPANT_DISTRICT_COMBOBOX =
+      By.cssSelector(".popupContent #district div");
   public static final By SEX_COMBOBOX =
       By.cssSelector(".v-window [location='sex'] [role='combobox'] div");
   public static final By PICK_OR_CREATE_PERSON_POPUP =

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/helpers/WebDriverHelpers.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/helpers/WebDriverHelpers.java
@@ -314,10 +314,10 @@ public class WebDriverHelpers {
                   .that(baseSteps.getDriver().findElement(selector).isDisplayed())
                   .isTrue(),
           seconds);
+      return true;
     } catch (Throwable ignored) {
       return false;
     }
-    return true;
   }
 
   public void clickOnWebElementWhichMayNotBePresent(final By byObject, final int index) {
@@ -375,9 +375,9 @@ public class WebDriverHelpers {
         assertHelpers.assertWithPoll20Second(
             () -> {
               javascriptExecutor.executeScript(SCROLL_TO_WEB_ELEMENT_SCRIPT, selector);
-              assertWithMessage("Element: %s is not displayed", selector)
-                  .that(((WebElement) selector).isDisplayed())
-                  .isTrue();
+                            assertWithMessage("Element: %s is not displayed", selector)
+                                .that(((WebElement) selector).isDisplayed())
+                                .isTrue();
             });
       } else {
         assertHelpers.assertWithPoll20Second(
@@ -665,9 +665,9 @@ public class WebDriverHelpers {
   }
 
   public void waitForPageLoadingSpinnerToDisappear(int maxWaitingTime) {
+    By loadingSpinner =
+        By.xpath("//div[@class='v-loading-indicator third v-loading-indicator-wait']");
     try {
-      By loadingSpinner =
-          By.xpath("//div[@class='v-loading-indicator third v-loading-indicator-wait']");
       if (isElementVisibleWithTimeout(loadingSpinner, 3))
         assertHelpers.assertWithPoll(
             () ->
@@ -675,8 +675,9 @@ public class WebDriverHelpers {
                     .contains("display: none"),
             maxWaitingTime);
     } catch (Throwable ignored) {
-      throw new TimeoutException(
-          String.format("Loading spinner didn't disappeared after %s seconds", maxWaitingTime));
+      if (!getAttributeFromWebElement(loadingSpinner, "style").contains("display: none"))
+        throw new TimeoutException(
+            String.format("Loading spinner didn't disappeared after %s seconds", maxWaitingTime));
     }
   }
 

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/NavBarSteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/NavBarSteps.java
@@ -54,7 +54,6 @@ public class NavBarSteps implements En {
           webDriverHelpers.waitForPageLoaded();
           webDriverHelpers.clickOnWebElementBySelector(NavBarPage.CASES_BUTTON);
           startTime = ZonedDateTime.now().toInstant().toEpochMilli();
-          webDriverHelpers.waitForPageLoadingSpinnerToDisappear(20);
         });
 
     When(
@@ -88,7 +87,6 @@ public class NavBarSteps implements En {
           webDriverHelpers.waitForPageLoaded();
           webDriverHelpers.clickOnWebElementBySelector(NavBarPage.TASKS_BUTTON);
           startTime = ZonedDateTime.now().toInstant().toEpochMilli();
-          webDriverHelpers.waitForPageLoadingSpinnerToDisappear(20);
         });
 
     When(

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/contacts/CreateNewVisitSteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/contacts/CreateNewVisitSteps.java
@@ -139,12 +139,12 @@ public class CreateNewVisitSteps implements En {
           webDriverHelpers.clearAndFillInWebElement(MULTIPLE_OPTIONS_SEARCH_INPUT, uuid);
           fillDateFrom(followUpVisitService.buildGeneratedFollowUpVisit().getDateOfVisit());
           fillDateTo(followUpVisitService.buildGeneratedFollowUpVisit().getDateOfVisit());
-
           webDriverHelpers.clickOnWebElementBySelector(APPLY_FILTERS_BUTTON);
           webDriverHelpers.waitUntilAListOfWebElementsAreNotEmpty(CONTACT_GRID_RESULTS_ROWS);
           softly
               .assertThat(webDriverHelpers.getNumberOfElements(CONTACT_GRID_RESULTS_ROWS))
-              .isEqualTo(1);
+              .isEqualTo(1)
+              .withFailMessage("Contact grid results rows are not equal with 1");
           softly.assertAll();
         });
   }

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/contacts/EditContactPersonSteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/contacts/EditContactPersonSteps.java
@@ -128,10 +128,7 @@ public class EditContactPersonSteps implements En {
         "I click on save button from Contact Person tab",
         () -> {
           webDriverHelpers.clickOnWebElementBySelector(SAVE_BUTTON);
-          webDriverHelpers.waitForPageLoadingSpinnerToDisappear(40);
-          // Workaround created until #5535 is fixed
-          baseSteps.getDriver().navigate().refresh();
-          webDriverHelpers.waitUntilIdentifiedElementIsVisibleAndClickable(UUID_INPUT, 120);
+          webDriverHelpers.waitForPageLoadingSpinnerToDisappear(50);
           Person contactInfo = getPersonInformation();
           fullyDetailedPerson =
               personService.updateExistentPerson(
@@ -176,8 +173,8 @@ public class EditContactPersonSteps implements En {
   private void fillExternalToken(String token) {
     webDriverHelpers.fillInWebElement(EXTERNAL_TOKEN_INPUT, token);
     // TODO validate if this fix is stable in Jenkins run
-    TimeUnit.SECONDS.sleep(1);
-    webDriverHelpers.waitForPageLoadingSpinnerToDisappear(10);
+    TimeUnit.SECONDS.sleep(3);
+    webDriverHelpers.waitForPageLoadingSpinnerToDisappear(15);
   }
 
   private void selectTypeOfOccupation(String occupation) {

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/events/EditEventSteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/events/EditEventSteps.java
@@ -35,7 +35,9 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import javax.inject.Inject;
 import javax.inject.Named;
+import org.sormas.e2etests.enums.DistrictsValues;
 import org.sormas.e2etests.enums.GenderValues;
+import org.sormas.e2etests.enums.RegionsValues;
 import org.sormas.e2etests.helpers.WebDriverHelpers;
 import org.sormas.e2etests.pojo.web.Event;
 import org.sormas.e2etests.pojo.web.EventGroup;
@@ -134,6 +136,10 @@ public class EditEventSteps implements En {
           webDriverHelpers.fillInWebElement(PARTICIPANT_FIRST_NAME_INPUT, faker.name().firstName());
           webDriverHelpers.fillInWebElement(PARTICIPANT_LAST_NAME_INPUT, faker.name().lastName());
           webDriverHelpers.selectFromCombobox(SEX_COMBOBOX, GenderValues.getRandomGender());
+          webDriverHelpers.selectFromCombobox(
+              PARTICIPANT_REGION_COMBOBOX, RegionsValues.VoreingestellteBundeslander.getName());
+          webDriverHelpers.selectFromCombobox(
+              PARTICIPANT_DISTRICT_COMBOBOX, DistrictsValues.VoreingestellterLandkreis.getName());
           webDriverHelpers.clickOnWebElementBySelector(POPUP_SAVE);
           if (webDriverHelpers.isElementVisibleWithTimeout(PICK_OR_CREATE_PERSON_POPUP, 15)) {
             webDriverHelpers.clickOnWebElementBySelector(CREATE_NEW_PERSON_RADIO_BUTTON);

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/persons/EditPersonSteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/persons/EditPersonSteps.java
@@ -113,12 +113,8 @@ public class EditPersonSteps implements En {
     Then(
         "I click on save button from Edit Person page",
         () -> {
-          webDriverHelpers.scrollToElement(SAVE_BUTTON);
           webDriverHelpers.clickOnWebElementBySelector(SAVE_BUTTON);
-          webDriverHelpers.waitForPageLoadingSpinnerToDisappear(100);
-          // Workaround created until #5535 is fixed
-          baseSteps.getDriver().navigate().refresh();
-          webDriverHelpers.waitForPageLoaded();
+          webDriverHelpers.waitForPageLoadingSpinnerToDisappear(150);
           previousCreatedPerson = collectedPerson;
         });
 

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/samples/EditSampleSteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/samples/EditSampleSteps.java
@@ -93,6 +93,7 @@ public class EditSampleSteps implements En {
           fillLabSampleId(editedSample.getLabSampleId());
           fillCommentsOnSample(editedSample.getCommentsOnSample());
           webDriverHelpers.clickOnWebElementBySelector(SAVE_SAMPLE_BUTTON);
+          webDriverHelpers.waitForPageLoadingSpinnerToDisappear(15);
         });
 
     When(

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/users/CreateNewUserSteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/users/CreateNewUserSteps.java
@@ -222,7 +222,7 @@ public class CreateNewUserSteps implements En {
   }
 
   public void closeNewPasswordPopUp() {
-    webDriverHelpers.waitUntilElementIsVisibleAndClickable(CLOSE_DIALOG_BUTTON);
+    webDriverHelpers.waitUntilIdentifiedElementIsVisibleAndClickable(CLOSE_DIALOG_BUTTON, 15);
     webDriverHelpers.clickOnWebElementBySelector(CLOSE_DIALOG_BUTTON);
   }
 

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/users/UserManagementSteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/users/UserManagementSteps.java
@@ -59,10 +59,12 @@ public class UserManagementSteps implements En {
   }
 
   private void searchForUser(String userName) {
+    webDriverHelpers.waitUntilIdentifiedElementIsVisibleAndClickable(SEARCH_USER_INPUT);
     webDriverHelpers.fillAndSubmitInWebElement(SEARCH_USER_INPUT, userName);
   }
 
   private void selectFirstElementFromList() {
+    webDriverHelpers.waitUntilIdentifiedElementIsVisibleAndClickable(FIRST_EDIT_BUTTON_FROM_LIST);
     webDriverHelpers.clickOnWebElementBySelector(FIRST_EDIT_BUTTON_FROM_LIST);
   }
 }


### PR DESCRIPTION
1. Updated wait for loading spinner to disappear in order to fix: Edit a new Sample
2. Added fixes for Create a new user (noticed flaky situations on local execution and jenkins)
3. Updated and fixed test with the latest changes: Add a participant to an event
4. Corrected jenkins failing assert for test Edit all fields from Follow-up visits tab in order to identify why it fails only during jenkins execution