### PR TITLE
sordev 5688

### DIFF
--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/tasks/TaskManagementSteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/tasks/TaskManagementSteps.java
@@ -311,7 +311,8 @@ public class TaskManagementSteps implements En {
   }
 
   private LocalDateTime getLocalDateTimeFromColumns(String date) {
-    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("M/d/yyyy h:m a");
+    DateTimeFormatter formatter =
+        DateTimeFormatter.ofPattern("M/d/yyyy h:m a").localizedBy(Locale.GERMAN);
     try {
       return LocalDateTime.parse(date.trim(), formatter);
     } catch (Exception e) {

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/tasks/TaskManagementSteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/tasks/TaskManagementSteps.java
@@ -311,8 +311,7 @@ public class TaskManagementSteps implements En {
   }
 
   private LocalDateTime getLocalDateTimeFromColumns(String date) {
-    DateTimeFormatter formatter =
-        DateTimeFormatter.ofPattern("M/d/yyyy h:m a").localizedBy(Locale.GERMAN);
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("M/d/yyyy h:m a");
     try {
       return LocalDateTime.parse(date.trim(), formatter);
     } catch (Exception e) {

--- a/sormas-e2e-tests/src/test/resources/features/sanity/web/TaskManagementFilter.feature
+++ b/sormas-e2e-tests/src/test/resources/features/sanity/web/TaskManagementFilter.feature
@@ -1,7 +1,7 @@
 @UI @Sanity @TaskManagementFilter
 Feature: Tasks filtering functionalities
 
-  @issue=SORDEV-5688 @env_main @ignore
+  @issue=SORDEV-5688 @env_main
   Scenario Outline: Check the filter of tasks context
     Given I log in with National User
     And I click on the Tasks button from navbar
@@ -17,7 +17,7 @@ Feature: Tasks filtering functionalities
       | Event       |
       | General     |
 
-  @issue=SORDEV-5688 @env_main @ignore
+  @issue=SORDEV-5688 @env_main
   Scenario Outline: Check the filter of tasks status
     Given I log in with National User
     And I click on the Tasks button from navbar


### PR DESCRIPTION
Razvan, that test should be not ignored. When I changed parsing for DE specific datetime test is passing. There is a bug in the Service and until developers will not fix it, the test should be red.

Bug: https://github.com/hzi-braunschweig/SORMAS-Project/issues/8019
Report after changing date time parse for DE format: https://jenkins.sormas.netzlink.com/view/SORMAS-E2eTests/job/sormas-RunE2eTests-branch/91/allure/