### PR TITLE
cut label overflow in side components #7213

### DIFF
--- a/sormas-ui/src/main/webapp/VAADIN/themes/sormas/components/label.scss
+++ b/sormas-ui/src/main/webapp/VAADIN/themes/sormas/components/label.scss
@@ -174,4 +174,10 @@
 		display: block;
 	}
   }
+
+  .side-component .v-label {
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }


### PR DESCRIPTION
<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #7213

This solution is generic and affects all v-labels in side components, s.screenshot.
![image](https://user-images.githubusercontent.com/5616564/143073007-18896a32-554f-4149-a7a0-9aa44df7e7b2.png)
