### PR TITLE
Rebased tests for SORQA-69

### DIFF
--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/LoginSteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/LoginSteps.java
@@ -29,6 +29,7 @@ import org.sormas.e2etests.envconfig.dto.EnvUser;
 import org.sormas.e2etests.envconfig.manager.EnvironmentManager;
 import org.sormas.e2etests.helpers.WebDriverHelpers;
 import org.sormas.e2etests.pages.application.LoginPage;
+import org.sormas.e2etests.pages.application.NavBarPage;
 import org.sormas.e2etests.pages.application.dashboard.Surveillance.SurveillanceDashboardPage;
 import org.sormas.e2etests.steps.BaseSteps;
 
@@ -100,6 +101,13 @@ public class LoginSteps implements En {
           webDriverHelpers.clickOnWebElementBySelector(LoginPage.LOGIN_BUTTON);
           webDriverHelpers.waitForPageLoaded();
           webDriverHelpers.waitUntilIdentifiedElementIsVisibleAndClickable(LOGOUT_BUTTON, 50);
+        });
+
+    When(
+        "I check that German word for Configuration is present in the left main menu",
+        () -> {
+          webDriverHelpers.checkWebElementContainsText(
+              NavBarPage.CONFIGURATION_BUTTON, "Einstellungen");
         });
   }
 }

--- a/sormas-e2e-tests/src/test/resources/features/sanity/web/Login.feature
+++ b/sormas-e2e-tests/src/test/resources/features/sanity/web/Login.feature
@@ -14,3 +14,8 @@ Feature: Login with different type of users
       | Laboratory Officer        |
       | Point of Entry Supervisor |
       | Surveillance Officer      |
+
+  @issue=SORQA-69 @env_de
+  Scenario: Check German language setting
+    Given I log in with National User
+    Then I check that German word for Configuration is present in the left main menu


### PR DESCRIPTION
This includes content from https://github.com/hzi-braunschweig/SORMAS-Project/pull/8050 manually applied on top of a fresh development branch clone, due to problems with rebasing the old branches.

The only change is the suggested removal of German wording from step definition.

![image](https://user-images.githubusercontent.com/96250163/156421810-f3b37022-7c2b-4af7-ae1e-219b43ffdccf.png)