### PR TITLE
[#6470] better S2S errors

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/ValidationHelper.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/ValidationHelper.java
@@ -44,15 +44,15 @@ public class ValidationHelper {
 	}
 
 	public static ValidationErrorGroup buildCaseValidationGroupName(HasUuid caze) {
-		return buildValidationGroupName(Captions.CaseData, caze);
+		return buildValidationGroupName(Captions.CaseData_uuid, caze);
 	}
 
 	public static ValidationErrorGroup buildContactValidationGroupName(HasUuid contact) {
-		return buildValidationGroupName(Captions.Contact, contact);
+		return buildValidationGroupName(Captions.Contact_uuid, contact);
 	}
 
 	public static ValidationErrorGroup buildSampleValidationGroupName(SampleDto sample) {
-		return buildValidationGroupName(Captions.Sample, sample);
+		return buildValidationGroupName(Captions.Sample_uuid, sample);
 	}
 
 	public static ValidationErrorGroup buildPathogenTestValidationGroupName(PathogenTestDto pathogenTest) {
@@ -60,15 +60,15 @@ public class ValidationHelper {
 	}
 
 	public static ValidationErrorGroup buildEventValidationGroupName(HasUuid event) {
-		return buildValidationGroupName(Captions.Event, event);
+		return buildValidationGroupName(Captions.Event_uuid, event);
 	}
 
 	public static ValidationErrorGroup buildEventParticipantValidationGroupName(HasUuid event) {
-		return buildValidationGroupName(Captions.Event, event);
+		return buildValidationGroupName(Captions.EventParticipant_uuid, event);
 	}
 
 	public static ValidationErrorGroup buildImmunizationValidationGroupName(ImmunizationDto immunization) {
-		return buildValidationGroupName(Captions.Immunization, immunization);
+		return buildValidationGroupName(Captions.Immunization_uuid, immunization);
 	}
 
 	public static ValidationErrorGroup buildLabMessageValidationGroupName(LabMessageDto labMessageDto) {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/data/infra/InfrastructureValidator.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/data/infra/InfrastructureValidator.java
@@ -164,9 +164,11 @@ public class InfrastructureValidator {
 		}
 		if (validationDirection == ValidationDirection.INCOMING) {
 			// try to look up the received infrastructure entity locally
-			REF_DTO match = facade.getReferenceByUuid(dto.getUuid());
-			if (match != null) {
-				onNoErrors.accept(match);
+			DTO match = facade.getByUuid(dto.getUuid());
+			if (match != null && match.isCentrallyManaged()) {
+				// todo AbstractBaseEjb::toRefDto is not part of the facade, so we load twice here, this will be fixed in the future
+				REF_DTO matchRef = facade.getReferenceByUuid(dto.getUuid());
+				onNoErrors.accept(matchRef);
 			} else {
 				validationErrors.add(new ValidationErrorGroup(groupNameTag), new ValidationErrorMessage(i18property, dto.getCaption()));
 			}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/SormasToSormasShareable.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/SormasToSormasShareable.java
@@ -17,11 +17,12 @@ package de.symeda.sormas.backend.sormastosormas.entities;
 
 import java.util.List;
 
+import de.symeda.sormas.api.HasUuid;
 import de.symeda.sormas.backend.sormastosormas.origin.SormasToSormasOriginInfo;
 import de.symeda.sormas.backend.sormastosormas.share.shareinfo.SormasToSormasShareInfo;
 import de.symeda.sormas.backend.user.User;
 
-public interface SormasToSormasShareable {
+public interface SormasToSormasShareable extends HasUuid {
 
 	SormasToSormasOriginInfo getSormasToSormasOriginInfo();
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/caze/SormasToSormasCaseDtoValidator.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/caze/SormasToSormasCaseDtoValidator.java
@@ -15,6 +15,8 @@ import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
 import javax.inject.Inject;
 
+import static de.symeda.sormas.backend.sormastosormas.ValidationHelper.buildCaseValidationGroupName;
+
 @Stateless
 @LocalBean
 public class SormasToSormasCaseDtoValidator extends SormasToSormasDtoValidator<CaseDataDto, SormasToSormasCaseDto, SormasToSormasCasePreview> {
@@ -30,7 +32,7 @@ public class SormasToSormasCaseDtoValidator extends SormasToSormasDtoValidator<C
 	@Override
 	public ValidationErrors validate(SormasToSormasCaseDto sharedData, ValidationDirection direction) {
 		CaseDataDto caze = sharedData.getEntity();
-		ValidationErrors validationErrors = new ValidationErrors();
+		ValidationErrors validationErrors = new ValidationErrors(buildCaseValidationGroupName(caze));
 
 		ValidationErrors personValidationErrors = validatePerson(sharedData.getPerson(), direction);
 		validationErrors.addAll(personValidationErrors);
@@ -79,7 +81,7 @@ public class SormasToSormasCaseDtoValidator extends SormasToSormasDtoValidator<C
 
 	@Override
 	public ValidationErrors validatePreview(SormasToSormasCasePreview preview, ValidationDirection direction) {
-		ValidationErrors validationErrors = new ValidationErrors();
+		ValidationErrors validationErrors = new ValidationErrors(buildCaseValidationGroupName(preview));
 		validationErrors.addAll(validatePersonPreview(preview.getPerson(), direction));
 
 		final String groupNameTag = Captions.CaseData;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/contact/SormasToSormasContactDtoValidator.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/contact/SormasToSormasContactDtoValidator.java
@@ -13,6 +13,8 @@ import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
 import javax.inject.Inject;
 
+import static de.symeda.sormas.backend.sormastosormas.ValidationHelper.buildContactValidationGroupName;
+
 @Stateless
 @LocalBean
 public class SormasToSormasContactDtoValidator
@@ -29,7 +31,7 @@ public class SormasToSormasContactDtoValidator
 	@Override
 	public ValidationErrors validate(SormasToSormasContactDto sharedData, ValidationDirection direction) {
 		ContactDto contact = sharedData.getEntity();
-		ValidationErrors validationErrors = new ValidationErrors();
+		ValidationErrors validationErrors = new ValidationErrors(buildContactValidationGroupName(contact));
 
 		ValidationErrors personValidationErrors = validatePerson(sharedData.getPerson(), direction);
 		validationErrors.addAll(personValidationErrors);
@@ -46,7 +48,7 @@ public class SormasToSormasContactDtoValidator
 	}
 
 	public ValidationErrors validatePreview(SormasToSormasContactPreview preview, ValidationDirection direction) {
-		ValidationErrors validationErrors = new ValidationErrors();
+		ValidationErrors validationErrors = new ValidationErrors(buildContactValidationGroupName(preview));
 
 		ValidationErrors personValidationErrors = validatePersonPreview(preview.getPerson(), direction);
 		validationErrors.addAll(personValidationErrors);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/event/SormasToSormasEventDtoValidator.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/event/SormasToSormasEventDtoValidator.java
@@ -13,6 +13,8 @@ import de.symeda.sormas.backend.sormastosormas.data.infra.InfrastructureValidato
 import de.symeda.sormas.backend.sormastosormas.data.validation.SormasToSormasDtoValidator;
 import de.symeda.sormas.backend.sormastosormas.data.validation.ValidationDirection;
 
+import static de.symeda.sormas.backend.sormastosormas.ValidationHelper.buildEventValidationGroupName;
+
 @Stateless
 @LocalBean
 public class SormasToSormasEventDtoValidator extends SormasToSormasDtoValidator<EventDto, SormasToSormasEventDto, SormasToSormasEventPreview> {
@@ -28,7 +30,7 @@ public class SormasToSormasEventDtoValidator extends SormasToSormasDtoValidator<
 	@Override
 	public ValidationErrors validate(SormasToSormasEventDto sharedData, ValidationDirection direction) {
 		EventDto event = sharedData.getEntity();
-		ValidationErrors validationErrors = new ValidationErrors();
+		ValidationErrors validationErrors = new ValidationErrors(buildEventValidationGroupName(event));
 		validateLocation(event.getEventLocation(), Captions.Event, validationErrors, direction);
 
 		return validationErrors;
@@ -36,7 +38,7 @@ public class SormasToSormasEventDtoValidator extends SormasToSormasDtoValidator<
 
 	@Override
 	public ValidationErrors validatePreview(SormasToSormasEventPreview preview, ValidationDirection direction) {
-		ValidationErrors eventValidationErrors = new ValidationErrors();
+		ValidationErrors eventValidationErrors = new ValidationErrors(buildEventValidationGroupName(preview));
 		validateLocation(preview.getEventLocation(), Captions.Event, eventValidationErrors, direction);
 		return eventValidationErrors;
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/eventparticipant/SormasToSormasEventParticipantDtoValidator.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/eventparticipant/SormasToSormasEventParticipantDtoValidator.java
@@ -13,6 +13,8 @@ import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
 import javax.inject.Inject;
 
+import static de.symeda.sormas.backend.sormastosormas.ValidationHelper.buildEventParticipantValidationGroupName;
+
 @Stateless
 @LocalBean
 public class SormasToSormasEventParticipantDtoValidator
@@ -29,7 +31,7 @@ public class SormasToSormasEventParticipantDtoValidator
 	@Override
 	public ValidationErrors validate(SormasToSormasEventParticipantDto sharedData, ValidationDirection direction) {
 		EventParticipantDto ep = sharedData.getEntity();
-		ValidationErrors validationErrors = new ValidationErrors();
+		ValidationErrors validationErrors = new ValidationErrors(buildEventParticipantValidationGroupName(ep));
 
 		ValidationErrors personValidationErrors = validatePerson(ep.getPerson(), direction);
 		validationErrors.addAll(personValidationErrors);
@@ -43,7 +45,8 @@ public class SormasToSormasEventParticipantDtoValidator
 
 	@Override
 	public ValidationErrors validatePreview(SormasToSormasEventParticipantPreview preview, ValidationDirection direction) {
-		return validatePersonPreview(preview.getPerson(), direction);
+		ValidationErrors validationErrors = new ValidationErrors(buildEventParticipantValidationGroupName(preview));
+		validationErrors.addAll(validatePersonPreview(preview.getPerson(), direction));
+		return validationErrors;
 	}
-
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/immunization/SormasToSormasImmunizationDtoValidator.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/immunization/SormasToSormasImmunizationDtoValidator.java
@@ -13,6 +13,8 @@ import de.symeda.sormas.backend.sormastosormas.data.infra.InfrastructureValidato
 import de.symeda.sormas.backend.sormastosormas.data.validation.SormasToSormasDtoValidator;
 import de.symeda.sormas.backend.sormastosormas.data.validation.ValidationDirection;
 
+import static de.symeda.sormas.backend.sormastosormas.ValidationHelper.buildImmunizationValidationGroupName;
+
 @Stateless
 @LocalBean
 public class SormasToSormasImmunizationDtoValidator
@@ -28,9 +30,8 @@ public class SormasToSormasImmunizationDtoValidator
 
 	@Override
 	public ValidationErrors validate(SormasToSormasImmunizationDto sharedData, ValidationDirection direction) {
-
-		ValidationErrors validationErrors = new ValidationErrors();
 		final ImmunizationDto im = sharedData.getEntity();
+		ValidationErrors validationErrors = new ValidationErrors(buildImmunizationValidationGroupName(im));
 
 		final String groupNameTag = Captions.Immunization;
 		infraValidator.validateCountry(im.getCountry(), groupNameTag, validationErrors, im::setCountry, direction);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/labmessage/SormasToSormasLabMessageDtoValidator.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/labmessage/SormasToSormasLabMessageDtoValidator.java
@@ -1,12 +1,11 @@
 package de.symeda.sormas.backend.sormastosormas.entities.labmessage;
 
+import static de.symeda.sormas.backend.sormastosormas.ValidationHelper.buildLabMessageValidationGroupName;
+
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
 import javax.inject.Inject;
 
-import de.symeda.sormas.api.caze.maternalhistory.MaternalHistoryDto;
-import de.symeda.sormas.api.hospitalization.HospitalizationDto;
-import de.symeda.sormas.api.i18n.Captions;
 import de.symeda.sormas.api.labmessage.LabMessageDto;
 import de.symeda.sormas.api.sormastosormas.labmessage.SormasToSormasLabMessageDto;
 import de.symeda.sormas.api.sormastosormas.sharerequest.PreviewNotImplementedDto;
@@ -30,7 +29,8 @@ public class SormasToSormasLabMessageDtoValidator
 
 	@Override
 	public ValidationErrors validate(SormasToSormasLabMessageDto sharedData, ValidationDirection direction) {
-		return new ValidationErrors();
+		LabMessageDto labMessage = sharedData.getEntity();
+		return new ValidationErrors(buildLabMessageValidationGroupName(labMessage));
 	}
 
 	@Override

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/sample/SormasToSormasSampleDtoValidator.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/sample/SormasToSormasSampleDtoValidator.java
@@ -14,6 +14,8 @@ import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
 import javax.inject.Inject;
 
+import static de.symeda.sormas.backend.sormastosormas.ValidationHelper.buildSampleValidationGroupName;
+
 @Stateless
 @LocalBean
 public class SormasToSormasSampleDtoValidator extends SormasToSormasDtoValidator<SampleDto, SormasToSormasSampleDto, PreviewNotImplementedDto> {
@@ -29,7 +31,7 @@ public class SormasToSormasSampleDtoValidator extends SormasToSormasDtoValidator
 	@Override
 	public ValidationErrors validate(SormasToSormasSampleDto sharedData, ValidationDirection direction) {
 		SampleDto sample = sharedData.getEntity();
-		ValidationErrors validationErrors = new ValidationErrors();
+		ValidationErrors validationErrors = new ValidationErrors(buildSampleValidationGroupName(sample));
 
 		// todo shouldn't this be FacilityType.LABORATORY?
 		infraValidator.validateFacility(sample.getLab(), null, sample.getLabDetails(), Captions.Sample_lab, validationErrors, f -> {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/share/ShareDataBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/share/ShareDataBuilder.java
@@ -23,12 +23,12 @@ import de.symeda.sormas.api.sormastosormas.SormasToSormasShareableDto;
 import de.symeda.sormas.api.sormastosormas.validation.SormasToSormasValidationException;
 import de.symeda.sormas.api.sormastosormas.validation.ValidationErrors;
 import de.symeda.sormas.api.utils.pseudonymization.PseudonymizableDto;
-import de.symeda.sormas.backend.common.AbstractDomainObject;
 import de.symeda.sormas.backend.sormastosormas.ValidationHelper;
 import de.symeda.sormas.backend.sormastosormas.data.validation.SormasToSormasDtoValidator;
+import de.symeda.sormas.backend.sormastosormas.entities.SormasToSormasShareable;
 import de.symeda.sormas.backend.sormastosormas.share.shareinfo.ShareRequestInfo;
-// todo SormasToSormasShareable
-public abstract class ShareDataBuilder<DTO extends SormasToSormasShareableDto, T extends AbstractDomainObject, SHARED extends SormasToSormasEntityDto<DTO>, PREVIEW extends PseudonymizableDto, VALIDATOR extends SormasToSormasDtoValidator<DTO, SHARED, PREVIEW>> {
+
+public abstract class ShareDataBuilder<DTO extends SormasToSormasShareableDto, ADO extends SormasToSormasShareable, SHARED extends SormasToSormasEntityDto<DTO>, PREVIEW extends PseudonymizableDto, VALIDATOR extends SormasToSormasDtoValidator<DTO, SHARED, PREVIEW>> {
 
 	VALIDATOR validator;
 
@@ -39,9 +39,9 @@ public abstract class ShareDataBuilder<DTO extends SormasToSormasShareableDto, T
 	protected ShareDataBuilder() {
 	}
 
-	protected abstract SHARED doBuildShareData(T data, ShareRequestInfo requestInfo);
+	protected abstract SHARED doBuildShareData(ADO data, ShareRequestInfo requestInfo);
 
-	public SHARED buildShareData(T data, ShareRequestInfo requestInfo) throws SormasToSormasValidationException {
+	public SHARED buildShareData(ADO data, ShareRequestInfo requestInfo) throws SormasToSormasValidationException {
 		SHARED shared = doBuildShareData(data, requestInfo);
 		ValidationErrors errors = validator.validateOutgoing(shared);
 		if (errors.hasError()) {
@@ -52,9 +52,9 @@ public abstract class ShareDataBuilder<DTO extends SormasToSormasShareableDto, T
 		return shared;
 	}
 
-	protected abstract PREVIEW doBuildShareDataPreview(T data, ShareRequestInfo requestInfo);
+	protected abstract PREVIEW doBuildShareDataPreview(ADO data, ShareRequestInfo requestInfo);
 
-	public  PREVIEW buildShareDataPreview(T data, ShareRequestInfo requestInfo) throws SormasToSormasValidationException {
+	public  PREVIEW buildShareDataPreview(ADO data, ShareRequestInfo requestInfo) throws SormasToSormasValidationException {
 		PREVIEW shared = doBuildShareDataPreview(data, requestInfo);
 		ValidationErrors errors = validator.validateOutgoingPreview(shared);
 		if (errors.hasError()) {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/share/ShareDataBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/share/ShareDataBuilder.java
@@ -54,12 +54,12 @@ public abstract class ShareDataBuilder<DTO extends SormasToSormasShareableDto, A
 
 	protected abstract PREVIEW doBuildShareDataPreview(ADO data, ShareRequestInfo requestInfo);
 
-	public  PREVIEW buildShareDataPreview(ADO data, ShareRequestInfo requestInfo) throws SormasToSormasValidationException {
+	public PREVIEW buildShareDataPreview(ADO data, ShareRequestInfo requestInfo) throws SormasToSormasValidationException {
 		PREVIEW shared = doBuildShareDataPreview(data, requestInfo);
 		ValidationErrors errors = validator.validateOutgoingPreview(shared);
 		if (errors.hasError()) {
 			List<ValidationErrors> validationErrors = new ArrayList<>();
-			validationErrors.add(new ValidationErrors(ValidationHelper.buildEventValidationGroupName(data), errors));
+			validationErrors.add(errors);
 			throw new SormasToSormasValidationException(validationErrors);
 		}
 		return shared;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/share/ShareDataBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/share/ShareDataBuilder.java
@@ -1,6 +1,6 @@
 /*
  * SORMAS® - Surveillance Outbreak Response Management & Analysis System
- * Copyright © 2016-2020 Helmholtz-Zentrum für Infektionsforschung GmbH (HZI)
+ * Copyright © 2016-2022 Helmholtz-Zentrum für Infektionsforschung GmbH (HZI)
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -23,7 +23,6 @@ import de.symeda.sormas.api.sormastosormas.SormasToSormasShareableDto;
 import de.symeda.sormas.api.sormastosormas.validation.SormasToSormasValidationException;
 import de.symeda.sormas.api.sormastosormas.validation.ValidationErrors;
 import de.symeda.sormas.api.utils.pseudonymization.PseudonymizableDto;
-import de.symeda.sormas.backend.sormastosormas.ValidationHelper;
 import de.symeda.sormas.backend.sormastosormas.data.validation.SormasToSormasDtoValidator;
 import de.symeda.sormas.backend.sormastosormas.entities.SormasToSormasShareable;
 import de.symeda.sormas.backend.sormastosormas.share.shareinfo.ShareRequestInfo;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/share/ShareDataBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/share/ShareDataBuilder.java
@@ -27,7 +27,7 @@ import de.symeda.sormas.backend.common.AbstractDomainObject;
 import de.symeda.sormas.backend.sormastosormas.ValidationHelper;
 import de.symeda.sormas.backend.sormastosormas.data.validation.SormasToSormasDtoValidator;
 import de.symeda.sormas.backend.sormastosormas.share.shareinfo.ShareRequestInfo;
-
+// todo SormasToSormasShareable
 public abstract class ShareDataBuilder<DTO extends SormasToSormasShareableDto, T extends AbstractDomainObject, SHARED extends SormasToSormasEntityDto<DTO>, PREVIEW extends PseudonymizableDto, VALIDATOR extends SormasToSormasDtoValidator<DTO, SHARED, PREVIEW>> {
 
 	VALIDATOR validator;
@@ -46,7 +46,7 @@ public abstract class ShareDataBuilder<DTO extends SormasToSormasShareableDto, T
 		ValidationErrors errors = validator.validateOutgoing(shared);
 		if (errors.hasError()) {
 			List<ValidationErrors> validationErrors = new ArrayList<>();
-			validationErrors.add(new ValidationErrors(ValidationHelper.buildEventValidationGroupName(data), errors));
+			validationErrors.add(errors);
 			throw new SormasToSormasValidationException(validationErrors);
 		}
 		return shared;

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/TestDataCreator.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/TestDataCreator.java
@@ -654,6 +654,11 @@ public class TestDataCreator {
 		return treatment;
 	}
 
+	public ContactDto createContact(RDCF rdcf, UserReferenceDto reportingUser, PersonReferenceDto contactPerson) {
+		return createContact(reportingUser, null, contactPerson, null, new Date(), null, null, rdcf);
+	}
+
+
 	public ContactDto createContact(UserReferenceDto reportingUser, PersonReferenceDto contactPerson) {
 		return createContact(reportingUser, null, contactPerson, null, new Date(), null, null, null);
 	}

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/entities/SormasToSormasContactFacadeEjbTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/entities/SormasToSormasContactFacadeEjbTest.java
@@ -307,7 +307,7 @@ public class SormasToSormasContactFacadeEjbTest extends SormasToSormasTest {
 		UserReferenceDto officer = creator.createUser(rdcf, UserRole.SURVEILLANCE_OFFICER).toReference();
 
 		PersonDto contactPerson = creator.createPerson();
-		ContactDto contact = creator.createContact(officer, contactPerson.toReference());
+		ContactDto contact = creator.createContact(rdcf, officer, contactPerson.toReference());
 		SampleDto sharedSample = creator.createSample(contact.toReference(), officer, rdcf.facility, null);
 		SampleDto newSample = createRemoteSample(contact.toReference(), officer, rdcf.facility);
 

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/validation/InfraValidationSoundnessTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/validation/InfraValidationSoundnessTest.java
@@ -1,6 +1,7 @@
 package de.symeda.sormas.backend.sormastosormas.validation;
 
 import static org.hibernate.validator.internal.util.Contracts.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 import java.lang.reflect.Constructor;
@@ -20,17 +21,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import de.symeda.sormas.api.sormastosormas.labmessage.SormasToSormasLabMessageDto;
-import de.symeda.sormas.api.utils.DefaultEntityHelper;
-import de.symeda.sormas.backend.AbstractBeanTest;
-import de.symeda.sormas.backend.common.DefaultEntitiesCreator;
-import de.symeda.sormas.backend.infrastructure.community.Community;
-import de.symeda.sormas.backend.infrastructure.continent.Continent;
-import de.symeda.sormas.backend.infrastructure.country.Country;
-import de.symeda.sormas.backend.infrastructure.district.District;
-import de.symeda.sormas.backend.infrastructure.region.Region;
-import de.symeda.sormas.backend.infrastructure.subcontinent.Subcontinent;
-import de.symeda.sormas.backend.sormastosormas.entities.labmessage.SormasToSormasLabMessageDtoValidator;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.commons.lang.StringUtils;
@@ -53,6 +43,7 @@ import de.symeda.sormas.api.sormastosormas.contact.SormasToSormasContactDto;
 import de.symeda.sormas.api.sormastosormas.event.SormasToSormasEventDto;
 import de.symeda.sormas.api.sormastosormas.event.SormasToSormasEventParticipantDto;
 import de.symeda.sormas.api.sormastosormas.immunization.SormasToSormasImmunizationDto;
+import de.symeda.sormas.api.sormastosormas.labmessage.SormasToSormasLabMessageDto;
 import de.symeda.sormas.api.sormastosormas.sample.SormasToSormasSampleDto;
 import de.symeda.sormas.api.sormastosormas.sharerequest.PreviewNotImplementedDto;
 import de.symeda.sormas.api.sormastosormas.sharerequest.SormasToSormasCasePreview;
@@ -62,13 +53,23 @@ import de.symeda.sormas.api.sormastosormas.sharerequest.SormasToSormasEventPrevi
 import de.symeda.sormas.api.sormastosormas.validation.ValidationErrorGroup;
 import de.symeda.sormas.api.sormastosormas.validation.ValidationErrorMessage;
 import de.symeda.sormas.api.sormastosormas.validation.ValidationErrors;
+import de.symeda.sormas.api.utils.DefaultEntityHelper;
 import de.symeda.sormas.api.utils.pseudonymization.PseudonymizableDto;
+import de.symeda.sormas.backend.AbstractBeanTest;
+import de.symeda.sormas.backend.common.DefaultEntitiesCreator;
+import de.symeda.sormas.backend.infrastructure.community.Community;
+import de.symeda.sormas.backend.infrastructure.continent.Continent;
+import de.symeda.sormas.backend.infrastructure.country.Country;
+import de.symeda.sormas.backend.infrastructure.district.District;
+import de.symeda.sormas.backend.infrastructure.region.Region;
+import de.symeda.sormas.backend.infrastructure.subcontinent.Subcontinent;
 import de.symeda.sormas.backend.sormastosormas.data.validation.SormasToSormasDtoValidator;
 import de.symeda.sormas.backend.sormastosormas.entities.caze.SormasToSormasCaseDtoValidator;
 import de.symeda.sormas.backend.sormastosormas.entities.contact.SormasToSormasContactDtoValidator;
 import de.symeda.sormas.backend.sormastosormas.entities.event.SormasToSormasEventDtoValidator;
 import de.symeda.sormas.backend.sormastosormas.entities.eventparticipant.SormasToSormasEventParticipantDtoValidator;
 import de.symeda.sormas.backend.sormastosormas.entities.immunization.SormasToSormasImmunizationDtoValidator;
+import de.symeda.sormas.backend.sormastosormas.entities.labmessage.SormasToSormasLabMessageDtoValidator;
 
 public abstract class InfraValidationSoundnessTest extends AbstractBeanTest {
 
@@ -515,8 +516,9 @@ public abstract class InfraValidationSoundnessTest extends AbstractBeanTest {
 	}
 
 	private void assertValidation(Set<String> expected, Set<String> foundFields) {
-		// smoke test, we allow both to be empty though, as lab messages currently don't have relevant fields
-		assertFalse(foundFields.isEmpty() ^ expected.isEmpty());
+		// smoke test, in case both are empty for some reason this will blow up
+		assertFalse(foundFields.isEmpty());
+		assertFalse(expected.isEmpty());
 		final Collection disjunction = CollectionUtils.disjunction(foundFields, expected);
 		assertTrue(disjunction.isEmpty(), "The following fields are not validated in the DTO: " + disjunction);
 	}
@@ -530,7 +532,14 @@ public abstract class InfraValidationSoundnessTest extends AbstractBeanTest {
 		SormasToSormasDtoValidator<DTO, SHARED, PREVIEW> validator)
 		throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException, NoSuchFieldException {
 		Set<String> expected = getExpected(entity, rootNode);
-
+		if (expected.isEmpty()) {
+			assertEquals(
+				"SormasToSormasLabMessageDto have no infra. fields as of now, therefore, the are not populated at all. "
+					+ "Other types are not expected to be completely empty.",
+				"de.symeda.sormas.api.sormastosormas.labmessage.SormasToSormasLabMessageDto",
+				typeResolver.resolve(entity.getClass()).getTypeName());
+			return;
+		}
 		Set<String> foundFieldsIncoming = getRejectedFields(getDtoValidationErrors(entity, validator));
 		assertValidation(expected, foundFieldsIncoming);
 	}
@@ -548,7 +557,14 @@ public abstract class InfraValidationSoundnessTest extends AbstractBeanTest {
 		SormasToSormasDtoValidator<DTO, SHARED, PREVIEW> validator)
 		throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException, NoSuchFieldException {
 		Set<String> expected = getExpected(entity, rootNode);
-
+		if (expected.isEmpty()) {
+			assertEquals(
+					"SormasToSormasLabMessageDto have no infra. fields as of now, therefore, the are not populated at all. "
+							+ "Other types are not expected to be completely empty.",
+					"de.symeda.sormas.api.sormastosormas.labmessage.SormasToSormasLabMessageDto",
+					typeResolver.resolve(entity.getClass()).getTypeName());
+			return;
+		}
 		Set<String> foundFieldsIncoming = getRejectedFields(getPreviewValidationErrors(entity, validator));
 		assertValidation(expected, foundFieldsIncoming);
 	}

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/sormastosormas/SormasToSormasController.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/sormastosormas/SormasToSormasController.java
@@ -1,6 +1,6 @@
 /*
  * SORMAS® - Surveillance Outbreak Response Management & Analysis System
- * Copyright © 2016-2021 Helmholtz-Zentrum für Infektionsforschung GmbH (HZI)
+ * Copyright © 2016-2022 Helmholtz-Zentrum für Infektionsforschung GmbH (HZI)
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -40,10 +40,8 @@ import de.symeda.sormas.api.i18n.Captions;
 import de.symeda.sormas.api.i18n.I18nProperties;
 import de.symeda.sormas.api.i18n.Strings;
 import de.symeda.sormas.api.labmessage.LabMessageDto;
-import de.symeda.sormas.api.sormastosormas.SormasServerDescriptor;
 import de.symeda.sormas.api.sormastosormas.SormasToSormasException;
 import de.symeda.sormas.api.sormastosormas.SormasToSormasOptionsDto;
-import de.symeda.sormas.api.sormastosormas.SormasToSormasOriginInfoDto;
 import de.symeda.sormas.api.sormastosormas.shareinfo.SormasToSormasShareInfoCriteria;
 import de.symeda.sormas.api.sormastosormas.shareinfo.SormasToSormasShareInfoDto;
 import de.symeda.sormas.api.sormastosormas.sharerequest.SormasToSormasShareRequestDto;
@@ -69,30 +67,34 @@ public class SormasToSormasController {
 		List<SormasToSormasShareInfoDto> currentShares = FacadeProvider.getSormasToSormasShareInfoFacade()
 			.getIndexList(new SormasToSormasShareInfoCriteria().caze(caze.toReference()), null, null);
 		shareToSormasFromDetailPage(
-			(options) -> FacadeProvider.getSormasToSormasCaseFacade().share(Collections.singletonList(caze.getUuid()), options),
+			options -> FacadeProvider.getSormasToSormasCaseFacade().share(Collections.singletonList(caze.getUuid()), options),
 			SormasToSormasOptionsForm.forCase(currentShares));
 	}
 
 	public void shareSelectedCases(Collection<? extends CaseIndexDto> selectedRows, Runnable callback) {
-		handleShareWithOptions((options) -> {
-			FacadeProvider.getSormasToSormasCaseFacade()
-				.share(selectedRows.stream().map(CaseIndexDto::getUuid).collect(Collectors.toList()), options);
-		}, callback, SormasToSormasOptionsForm.forCase(null), new SormasToSormasOptionsDto());
+		handleShareWithOptions(
+			options -> FacadeProvider.getSormasToSormasCaseFacade()
+				.share(selectedRows.stream().map(CaseIndexDto::getUuid).collect(Collectors.toList()), options),
+			callback,
+			SormasToSormasOptionsForm.forCase(null),
+			new SormasToSormasOptionsDto());
 	}
 
 	public void shareContactFromDetailsPage(ContactDto contact) {
 		List<SormasToSormasShareInfoDto> currentShares = FacadeProvider.getSormasToSormasShareInfoFacade()
 			.getIndexList(new SormasToSormasShareInfoCriteria().contact(contact.toReference()), null, null);
 		shareToSormasFromDetailPage(
-			(options) -> FacadeProvider.getSormasToSormasContactFacade().share(Collections.singletonList(contact.getUuid()), options),
+			options -> FacadeProvider.getSormasToSormasContactFacade().share(Collections.singletonList(contact.getUuid()), options),
 			SormasToSormasOptionsForm.forContact(currentShares));
 	}
 
 	public void shareSelectedContacts(Collection<? extends ContactIndexDto> selectedRows, Runnable callback) {
-		handleShareWithOptions((options) -> {
-			FacadeProvider.getSormasToSormasContactFacade()
-				.share(selectedRows.stream().map(ContactIndexDto::getUuid).collect(Collectors.toList()), options);
-		}, callback, SormasToSormasOptionsForm.forContact(null), new SormasToSormasOptionsDto());
+		handleShareWithOptions(
+			options -> FacadeProvider.getSormasToSormasContactFacade()
+				.share(selectedRows.stream().map(ContactIndexDto::getUuid).collect(Collectors.toList()), options),
+			callback,
+			SormasToSormasOptionsForm.forContact(null),
+			new SormasToSormasOptionsDto());
 	}
 
 	public void shareEventFromDetailsPage(EventDto event) {
@@ -100,14 +102,16 @@ public class SormasToSormasController {
 			.getIndexList(new SormasToSormasShareInfoCriteria().event(event.toReference()), null, null);
 
 		shareToSormasFromDetailPage(
-			(options) -> FacadeProvider.getSormasToSormasEventFacade().share(Collections.singletonList(event.getUuid()), options),
+			options -> FacadeProvider.getSormasToSormasEventFacade().share(Collections.singletonList(event.getUuid()), options),
 			SormasToSormasOptionsForm.forEvent(currentShares));
 	}
 
 	public void shareLabMessage(LabMessageDto labMessage, Runnable callback) {
-		handleShareWithOptions((options) -> {
-			FacadeProvider.getSormasToSormasLabMessageFacade().sendLabMessages(Collections.singletonList(labMessage.getUuid()), options);
-		}, callback, SormasToSormasOptionsForm.withoutOptions(), new SormasToSormasOptionsDto());
+		handleShareWithOptions(
+			options -> FacadeProvider.getSormasToSormasLabMessageFacade().sendLabMessages(Collections.singletonList(labMessage.getUuid()), options),
+			callback,
+			SormasToSormasOptionsForm.withoutOptions(),
+			new SormasToSormasOptionsDto());
 	}
 
 	public void rejectShareRequest(SormasToSormasShareRequestIndexDto request, Runnable callback) {
@@ -125,17 +129,18 @@ public class SormasToSormasController {
 			640,
 			confirmed -> {
 				if (confirmed) {
-					handleSormasToSormasRequest(() -> {
-						FacadeProvider.getSormasToSormasFacade().rejectRequest(request.getDataType(), request.getUuid(), commentField.getValue());
-					}, callback);
+					handleSormasToSormasRequest(
+						() -> FacadeProvider.getSormasToSormasFacade()
+							.rejectRequest(request.getDataType(), request.getUuid(), commentField.getValue()),
+						callback);
 				}
 			});
 	}
 
 	public void acceptShareRequest(SormasToSormasShareRequestIndexDto request, Runnable callback) {
-		handleSormasToSormasRequest(() -> {
-			FacadeProvider.getSormasToSormasFacade().acceptShareRequest(request.getDataType(), request.getUuid());
-		}, callback);
+		handleSormasToSormasRequest(
+			() -> FacadeProvider.getSormasToSormasFacade().acceptShareRequest(request.getDataType(), request.getUuid()),
+			callback);
 	}
 
 	public void revokeShare(String shareInfoUuid, Runnable callback) {
@@ -147,15 +152,13 @@ public class SormasToSormasController {
 			640,
 			confirmed -> {
 				if (confirmed) {
-					handleSormasToSormasRequest(() -> {
-						FacadeProvider.getSormasToSormasFacade().revokeShare(shareInfoUuid);
-					}, callback);
+					handleSormasToSormasRequest(() -> FacadeProvider.getSormasToSormasFacade().revokeShare(shareInfoUuid), callback);
 				}
 			});
 	}
 
 	private void shareToSormasFromDetailPage(HandleShareWithOptions handleShareWithOptions, SormasToSormasOptionsForm optionsForm) {
-		handleShareWithOptions(handleShareWithOptions::handle, SormasUI::refreshView, optionsForm, new SormasToSormasOptionsDto());
+		handleShareWithOptions(handleShareWithOptions, SormasUI::refreshView, optionsForm, new SormasToSormasOptionsDto());
 	}
 
 	private void handleShareWithOptions(
@@ -175,9 +178,7 @@ public class SormasToSormasController {
 		optionsCommitDiscard.addCommitListener(() -> {
 			SormasToSormasOptionsDto options = optionsForm.getValue();
 
-			handleSormasToSormasRequest(() -> {
-				handleShareWithOptions.handle(options);
-			}, () -> {
+			handleSormasToSormasRequest(() -> handleShareWithOptions.handle(options), () -> {
 				callback.run();
 				optionsPopup.close();
 			});
@@ -197,36 +198,25 @@ public class SormasToSormasController {
 			} else {
 				Component messageComponent = buildShareErrorMessage(ex.getHumanMessage(), ex.getErrors());
 				messageComponent.setWidth(100, Sizeable.Unit.PERCENTAGE);
-				VaadinUiUtil
-					.showPopupWindow(new VerticalLayout(messageComponent), I18nProperties.getCaption(Captions.sormasToSormasErrorDialogTitle));
+				VaadinUiUtil.showPopupWindowWithWidth(
+					new VerticalLayout(messageComponent),
+					I18nProperties.getCaption(Captions.sormasToSormasErrorDialogTitle),
+					100);
 			}
 		} catch (SormasToSormasValidationException ex) {
 			Component messageComponent = buildShareErrorMessage(ex.getMessage(), ex.getErrors());
 			messageComponent.setWidth(100, Sizeable.Unit.PERCENTAGE);
-			VaadinUiUtil.showPopupWindow(new VerticalLayout(messageComponent), I18nProperties.getCaption(Captions.sormasToSormasErrorDialogTitle));
+			VaadinUiUtil.showPopupWindowWithWidth(
+				new VerticalLayout(messageComponent),
+				I18nProperties.getCaption(Captions.sormasToSormasErrorDialogTitle),
+				100);
 		}
-	}
-
-	private void handleReturn(
-		HandleShareWithOptions handleShareWithOptions,
-		SormasToSormasOptionsForm optionsForm,
-		SormasToSormasOriginInfoDto originInfo) {
-		SormasToSormasOptionsDto defaultOptions = new SormasToSormasOptionsDto();
-		defaultOptions.setOrganization(new SormasServerDescriptor(originInfo.getOrganizationId()));
-		defaultOptions.setHandOverOwnership(true);
-		defaultOptions.setWithAssociatedContacts(originInfo.isWithAssociatedContacts());
-		defaultOptions.setWithSamples(originInfo.isWithSamples());
-		defaultOptions.setWithEventParticipants(originInfo.isWithEventParticipants());
-
-		optionsForm.disableAllOptions();
-
-		handleShareWithOptions(handleShareWithOptions::handle, SormasUI::refreshView, optionsForm, defaultOptions);
 	}
 
 	private Component buildShareErrorMessage(String message, List<ValidationErrors> errors) {
 		Label errorMessageLabel = new Label(message, ContentMode.HTML);
 
-		if (errors == null || errors.size() == 0) {
+		if (errors == null || errors.isEmpty()) {
 			return errorMessageLabel;
 		}
 

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/sormastosormas/SormasToSormasController.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/sormastosormas/SormasToSormasController.java
@@ -201,7 +201,7 @@ public class SormasToSormasController {
 				VaadinUiUtil.showPopupWindowWithWidth(
 					new VerticalLayout(messageComponent),
 					I18nProperties.getCaption(Captions.sormasToSormasErrorDialogTitle),
-					100);
+					38);
 			}
 		} catch (SormasToSormasValidationException ex) {
 			Component messageComponent = buildShareErrorMessage(ex.getMessage(), ex.getErrors());
@@ -209,7 +209,7 @@ public class SormasToSormasController {
 			VaadinUiUtil.showPopupWindowWithWidth(
 				new VerticalLayout(messageComponent),
 				I18nProperties.getCaption(Captions.sormasToSormasErrorDialogTitle),
-				100);
+				38);
 		}
 	}
 

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/VaadinUiUtil.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/VaadinUiUtil.java
@@ -108,16 +108,27 @@ public final class VaadinUiUtil {
 	}
 
 	public static Window showPopupWindow(Component content, String caption) {
-
 		Window window = new Window(caption);
 		window.setModal(true);
-		window.setSizeUndefined();
 		window.setResizable(false);
 		window.center();
 		window.setContent(content);
+		UI.getCurrent().addWindow(window);
+		return window;
+	}
+
+	public static Window showPopupWindowWithWidth(Component content, String caption, Integer width) {
+		Window window = new Window(caption);
+		window.setModal(true);
+		window.setResizable(false);
+		window.center();
+		window.setContent(content);
+		if (width != null) {
+			window.setWidth(width, Unit.PERCENTAGE);
+		}
+
 
 		UI.getCurrent().addWindow(window);
-
 		return window;
 	}
 


### PR DESCRIPTION
Fixes #6470 
This fixes the following:

- [x] The group name will now show e.g., `Case ID` what is coherent with the column if you open the case directory view
- [x] validation will now use the correct group name directly
- [x] Fixed a bug in `ShareDataBuilder.java` which caused the top group to be always `Event`
- [x] Fixed failing validation test due to labmessage not having any infra data yet
- [x] Fixed the popup window label being cut off
- [x] Removed unused function `handleReturn`
- [x] Couple of sonar lint warnings fixed
- [x] Sneaked 16b7fcf in here as well, as it needs to be in the release 
----
![fixed](https://user-images.githubusercontent.com/20031875/150139362-7e359a76-41f0-4817-a146-817114dc675b.png)