### PR TITLE
[#7543] ensure proper checkout and pull

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
             mkdir /tmp/openapi
             cp sormas-rest/target/external_visits_API.* /tmp/openapi
             
+            git fetch
             git checkout development
             git pull
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,12 +76,16 @@ jobs:
         run: |
             git config --global user.name "sormas-vitagroup"
             git config --global user.email "support.sormas@helpdesk.symeda.de"
+          
+            mkdir /tmp/openapi
+            cp sormas-rest/target/external_visits_API.* /tmp/openapi
+            
+            git checkout development
+            git pull
 
             rm -rf openapi
-            mkdir openapi/
-            cp sormas-rest/target/external_visits_API.* openapi
+            cp tmp/openapi .
 
             git add openapi
             git commit -m "[GitHub Actions] Update external visits API spec files"
-            git pull --rebase
             git push


### PR DESCRIPTION
Fixes #7543 
Here we go again...

Problem is apparently that the CI checkouts the commit of the branch rather then doing a full checkout with all refs, so updating will not work until everything is in place.