### PR TITLE
#7978: h2database update

### DIFF
--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/AbstractBeanTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/AbstractBeanTest.java
@@ -244,8 +244,6 @@ public abstract class AbstractBeanTest extends BaseBeanTest {
 		em.getTransaction().begin();
 		Query nativeQuery = em.createNativeQuery("CREATE ALIAS similarity FOR \"de.symeda.sormas.backend.H2Function.similarity\"");
 		nativeQuery.executeUpdate();
-		nativeQuery = em.createNativeQuery("CREATE ALIAS array_to_string FOR \"de.symeda.sormas.backend.H2Function.array_to_string\"");
-		nativeQuery.executeUpdate();
 		nativeQuery = em.createNativeQuery("CREATE ALIAS date_part FOR \"de.symeda.sormas.backend.H2Function.date_part\"");
 		nativeQuery.executeUpdate();
 		nativeQuery = em.createNativeQuery("CREATE ALIAS epi_week FOR \"de.symeda.sormas.backend.H2Function.epi_week\"");
@@ -257,8 +255,6 @@ public abstract class AbstractBeanTest extends BaseBeanTest {
 		nativeQuery = em.createNativeQuery("CREATE ALIAS set_limit FOR \"de.symeda.sormas.backend.H2Function.set_limit\"");
 		nativeQuery.executeUpdate();
 		nativeQuery = em.createNativeQuery("CREATE ALIAS date FOR \"de.symeda.sormas.backend.H2Function.date\"");
-		nativeQuery.executeUpdate();
-		nativeQuery = em.createNativeQuery("CREATE TYPE \"JSONB\" AS other;");
 		nativeQuery.executeUpdate();
 		em.getTransaction().commit();
 	}

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/ExtendedH2Dialect.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/ExtendedH2Dialect.java
@@ -1,12 +1,8 @@
 package de.symeda.sormas.backend;
 
-import java.sql.Types;
-
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.dialect.function.SQLFunctionTemplate;
 import org.hibernate.dialect.function.StandardSQLFunction;
-
-import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 import org.hibernate.type.StandardBasicTypes;
 
 public class ExtendedH2Dialect extends H2Dialect {
@@ -15,7 +11,6 @@ public class ExtendedH2Dialect extends H2Dialect {
 	public final static String WINDOW_FIRST_VALUE_DESC = "window_first_value_desc";
 	public final static String WINDOW_COUNT = "window_count";
 
-	public final static String ARRAY_TO_STRING = "array_to_string";
 	public final static String ARRAY_AGG = "array_agg";
 	public final static String CONCAT_FUNCTION = "concat_function";
 	public final static String GREATEST = "greatest";
@@ -24,10 +19,8 @@ public class ExtendedH2Dialect extends H2Dialect {
 		super();
 		// needed because of hibernate bug: https://hibernate.atlassian.net/browse/HHH-11938
 		registerFunction("regexp_replace", new StandardSQLFunction("regexp_replace"));
-		registerFunction(ARRAY_TO_STRING, new StandardSQLFunction(ARRAY_TO_STRING));
 		registerFunction(CONCAT_FUNCTION, new StandardSQLFunction("concat"));
 		registerFunction(ARRAY_AGG, new StandardSQLFunction(ARRAY_AGG));
-		registerHibernateType(Types.OTHER, JsonBinaryType.class.getName());
 		// The function unaccent is specific to PostgreSQL
 		// With H2 let's make sure it wont fail by making the function "unaccent" do nothing
 		registerFunction(UNACCENT, new SQLFunctionTemplate(StandardBasicTypes.STRING, "?1"));

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/H2Function.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/H2Function.java
@@ -1,6 +1,5 @@
 package de.symeda.sormas.backend;
 
-import java.util.Arrays;
 import java.util.Date;
 
 import de.symeda.sormas.api.utils.DateHelper;
@@ -13,10 +12,6 @@ public class H2Function {
 
 	public static float similarity(String a, String b) {
 		return a.equalsIgnoreCase(b) ? 1 : 0;
-	}
-
-	public static String array_to_string(String[] array, String delimiter) {
-		return array != null ? String.join(delimiter, Arrays.asList(array)) : null;
 	}
 
 	public static long date_part(String part, Date date) {

--- a/sormas-base/pom.xml
+++ b/sormas-base/pom.xml
@@ -761,7 +761,7 @@
 			<dependency>
 				<groupId>com.h2database</groupId>
 				<artifactId>h2</artifactId>
-				<version>1.4.200</version>
+				<version>2.1.210</version>
 				<scope>test</scope>
 				<!-- In-memory-database for bean-test -->
 				<!-- better compatibility to PostgreSQL than HSQLDB -->

--- a/sormas-ui/src/test/java/de/symeda/sormas/ui/AbstractBeanTest.java
+++ b/sormas-ui/src/test/java/de/symeda/sormas/ui/AbstractBeanTest.java
@@ -40,9 +40,7 @@ import com.opencsv.CSVReader;
 
 import de.symeda.sormas.api.Disease;
 import de.symeda.sormas.api.Language;
-import de.symeda.sormas.api.caze.CaseFacade;
 import de.symeda.sormas.api.caze.caseimport.CaseImportFacade;
-import de.symeda.sormas.api.contact.ContactFacade;
 import de.symeda.sormas.api.event.EventFacade;
 import de.symeda.sormas.api.event.EventParticipantFacade;
 import de.symeda.sormas.api.i18n.I18nProperties;
@@ -105,8 +103,6 @@ public abstract class AbstractBeanTest extends BaseBeanTest {
 		EntityManager em = getEntityManager();
 		em.getTransaction().begin();
 		Query nativeQuery = em.createNativeQuery("CREATE ALIAS similarity FOR \"de.symeda.sormas.ui.H2Function.similarity\"");
-		nativeQuery.executeUpdate();
-		nativeQuery = em.createNativeQuery("CREATE ALIAS array_to_string FOR \"de.symeda.sormas.ui.H2Function.array_to_string\"");
 		nativeQuery.executeUpdate();
 		nativeQuery = em.createNativeQuery("CREATE ALIAS similarity_operator FOR \"de.symeda.sormas.ui.H2Function.similarity_operator\"");
 		nativeQuery.executeUpdate();

--- a/sormas-ui/src/test/java/de/symeda/sormas/ui/ExtendedH2Dialect.java
+++ b/sormas-ui/src/test/java/de/symeda/sormas/ui/ExtendedH2Dialect.java
@@ -7,7 +7,6 @@ import org.hibernate.type.StandardBasicTypes;
 
 public class ExtendedH2Dialect extends H2Dialect {
 
-	public final static String ARRAY_TO_STRING = "array_to_string";
 	public final static String ARRAY_AGG = "array_agg";
 	public final static String CONCAT_FUNCTION = "concat_function";
 	public final static String UNACCENT = "unaccent";
@@ -20,7 +19,6 @@ public class ExtendedH2Dialect extends H2Dialect {
 		super();
 		// needed because of hibernate bug: https://hibernate.atlassian.net/browse/HHH-11938
 		registerFunction("regexp_replace", new StandardSQLFunction("regexp_replace"));
-		registerFunction(ARRAY_TO_STRING, new StandardSQLFunction(ARRAY_TO_STRING));
 		registerFunction(CONCAT_FUNCTION, new StandardSQLFunction("concat"));
 		registerFunction(ARRAY_AGG, new StandardSQLFunction(ARRAY_AGG));
 		registerFunction(ILIKE, new SQLFunctionTemplate(StandardBasicTypes.BOOLEAN, "?1 ILIKE ?2"));

--- a/sormas-ui/src/test/java/de/symeda/sormas/ui/H2Function.java
+++ b/sormas-ui/src/test/java/de/symeda/sormas/ui/H2Function.java
@@ -1,6 +1,5 @@
 package de.symeda.sormas.ui;
 
-import java.util.Arrays;
 import java.util.Date;
 
 import de.symeda.sormas.api.utils.DateHelper;
@@ -16,10 +15,6 @@ public class H2Function {
 
 	public static boolean similarity_operator(String a, String b) {
 		return a.equalsIgnoreCase(b) ? true : false;
-	}
-
-	public static String array_to_string(String[] array, String delimiter) {
-		return array != null ? String.join(delimiter, Arrays.asList(array)) : null;
 	}
 
 	public static double set_limit(Double limit) {


### PR DESCRIPTION
WIP: Still broken tests.

<details>
<summary>JdbcSQLSyntaxErrorException: Values of types "BOOLEAN" and "INTEGER" are not comparable</summary>

```

javax.persistence.PersistenceException: org.hibernate.exception.SQLGrammarException: could not prepare statement
	at org.hibernate.internal.ExceptionConverterImpl.convert(ExceptionConverterImpl.java:154)
	at org.hibernate.query.internal.AbstractProducedQuery.list(AbstractProducedQuery.java:1602)
	at org.hibernate.query.Query.getResultList(Query.java:165)
	at org.hibernate.query.criteria.internal.compile.CriteriaQueryTypeQueryAdapter.getResultList(CriteriaQueryTypeQueryAdapter.java:76)
	at de.symeda.sormas.backend.user.UserService.getInformantsOfFacility(UserService.java:323)
	at de.symeda.sormas.backend.user.UserService$Proxy$_$$_WeldSubclass.getInformantsOfFacility(Unknown Source)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.jboss.weld.interceptor.proxy.SimpleInterceptionChain.interceptorChainCompleted(SimpleInterceptionChain.java:52)
	at org.jboss.weld.interceptor.chain.AbstractInterceptionChain.invokeNextInterceptor(AbstractInterceptionChain.java:83)
	at org.jboss.weld.interceptor.proxy.InterceptorInvocationContext.proceed(InterceptorInvocationContext.java:146)
	at info.novatec.beantest.transactions.TransactionalInterceptor.manageTransaction(TransactionalInterceptor.java:81)
	at jdk.internal.reflect.GeneratedMethodAccessor46.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.jboss.weld.interceptor.proxy.SimpleMethodInvocation.invoke(SimpleMethodInvocation.java:30)
	at org.jboss.weld.interceptor.chain.AbstractInterceptionChain.invokeNext(AbstractInterceptionChain.java:103)
	at org.jboss.weld.interceptor.chain.AbstractInterceptionChain.invokeNextInterceptor(AbstractInterceptionChain.java:81)
	at org.jboss.weld.interceptor.proxy.InterceptorMethodHandler.executeInterception(InterceptorMethodHandler.java:48)
	at org.jboss.weld.interceptor.proxy.InterceptorMethodHandler.invoke(InterceptorMethodHandler.java:41)
	at org.jboss.weld.bean.proxy.CombinedInterceptorAndDecoratorStackMethodHandler.invoke(CombinedInterceptorAndDecoratorStackMethodHandler.java:53)
	at de.symeda.sormas.backend.user.UserService$Proxy$_$$_WeldSubclass.getInformantsOfFacility(Unknown Source)
	at de.symeda.sormas.backend.user.UserService$Proxy$_$$_WeldClientProxy.getInformantsOfFacility(Unknown Source)
	at de.symeda.sormas.backend.caze.CaseFacadeEjb.setResponsibleSurveillanceOfficer(CaseFacadeEjb.java:2034)
	at de.symeda.sormas.backend.caze.CaseFacadeEjb$CaseFacadeEjbLocal$Proxy$_$$_WeldSubclass.setResponsibleSurveillanceOfficer(Unknown Source)
	at de.symeda.sormas.backend.caze.CaseFacadeEjb.onCaseChanged(CaseFacadeEjb.java:1801)
	at de.symeda.sormas.backend.caze.CaseFacadeEjb$CaseFacadeEjbLocal$Proxy$_$$_WeldSubclass.onCaseChanged(Unknown Source)
	at de.symeda.sormas.backend.caze.CaseFacadeEjb.doSave(CaseFacadeEjb.java:1523)
	at de.symeda.sormas.backend.caze.CaseFacadeEjb.caseSave(CaseFacadeEjb.java:1508)
	at de.symeda.sormas.backend.caze.CaseFacadeEjb.save(CaseFacadeEjb.java:1482)
	at de.symeda.sormas.backend.caze.CaseFacadeEjb$CaseFacadeEjbLocal$Proxy$_$$_WeldSubclass.save(Unknown Source)
	at de.symeda.sormas.backend.caze.CaseFacadeEjb.save(CaseFacadeEjb.java:1350)
	at de.symeda.sormas.backend.caze.CaseFacadeEjb$CaseFacadeEjbLocal$Proxy$_$$_WeldSubclass.save(Unknown Source)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
...
	at org.hibernate.query.internal.AbstractProducedQuery.list(AbstractProducedQuery.java:1593)
	... 84 more
Caused by: org.h2.jdbc.JdbcSQLSyntaxErrorException: Werte des Typs "BOOLEAN" und "INTEGER" sind nicht vergleichbar
Values of types "BOOLEAN" and "INTEGER" are not comparable; SQL statement:
select distinct user0_.id as id1_69_, user0_.changeDate as changeda2_69_, user0_.creationDate as creation3_69_, user0_.uuid as uuid4_69_, user0_.active as active5_69_, user0_.address_id as address17_69_, user0_.associatedOfficer_id as associa18_69_, user0_.community_id as communi19_69_, user0_.district_id as distric20_69_, user0_.firstName as firstnam6_69_, user0_.hasConsentedToGdpr as hasconse7_69_, user0_.healthFacility_id as healthf21_69_, user0_.jurisdictionLevel as jurisdic8_69_, user0_.laboratory_id as laborat22_69_, user0_.language as language9_69_, user0_.lastName as lastnam10_69_, user0_.limitedDisease as limited11_69_, user0_.password as passwor12_69_, user0_.phone as phone13_69_, user0_.pointOfEntry_id as pointof23_69_, user0_.region_id as region_24_69_, user0_.seed as seed14_69_, user0_.userEmail as userema15_69_, user0_.userName as usernam16_69_ from users user0_ left outer join users_userroles userroles1_ on user0_.id=userroles1_.user_id where user0_.active=1 and user0_.healthFacility_id=? and (userroles1_.userrole in (?)) [90110-210]
	at org.h2.message.DbException.getJdbcSQLException(DbException.java:651)
	at org.h2.message.DbException.getJdbcSQLException(DbException.java:496)
	at org.h2.message.DbException.get(DbException.java:227)
	at org.h2.value.TypeInfo.checkComparable(TypeInfo.java:724)
	at org.h2.expression.condition.Comparison.optimize(Comparison.java:159)
	at org.h2.expression.condition.ConditionAndOr.optimize(ConditionAndOr.java:136)
	at org.h2.expression.condition.ConditionAndOr.optimize(ConditionAndOr.java:136)
	at org.h2.expression.Expression.optimizeCondition(Expression.java:148)
	at org.h2.command.query.Select.prepare(Select.java:1184)
	at org.h2.command.Parser.prepareCommand(Parser.java:557)
	at org.h2.engine.SessionLocal.prepareLocal(SessionLocal.java:615)
	at org.h2.engine.SessionLocal.prepareCommand(SessionLocal.java:553)
	at org.h2.jdbc.JdbcConnection.prepareCommand(JdbcConnection.java:1116)
	at org.h2.jdbc.JdbcPreparedStatement.<init>(JdbcPreparedStatement.java:92)
	at org.h2.jdbc.JdbcConnection.prepareStatement(JdbcConnection.java:288)
	at org.hibernate.engine.jdbc.internal.StatementPreparerImpl$5.doPrepare(StatementPreparerImpl.java:149)
	at org.hibernate.engine.jdbc.internal.StatementPreparerImpl$StatementPreparationTemplate.prepareStatement(StatementPreparerImpl.java:176)
	... 100 more
```

</details>

<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->