### PR TITLE
#7276 Fix person details update when importing contacts or event aparticipants

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/person/PersonFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/person/PersonFacade.java
@@ -1,20 +1,17 @@
-/*******************************************************************************
+/*
  * SORMAS® - Surveillance Outbreak Response Management & Analysis System
- * Copyright © 2016-2018 Helmholtz-Zentrum für Infektionsforschung GmbH (HZI)
- *
+ * Copyright © 2016-2021 Helmholtz-Zentrum für Infektionsforschung GmbH (HZI)
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
- *******************************************************************************/
+ */
 package de.symeda.sormas.api.person;
 
 import java.util.Date;
@@ -100,6 +97,8 @@ public interface PersonFacade {
 	void updateExternalData(@Valid List<ExternalDataDto> externalData) throws ExternalDataUpdateException;
 
 	void mergePerson(PersonDto leadPerson, PersonDto otherPerson);
+
+	void mergePerson(PersonDto leadPerson, PersonDto otherPerson, boolean overrideValues, boolean skipValidation);
 
 	PersonDto getByContext(PersonContext context, String contextUuid);
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonFacadeEjb.java
@@ -1662,8 +1662,13 @@ public class PersonFacadeEjb implements PersonFacade {
 
 	@Override
 	public void mergePerson(PersonDto leadPerson, PersonDto otherPerson) {
+		mergePerson(leadPerson, otherPerson, false, false);
+	}
+
+	@Override
+	public void mergePerson(PersonDto leadPerson, PersonDto otherPerson, boolean overrideValues, boolean skipValidation) {
 		// Make sure the resulting person does not have multiple primary contact details
-		Set primaryContactDetailTypes = new HashSet<>();
+		Set<PersonContactDetailType> primaryContactDetailTypes = new HashSet<>();
 		for (PersonContactDetailDto contactDetailDto : leadPerson.getPersonContactDetails()) {
 			if (contactDetailDto.isPrimaryContact()) {
 				primaryContactDetailTypes.add(contactDetailDto.getPersonContactDetailType());
@@ -1674,8 +1679,8 @@ public class PersonFacadeEjb implements PersonFacade {
 				contactDetailDto.setPrimaryContact(false);
 			}
 		}
-		DtoHelper.copyDtoValues(leadPerson, otherPerson, false);
-		savePerson(leadPerson);
+		DtoHelper.copyDtoValues(leadPerson, otherPerson, overrideValues);
+		savePerson(leadPerson, skipValidation);
 	}
 
 	@Override

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/events/eventparticipantimporter/EventParticipantImporter.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/events/eventparticipantimporter/EventParticipantImporter.java
@@ -159,10 +159,8 @@ public class EventParticipantImporter extends DataImporter {
 			}
 		}
 
-		PersonDto newPerson = newPersonTemp;
-
 		// Sanitize non-HOME address
-		PersonHelper.sanitizeNonHomeAddress(newPerson);
+		PersonHelper.sanitizeNonHomeAddress(newPersonTemp);
 
 		// If the eventparticipant still does not have any import errors, search for persons similar to the eventparticipant person in the database and,
 		// if there are any, display a window to resolve the conflict to the user
@@ -173,14 +171,17 @@ public class EventParticipantImporter extends DataImporter {
 				ImportSimilarityResultOption resultOption = null;
 
 				EventParticipantImportLock personSelectLock = new EventParticipantImportLock();
+
+				String selectedPersonUuid = null;
+
 				// We need to pause the current thread to prevent the import from continuing until the user has acted
 				synchronized (personSelectLock) {
 					// Call the logic that allows the user to handle the similarity; once this has been done, the LOCK should be notified
 					// to allow the importer to resume
 					handlePersonSimilarity(
-						newPerson,
+						newPersonTemp,
 						result -> consumer.onImportResult(result, personSelectLock),
-						(person, similarityResultOption) -> new PersonImportSimilarityResult(person, similarityResultOption),
+						PersonImportSimilarityResult::new,
 						Strings.infoSelectOrCreatePersonForImport,
 						currentUI);
 
@@ -199,32 +200,7 @@ public class EventParticipantImporter extends DataImporter {
 
 					// If the user picked an existing person, override the eventparticipant person with it
 					if (ImportSimilarityResultOption.PICK.equals(resultOption)) {
-						newPerson = personFacade.getPersonByUuid(consumer.result.getMatchingPerson().getUuid());
-
-						// get first eventparticipant for event and person
-						EventParticipantCriteria eventParticipantCriteria =
-							new EventParticipantCriteria().withPerson(newPerson.toReference()).withEvent(event);
-						EventParticipantDto pickedEventParticipant = eventParticipantFacade.getFirst(eventParticipantCriteria);
-
-						if (pickedEventParticipant != null) {
-							// re-apply import on pickedEventParticipant
-							insertRowIntoData(values, entityClasses, entityPropertyPaths, true, importColumnInformation -> {
-								// If the cell entry is not empty, try to insert it into the current contact or person object
-								if (!StringUtils.isEmpty(importColumnInformation.getValue())) {
-									try {
-										insertColumnEntryIntoData(
-											pickedEventParticipant,
-											newPersonTemp,
-											importColumnInformation.getValue(),
-											importColumnInformation.getEntityPropertyPath());
-									} catch (ImportErrorException | InvalidColumnException e) {
-										return e;
-									}
-								}
-								return null;
-							});
-							newEventParticipant = pickedEventParticipant;
-						}
+						selectedPersonUuid = consumer.result.getMatchingPerson().getUuid();
 					}
 				}
 
@@ -233,11 +209,54 @@ public class EventParticipantImporter extends DataImporter {
 				if (ImportSimilarityResultOption.SKIP.equals(resultOption)) {
 					return ImportLineResult.SKIPPED;
 				} else {
-					// Workaround: Reset the change date to avoid OutdatedEntityExceptions
-					newPerson.setChangeDate(new Date());
+
 					boolean skipPersonValidation = ImportSimilarityResultOption.PICK.equals(resultOption);
-					final PersonDto savedPerson = personFacade.savePerson(newPerson, skipPersonValidation);
-					newEventParticipant.setPerson(savedPerson);
+
+
+					PersonDto importPerson = newPersonTemp;
+
+					if (selectedPersonUuid != null) {
+						importPerson = FacadeProvider.getPersonFacade().getPersonByUuid(selectedPersonUuid);
+					}
+
+					// get first eventparticipant for event and person
+					EventParticipantCriteria eventParticipantCriteria =
+							new EventParticipantCriteria().withPerson(importPerson.toReference()).withEvent(event);
+					EventParticipantDto pickedEventParticipant = eventParticipantFacade.getFirst(eventParticipantCriteria);
+
+					if (pickedEventParticipant != null) {
+						// re-apply import on pickedEventParticipant
+						insertRowIntoData(values, entityClasses, entityPropertyPaths, true, importColumnInformation -> {
+							// If the cell entry is not empty, try to insert it into the current contact or person object
+							if (!StringUtils.isEmpty(importColumnInformation.getValue())) {
+								try {
+									insertColumnEntryIntoData(
+											pickedEventParticipant,
+											newPersonTemp,
+											importColumnInformation.getValue(),
+											importColumnInformation.getEntityPropertyPath());
+								} catch (ImportErrorException | InvalidColumnException e) {
+									return e;
+								}
+							}
+							return null;
+						});
+						newEventParticipant = pickedEventParticipant;
+					}
+
+
+
+					PersonDto savedPersonDto;
+					if (selectedPersonUuid != null) {
+						// Workaround: Reset the change date to avoid OutdatedEntityExceptions
+						importPerson.setChangeDate(new Date());
+						FacadeProvider.getPersonFacade().mergePerson(importPerson, newPersonTemp, true, skipPersonValidation);
+						savedPersonDto = importPerson;
+					} else {
+						savedPersonDto = FacadeProvider.getPersonFacade().savePerson(newPersonTemp, skipPersonValidation);
+					}
+
+					newEventParticipant.setPerson(savedPersonDto);
 					newEventParticipant.setChangeDate(new Date());
 					eventParticipantFacade.saveEventParticipant(newEventParticipant);
 

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/events/importer/EventImporter.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/events/importer/EventImporter.java
@@ -1,6 +1,6 @@
-/*******************************************************************************
+/*
  * SORMAS® - Surveillance Outbreak Response Management & Analysis System
- * Copyright © 2016-2018 Helmholtz-Zentrum für Infektionsforschung GmbH (HZI)
+ * Copyright © 2016-2021 Helmholtz-Zentrum für Infektionsforschung GmbH (HZI)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,16 +14,13 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
- *******************************************************************************/
+ */
 package de.symeda.sormas.ui.events.importer;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.function.Consumer;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.opencsv.exceptions.CsvValidationException;
 import com.vaadin.server.Sizeable.Unit;
@@ -32,9 +29,7 @@ import com.vaadin.ui.UI;
 import com.vaadin.ui.Window;
 
 import de.symeda.sormas.api.FacadeProvider;
-import de.symeda.sormas.api.event.EventFacade;
 import de.symeda.sormas.api.event.EventParticipantDto;
-import de.symeda.sormas.api.event.EventParticipantFacade;
 import de.symeda.sormas.api.event.eventimport.EventImportEntities;
 import de.symeda.sormas.api.event.eventimport.EventImportFacade;
 import de.symeda.sormas.api.i18n.I18nProperties;
@@ -42,7 +37,6 @@ import de.symeda.sormas.api.i18n.Strings;
 import de.symeda.sormas.api.importexport.ImportLineResultDto;
 import de.symeda.sormas.api.importexport.ValueSeparator;
 import de.symeda.sormas.api.person.PersonDto;
-import de.symeda.sormas.api.person.PersonFacade;
 import de.symeda.sormas.api.person.SimilarPersonDto;
 import de.symeda.sormas.api.user.UserDto;
 import de.symeda.sormas.ui.importer.DataImporter;
@@ -67,21 +61,13 @@ import de.symeda.sormas.ui.utils.VaadinUiUtil;
  */
 public class EventImporter extends DataImporter {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(EventImporter.class);
-
 	private UI currentUI;
 	private final EventImportFacade eventImportFacade;
-	private final EventFacade eventFacade;
-	private final EventParticipantFacade eventParticipantFacade;
-	private final PersonFacade personFacade;
 
 	public EventImporter(File inputFile, boolean hasEntityClassRow, UserDto currentUser, ValueSeparator csvSeparator) throws IOException {
 		super(inputFile, hasEntityClassRow, currentUser, csvSeparator);
 
 		eventImportFacade = FacadeProvider.getEventImportFacade();
-		eventFacade = FacadeProvider.getEventFacade();
-		eventParticipantFacade = FacadeProvider.getEventParticipantFacade();
-		personFacade = FacadeProvider.getPersonFacade();
 	}
 
 	@Override

--- a/sormas-ui/src/test/java/de/symeda/sormas/ui/event/eventparticipantimporter/EventParticipantImporterTest.java
+++ b/sormas-ui/src/test/java/de/symeda/sormas/ui/event/eventparticipantimporter/EventParticipantImporterTest.java
@@ -177,7 +177,7 @@ public class EventParticipantImporterTest extends AbstractBeanTest {
 		assertEquals(1, eventParticipantFacade.count(new EventParticipantCriteria().withEvent(eventRef)));
 		assertEquals(person.getUuid(), importedEventParticipant.getPersonUuid());
 		assertEquals(person.getFirstName(), importedPerson.getFirstName());
-		assertEquals(person.getLastName(), importedPerson.getLastName());
+		assertEquals("Heinze", importedPerson.getLastName());
 
 		assertEquals(1, getPersonFacade().getAllUuids().size());
 	}


### PR DESCRIPTION
The ticket only reffered to contact person, but I noticed the same issue was present on event participants as well.

Basically if an existing person was picked, the Importers discared the new person details and used only the existing person, so I changed it to merge the new person with the existing person if a person was picked.

Fixes #7276