### PR TITLE
#7757 - Info dialog does not show whole content. 

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/sormastosormas/SormasToSormasController.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/sormastosormas/SormasToSormasController.java
@@ -201,7 +201,7 @@ public class SormasToSormasController {
 				VaadinUiUtil.showPopupWindowWithWidth(
 					new VerticalLayout(messageComponent),
 					I18nProperties.getCaption(Captions.sormasToSormasErrorDialogTitle),
-					38);
+					48);
 			}
 		} catch (SormasToSormasValidationException ex) {
 			Component messageComponent = buildShareErrorMessage(ex.getMessage(), ex.getErrors());
@@ -209,12 +209,13 @@ public class SormasToSormasController {
 			VaadinUiUtil.showPopupWindowWithWidth(
 				new VerticalLayout(messageComponent),
 				I18nProperties.getCaption(Captions.sormasToSormasErrorDialogTitle),
-				38);
+				48);
 		}
 	}
 
 	private Component buildShareErrorMessage(String message, List<ValidationErrors> errors) {
 		Label errorMessageLabel = new Label(message, ContentMode.HTML);
+		errorMessageLabel.addStyleName(CssStyles.LABEL_WHITE_SPACE_NORMAL);
 
 		if (errors == null || errors.isEmpty()) {
 			return errorMessageLabel;
@@ -228,6 +229,7 @@ public class SormasToSormasController {
 			groupErrorsLayout.setMargin(false);
 			groupErrorsLayout.setSpacing(false);
 			groupErrorsLayout.setStyleName(CssStyles.HSPACE_LEFT_3);
+			groupErrorsLayout.setWidth(92, Sizeable.Unit.PERCENTAGE);
 
 			VerticalLayout layout = new VerticalLayout(groupLabel, groupErrorsLayout);
 			layout.setMargin(false);
@@ -248,11 +250,12 @@ public class SormasToSormasController {
 		return errors.getSubGroups().stream().map(e -> {
 			Label groupLabel = new Label(e.getHumanMessage() + ":");
 			groupLabel.addStyleName(CssStyles.LABEL_BOLD);
-			HorizontalLayout layout = new HorizontalLayout(
-				groupLabel,
-				new Label(
+			Label label = new Label(
 					String
-						.join(", ", e.getMessages().stream().map(ValidationErrorMessage::getHumanMessage).collect(Collectors.toList()).toString())));
+							.join(", ", e.getMessages().stream().map(ValidationErrorMessage::getHumanMessage).collect(Collectors.toList()).toString()));
+			HorizontalLayout layout = new HorizontalLayout(
+				groupLabel, label);
+			label.addStyleName(CssStyles.LABEL_WHITE_SPACE_NORMAL);
 			layout.setMargin(false);
 
 			return layout;


### PR DESCRIPTION
Where fixed: 1. Window size that header with health department is displayed totally. 2. Was added new line passing for header line (prior all errors) 3. Was added new line passing for all errors. 4. Was adjusted width for groupErrorsLayout in order to see all complete words in errors(as sometime 1 word is missing)

<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #7757