### PR TITLE
#7978: Updated xdocreport

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/docgeneration/CleanHtmlReference.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/docgeneration/CleanHtmlReference.java
@@ -16,13 +16,14 @@
 package de.symeda.sormas.backend.docgeneration;
 
 import org.apache.velocity.app.event.ReferenceInsertionEventHandler;
+import org.apache.velocity.context.Context;
 
 import de.symeda.sormas.api.utils.HtmlHelper;
 
 public class CleanHtmlReference implements ReferenceInsertionEventHandler {
 
 	@Override
-	public Object referenceInsert(String s, Object o) {
-		return o == null ? null : HtmlHelper.cleanHtml(o.toString(), HtmlHelper.EVENTACTION_WHITELIST);
+	public Object referenceInsert(Context context, String reference, Object value) {
+		return value == null ? null : HtmlHelper.cleanHtml(value.toString(), HtmlHelper.EVENTACTION_WHITELIST);
 	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/docgeneration/NoIncludesEventHandler.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/docgeneration/NoIncludesEventHandler.java
@@ -16,11 +16,12 @@
 package de.symeda.sormas.backend.docgeneration;
 
 import org.apache.velocity.app.event.IncludeEventHandler;
+import org.apache.velocity.context.Context;
 
 public class NoIncludesEventHandler implements IncludeEventHandler {
 
 	@Override
-	public String includeEvent(String s, String s1, String s2) {
+	public String includeEvent(Context context, String includeResourcePath, String currentResourcePath, String directiveName) {
 		return null;
 	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/docgeneration/TemplateEngine.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/docgeneration/TemplateEngine.java
@@ -222,7 +222,8 @@ public class TemplateEngine {
 		FieldsExtractor<FieldExtractor> extractor = FieldsExtractor.create();
 		ExtractVariablesVelocityVisitor visitor = new ExtractVariablesVelocityVisitor(extractor);
 		try {
-			SimpleNode document = RuntimeSingleton.parse(templateFileReader, templateName);
+			Template template = RuntimeSingleton.getTemplate(templateName);
+			SimpleNode document = RuntimeSingleton.parse(templateFileReader, template);
 			document.jjtAccept(visitor, null);
 			return extractor;
 		} catch (ParseException e) {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/docgeneration/TemplateEngine.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/docgeneration/TemplateEngine.java
@@ -222,7 +222,8 @@ public class TemplateEngine {
 		FieldsExtractor<FieldExtractor> extractor = FieldsExtractor.create();
 		ExtractVariablesVelocityVisitor visitor = new ExtractVariablesVelocityVisitor(extractor);
 		try {
-			Template template = RuntimeSingleton.getTemplate(templateName);
+			Template template = new Template();
+			template.setName(templateName);
 			SimpleNode document = RuntimeSingleton.parse(templateFileReader, template);
 			document.jjtAccept(visitor, null);
 			return extractor;

--- a/sormas-backend/src/test/resources/docgeneration/eventHandout/EventHandout.cmp
+++ b/sormas-backend/src/test/resources/docgeneration/eventHandout/EventHandout.cmp
@@ -55,10 +55,10 @@
 
 <table>
     <tbody><tr><th>First Name</th><th>Last Name</th><th>Phone</th><th>Contacted</th></tr>
-        <tr><td>Georges</td><td>Bataille</td><td>+49 681 8901</td><td>[ ]</td></tr>
-        <tr><td>Guy</td><td>Debord</td><td>+49 681 4567</td><td>[ ]</td></tr>
-        <tr><td>Isidore</td><td>Isou</td><td>+49 681 1234</td><td>[ ]</td></tr>
-    </tbody></table>
+    <tr><td>Georges</td><td>Bataille</td><td>+49 681 8901</td><td>[ ]</td></tr>
+    <tr><td>Guy</td><td>Debord</td><td>+49 681 4567</td><td>[ ]</td></tr>
+    <tr><td>Isidore</td><td>Isou</td><td>+49 681 1234</td><td>[ ]</td></tr>
+</tbody></table>
 
 
 <div class="actions">

--- a/sormas-backend/src/test/resources/docgeneration/eventHandout/EventHandoutPreformatting.cmp
+++ b/sormas-backend/src/test/resources/docgeneration/eventHandout/EventHandoutPreformatting.cmp
@@ -55,10 +55,10 @@
 
 <table>
     <tbody><tr><th>First Name</th><th>Last Name</th><th>Phone</th><th>Contacted</th></tr>
-        <tr><td>Georges</td><td>Bataille</td><td>+49 681 8901</td><td>[ ]</td></tr>
-        <tr><td>Guy</td><td>Debord</td><td>+49 681 4567</td><td>[ ]</td></tr>
-        <tr><td>Isidore</td><td>Isou</td><td>+49 681 1234</td><td>[ ]</td></tr>
-    </tbody></table>
+    <tr><td>Georges</td><td>Bataille</td><td>+49 681 8901</td><td>[ ]</td></tr>
+    <tr><td>Guy</td><td>Debord</td><td>+49 681 4567</td><td>[ ]</td></tr>
+    <tr><td>Isidore</td><td>Isou</td><td>+49 681 1234</td><td>[ ]</td></tr>
+</tbody></table>
 
 
 <div class="actions">

--- a/sormas-base/pom.xml
+++ b/sormas-base/pom.xml
@@ -35,7 +35,7 @@
 		<bouncycastle.version>1.67</bouncycastle.version>
 		<keycloak.version>16.1.0</keycloak.version>
 		<resteasy.version>3.15.1.Final</resteasy.version>
-		<xdocreport.version>2.0.2</xdocreport.version>
+		<xdocreport.version>2.0.3</xdocreport.version>
 		<docx4j.version>8.3.1</docx4j.version>
 		<archunit.version>0.22.0</archunit.version>
 


### PR DESCRIPTION
- xdocreport 2.0.2 -> 2.0.3 (some breaking changes)
- velocity 1.7 -> velocity-engine-core 2.3
- commons-lang 2.6 -> removed

Initiating text templates in unit tests is broken:

```
EventDocumentFacadeEjbTest.generateEventHandoutTest

org.apache.velocity.exception.ResourceNotFoundException: Unable to find resource 'EventHandout.html'
	at org.apache.velocity.runtime.resource.ResourceManagerImpl.loadResource(ResourceManagerImpl.java:465)
	at org.apache.velocity.runtime.resource.ResourceManagerImpl.getResource(ResourceManagerImpl.java:346)
	at org.apache.velocity.runtime.RuntimeInstance.getTemplate(RuntimeInstance.java:1677)
	at org.apache.velocity.runtime.RuntimeInstance.getTemplate(RuntimeInstance.java:1656)
	at org.apache.velocity.runtime.RuntimeSingleton.getTemplate(RuntimeSingleton.java:286)
	at de.symeda.sormas.backend.docgeneration.TemplateEngine.getFieldExtractorTxt(TemplateEngine.java:225)
	at de.symeda.sormas.backend.docgeneration.TemplateEngine.extractTemplateVariablesTxt(TemplateEngine.java:110)
	at de.symeda.sormas.backend.docgeneration.DocumentTemplateFacadeEjb.getTemplateVariablesTxt(DocumentTemplateFacadeEjb.java:366)
	at de.symeda.sormas.backend.docgeneration.DocumentTemplateFacadeEjb.generateDocumentTxtFromEntities(DocumentTemplateFacadeEjb.java:171)
	at de.symeda.sormas.backend.docgeneration.DocumentTemplateFacadeEjb$DocumentTemplateFacadeEjbLocal$Proxy$_$$_WeldSubclass.generateDocumentTxtFromEntities(Unknown Source)
```

<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->