### PR TITLE
#7978: Update test dependencies

### DIFF
--- a/sormas-app/app/build.gradle
+++ b/sormas-app/app/build.gradle
@@ -124,10 +124,12 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.10.2'
     implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_version"
     implementation "androidx.paging:paging-runtime:$paging_version"
-    testImplementation 'junit:junit:4.13.1'
-    testImplementation 'org.hamcrest:hamcrest-library:1.3'
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.hamcrest:hamcrest:2.2'
+    testImplementation 'org.hamcrest:hamcrest-core:2.2'
+    testImplementation 'org.hamcrest:hamcrest-library:2.2'
     testImplementation 'org.robolectric:robolectric:4.2.1'
-    testImplementation 'org.mockito:mockito-core:1.10.19'
+    testImplementation 'org.mockito:mockito-core:4.3.1'
     androidTestImplementation 'androidx.annotation:annotation:1.2.0'
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation 'androidx.test:rules:1.4.0'

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/caze/CaseFacadeEjbPseudonymizationTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/caze/CaseFacadeEjbPseudonymizationTest.java
@@ -18,7 +18,6 @@
 package de.symeda.sormas.backend.caze;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.not;
@@ -33,7 +32,7 @@ import java.util.List;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import de.symeda.sormas.api.Disease;
 import de.symeda.sormas.api.Language;

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/clinicalcourse/ClinicalVisitFacadeEjbPseudonymizationTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/clinicalcourse/ClinicalVisitFacadeEjbPseudonymizationTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 import org.joda.time.DateTime;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import de.symeda.sormas.api.caze.CaseCriteria;
 import de.symeda.sormas.api.caze.CaseDataDto;

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/contact/ContactFacadeEjbPseudonymizationTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/contact/ContactFacadeEjbPseudonymizationTest.java
@@ -35,7 +35,7 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import de.symeda.sormas.api.Disease;
 import de.symeda.sormas.api.Language;

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/epidata/EpiDataPseudonymizationTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/epidata/EpiDataPseudonymizationTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.when;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import de.symeda.sormas.api.caze.CaseDataDto;
 import de.symeda.sormas.api.epidata.AnimalCondition;

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/event/EventFacadeEjbPseudonymizationTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/event/EventFacadeEjbPseudonymizationTest.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import de.symeda.sormas.api.event.EventDto;
 import de.symeda.sormas.api.event.EventInvestigationStatus;

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/event/EventParticipantFacadeEjbPseudonymizationTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/event/EventParticipantFacadeEjbPseudonymizationTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import de.symeda.sormas.api.event.EventDto;
 import de.symeda.sormas.api.event.EventInvestigationStatus;

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/hospitalization/HospitalizationFacadeEjbPseudonymizationTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/hospitalization/HospitalizationFacadeEjbPseudonymizationTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.when;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import de.symeda.sormas.api.caze.CaseDataDto;
 import de.symeda.sormas.api.hospitalization.HospitalizationDto;

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/sample/PathogenTestFacadeEjbPseudonymizationTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/sample/PathogenTestFacadeEjbPseudonymizationTest.java
@@ -27,7 +27,7 @@ import java.util.List;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import de.symeda.sormas.api.Disease;
 import de.symeda.sormas.api.caze.CaseDataDto;

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/sample/SampleFacadeEjbPseudonymizationTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/sample/SampleFacadeEjbPseudonymizationTest.java
@@ -33,7 +33,7 @@ import java.util.Optional;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import de.symeda.sormas.api.Disease;
 import de.symeda.sormas.api.caze.CaseDataDto;

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasTest.java
@@ -15,6 +15,8 @@
 
 package de.symeda.sormas.backend.sormastosormas;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 
 import java.io.File;
@@ -24,7 +26,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.function.Consumer;
 
-import org.mockito.Matchers;
 import org.mockito.Mockito;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
@@ -238,7 +239,7 @@ public abstract class SormasToSormasTest extends AbstractBeanTest {
 	}
 
 	protected void mockS2Snetwork() throws SormasToSormasException {
-		Mockito.when(MockProducer.getSormasToSormasClient().get(Matchers.anyString(), eq("/sormasToSormas/cert"), Matchers.any()))
+		Mockito.when(MockProducer.getSormasToSormasClient().get(anyString(), eq("/sormasToSormas/cert"), any()))
 			.thenAnswer(invocation -> {
 				if (invocation.getArgument(0, String.class).equals(DEFAULT_SERVER_ID)) {
 					mockDefaultServerAccess();

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/symptoms/SymptomsPseudonymizationTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/symptoms/SymptomsPseudonymizationTest.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.when;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import de.symeda.sormas.api.caze.CaseDataDto;
 import de.symeda.sormas.api.symptoms.SymptomState;

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/task/TaskFacadeEjbPseudonymizationTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/task/TaskFacadeEjbPseudonymizationTest.java
@@ -30,7 +30,7 @@ import java.util.List;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import de.symeda.sormas.api.Disease;
 import de.symeda.sormas.api.caze.CaseDataDto;

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/task/TaskFacadeEjbTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/task/TaskFacadeEjbTest.java
@@ -36,7 +36,7 @@ import java.util.Map;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import de.symeda.sormas.api.Disease;
 import de.symeda.sormas.api.EntityDto;

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/task/TaskServiceTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/task/TaskServiceTest.java
@@ -4,7 +4,6 @@ import static de.symeda.sormas.api.user.UserRole.CONTACT_OFFICER;
 import static de.symeda.sormas.api.user.UserRole.CONTACT_SUPERVISOR;
 import static junit.framework.TestCase.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyObject;
 import static org.mockito.ArgumentMatchers.eq;
 
 import java.util.Collections;
@@ -20,10 +19,10 @@ import de.symeda.sormas.backend.AbstractBeanTest;
 import de.symeda.sormas.backend.caze.Case;
 import de.symeda.sormas.backend.common.TaskCreationException;
 import de.symeda.sormas.backend.contact.Contact;
-import de.symeda.sormas.backend.location.Location;
-import de.symeda.sormas.backend.person.Person;
 import de.symeda.sormas.backend.infrastructure.district.District;
 import de.symeda.sormas.backend.infrastructure.region.Region;
+import de.symeda.sormas.backend.location.Location;
+import de.symeda.sormas.backend.person.Person;
 import de.symeda.sormas.backend.user.User;
 import de.symeda.sormas.backend.user.UserService;
 
@@ -93,7 +92,7 @@ public class TaskServiceTest extends AbstractBeanTest {
 		Case caze = new Case();
 		contact.setCaze(caze);
 
-		Mockito.when(userService.getAllByRegionAndUserRoles(any(Region.class), anyObject())).thenReturn(Collections.emptyList());
+		Mockito.when(userService.getAllByRegionAndUserRoles(any(Region.class), any())).thenReturn(Collections.emptyList());
 
 		taskService.getTaskAssignee(contact);
 	}

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/therapy/PresicriptionFacadeEjbPseudonymizationTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/therapy/PresicriptionFacadeEjbPseudonymizationTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 import org.joda.time.DateTime;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import de.symeda.sormas.api.caze.CaseCriteria;
 import de.symeda.sormas.api.caze.CaseDataDto;

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/therapy/TreatmentFacadeEjbPseudonymizationTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/therapy/TreatmentFacadeEjbPseudonymizationTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 import org.joda.time.DateTime;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import de.symeda.sormas.api.caze.CaseCriteria;
 import de.symeda.sormas.api.caze.CaseDataDto;

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/visit/VisitFacadeEjbPseudonymizationTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/visit/VisitFacadeEjbPseudonymizationTest.java
@@ -28,7 +28,7 @@ import java.util.List;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import de.symeda.sormas.api.Disease;
 import de.symeda.sormas.api.VisitOrigin;

--- a/sormas-base/pom.xml
+++ b/sormas-base/pom.xml
@@ -38,6 +38,7 @@
 		<xdocreport.version>2.0.2</xdocreport.version>
 		<docx4j.version>8.3.1</docx4j.version>
 		<archunit.version>0.22.0</archunit.version>
+		<hamcrest.version>2.2</hamcrest.version>
 
 		<!-- Attention: Compile dependencies with versions are maintained redundantly in sormas-app/app/build.gradle -->
 
@@ -777,7 +778,7 @@
 			<dependency>
 				<groupId>junit</groupId>
 				<artifactId>junit</artifactId>
-				<version>4.13.1</version>
+				<version>4.13.2</version>
 				<scope>test</scope>
 			</dependency>
 
@@ -796,15 +797,23 @@
 
 			<dependency>
 				<groupId>org.hamcrest</groupId>
-				<artifactId>hamcrest-core</artifactId>
-				<version>1.3</version>
+				<artifactId>hamcrest</artifactId>
+				<version>${hamcrest.version}</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.hamcrest</groupId>
-				<artifactId>hamcrest-library</artifactId>
-				<version>1.3</version>
+				<artifactId>hamcrest-core</artifactId>
+				<version>${hamcrest.version}</version>
 				<scope>test</scope>
+				<!-- Needed for junit4 -->
+			</dependency>
+			<dependency>
+				<groupId>org.hamcrest</groupId>
+				<artifactId>hamcrest-library</artifactId>
+				<version>${hamcrest.version}</version>
+				<scope>test</scope>
+				<!-- Needed for junit4 -->
 			</dependency>
 
 			<dependency>
@@ -817,7 +826,7 @@
 			<dependency>
 				<groupId>org.mockito</groupId>
 				<artifactId>mockito-inline</artifactId>
-				<version>3.5.15</version>
+				<version>4.3.1</version>
 				<scope>test</scope>
 			</dependency>
 
@@ -892,19 +901,18 @@
 	<dependencies>
 
 		<!-- Test libraries for all modules as baseline -->
-		<!-- Order is important because of Matcher implementations -->
+
 		<dependency>
 			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-core</artifactId>
+			<artifactId>hamcrest</artifactId>
+			<!-- Order is important because of Matcher implementations -->
 		</dependency>
+
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-library</artifactId>
-		</dependency>
+
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-inline</artifactId>

--- a/sormas-ui/src/test/java/de/symeda/sormas/ui/caze/importer/CaseImporterTest.java
+++ b/sormas-ui/src/test/java/de/symeda/sormas/ui/caze/importer/CaseImporterTest.java
@@ -49,7 +49,7 @@ import org.apache.commons.io.output.StringBuilderWriter;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.opencsv.exceptions.CsvValidationException;
 import com.vaadin.ui.UI;

--- a/sormas-ui/src/test/java/de/symeda/sormas/ui/dashboard/campaigns/GridTemplateAreaCreatorTest.java
+++ b/sormas-ui/src/test/java/de/symeda/sormas/ui/dashboard/campaigns/GridTemplateAreaCreatorTest.java
@@ -6,7 +6,7 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import de.symeda.sormas.api.campaign.diagram.CampaignDashboardElement;
 

--- a/sormas-ui/src/test/java/de/symeda/sormas/ui/event/importer/EventImporterTest.java
+++ b/sormas-ui/src/test/java/de/symeda/sormas/ui/event/importer/EventImporterTest.java
@@ -17,7 +17,7 @@ import java.util.function.Consumer;
 import org.apache.commons.io.output.StringBuilderWriter;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.opencsv.exceptions.CsvValidationException;
 

--- a/sormas-ui/src/test/java/de/symeda/sormas/ui/utils/DownloadUtilTest.java
+++ b/sormas-ui/src/test/java/de/symeda/sormas/ui/utils/DownloadUtilTest.java
@@ -11,7 +11,7 @@ import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.vaadin.server.StreamResource;
 

--- a/sormas-ui/src/test/java/travelentry/importer/TravelEntryImporterTest.java
+++ b/sormas-ui/src/test/java/travelentry/importer/TravelEntryImporterTest.java
@@ -32,7 +32,7 @@ import java.nio.file.Paths;
 import org.apache.commons.io.output.StringBuilderWriter;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.opencsv.exceptions.CsvValidationException;
 


### PR DESCRIPTION
- hamcrest 1.3 -> 2.2
- junit 4.13.1 -> 4.13.2
- mockito 3.5.15 -> 4.3.1

Fixed imports:
- org.mockito.runners.MockitoJUnitRunner ->
org.mockito.junit.MockitoJUnitRunner
- org.mockito.Matchers.anyObject -> org.mockito.ArgumentMatchers.any
- org.mockito.Matchers -> org.mockito.ArgumentMatchers

<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->