### PR TITLE
[#8029] add audit logging for server start

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/ConfigFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/ConfigFacade.java
@@ -143,4 +143,6 @@ public interface ConfigFacade {
 	long getImportFileSizeLimitMb();
 
 	String getAuditLoggerConfig();
+
+	String getAuditSourceSite();
 }

--- a/sormas-backend/pom.xml
+++ b/sormas-backend/pom.xml
@@ -247,6 +247,10 @@
             <artifactId>logback-core</artifactId>
 			<scope>compile</scope>
         </dependency>
+		<dependency>
+			<groupId>ca.uhn.hapi.fhir</groupId>
+			<artifactId>org.hl7.fhir.r4</artifactId>
+		</dependency>
 
     </dependencies>
 

--- a/sormas-backend/pom.xml
+++ b/sormas-backend/pom.xml
@@ -251,8 +251,13 @@
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>org.hl7.fhir.r4</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<scope>compile</scope>
+		</dependency>
 
-    </dependencies>
+	</dependencies>
 
 	<build>
 		<finalName>${project.artifactId}</finalName>

--- a/sormas-backend/pom.xml
+++ b/sormas-backend/pom.xml
@@ -252,6 +252,12 @@
 			<artifactId>org.hl7.fhir.r4</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>ca.uhn.hapi.fhir</groupId>
+			<artifactId>hapi-fhir-structures-r4</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
 			<scope>compile</scope>

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/audit/AuditLogger.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/audit/AuditLogger.java
@@ -1,3 +1,18 @@
+/*
+ * SORMAS® - Surveillance Outbreak Response Management & Analysis System
+ * Copyright © 2016-2022 Helmholtz-Zentrum für Infektionsforschung GmbH (HZI)
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package de.symeda.sormas.backend.audit;
 
 import ca.uhn.fhir.context.FhirContext;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/audit/AuditLogger.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/audit/AuditLogger.java
@@ -21,6 +21,9 @@ import de.symeda.sormas.api.ConfigFacade;
 import org.hl7.fhir.r4.model.AuditEvent;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.codesystems.AuditEntityType;
+import org.hl7.fhir.r4.model.codesystems.AuditSourceType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,8 +64,9 @@ public class AuditLogger {
 
         applicationStartAudit.setAction(AuditEvent.AuditEventAction.E);
         applicationStartAudit.setRecorded(Calendar.getInstance(TimeZone.getDefault()).getTime());
+
         // success
-        applicationStartAudit.setOutcome(AuditEvent.AuditEventOutcome.fromCode("0"));
+        applicationStartAudit.setOutcome(AuditEvent.AuditEventOutcome._0);
         applicationStartAudit.setOutcomeDesc("Application starting");
 
         AuditEvent.AuditEventAgentComponent agent = new AuditEvent.AuditEventAgentComponent();
@@ -79,10 +83,18 @@ public class AuditLogger {
             logger.error("Could not read the hostname of the machine: {}", e.toString());
         }
 
-        source.addType(new Coding("https://www.hl7.org/fhir/valueset-audit-source-type.html", "4", "Application Server"));
+        // Application Server
+        AuditSourceType auditSourceType = AuditSourceType._4;
+        source.addType(new Coding(auditSourceType.getSystem(), auditSourceType.toCode(), auditSourceType.getDisplay()));
         applicationStartAudit.setSource(source);
 
-        applicationStartAudit.addEntity();
+        AuditEvent.AuditEventEntityComponent entity = new AuditEvent.AuditEventEntityComponent();
+        entity.setWhat(new Reference("StartupShutdownService"));
+
+        // System Object
+        AuditEntityType entityType = AuditEntityType._2;
+        entity.setType(new Coding(entityType.getSystem(), entityType.toCode(), entityType.getDisplay()));
+        applicationStartAudit.addEntity(entity);
 
         accept(applicationStartAudit);
     }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/audit/AuditLogger.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/audit/AuditLogger.java
@@ -1,0 +1,67 @@
+package de.symeda.sormas.backend.audit;
+
+
+import ca.uhn.fhir.parser.IParser;
+import org.hl7.fhir.r4.model.AuditEvent;
+
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ca.uhn.fhir.context.FhirContext;
+import org.hl7.fhir.r4.model.Coding;
+
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Date;
+import java.util.TimeZone;
+
+public class AuditLogger {
+    private static AuditLogger instance;
+    private static final Logger logger = LoggerFactory.getLogger(AuditLogger.class);
+
+    private AuditLogger() {
+    }
+
+    public static synchronized AuditLogger getInstance() {
+        if (instance == null) {
+            instance = new AuditLogger();
+        }
+        return instance;
+    }
+
+    private void accept(AuditEvent event) {
+        FhirContext ctx = FhirContext.forR4();
+        IParser parser = ctx.newJsonParser();
+        String serialized = parser.encodeResourceToString(event);
+        logger.info(serialized);
+    }
+
+    public void logApplicationStart() {
+        AuditEvent applicationStartAudit = new AuditEvent();
+        applicationStartAudit.setType(new Coding("https://hl7.org/fhir/R4/valueset-audit-event-type.html", "110100", "Application Activity"));
+
+        Coding subtype = new Coding("https://hl7.org/fhir/R4/valueset-audit-event-sub-type.html", "110120", "Application Start");
+        applicationStartAudit.setSubtype(Collections.singletonList(subtype));
+
+        applicationStartAudit.setAction(AuditEvent.AuditEventAction.E);
+        applicationStartAudit.setRecorded(Calendar.getInstance(TimeZone.getDefault()).getTime());
+        // success
+        applicationStartAudit.setOutcome(AuditEvent.AuditEventOutcome.fromCode("0"));
+        applicationStartAudit.setOutcomeDesc("Application starting");
+
+        AuditEvent.AuditEventAgentComponent agent = new AuditEvent.AuditEventAgentComponent();
+        CodeableConcept codeableConcept = new CodeableConcept();
+        codeableConcept.addCoding(new Coding("https://www.hl7.org/fhir/valueset-participation-role-type.html", "110151", "Application Launcher"));
+        agent.setType(codeableConcept);
+        agent.setName("SYSTEM");
+        applicationStartAudit.setAgent(Collections.singletonList(agent));
+
+        AuditEvent.AuditEventSourceComponent source = new AuditEvent.AuditEventSourceComponent();
+        // todo source.site
+        // todo source.observer
+        source.addType(new Coding("https://www.hl7.org/fhir/valueset-audit-source-type.html", "4", "Application Server"));
+        applicationStartAudit.setSource(source);
+
+        applicationStartAudit.addEntity();
+    }
+}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/audit/AuditLogger.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/audit/AuditLogger.java
@@ -17,7 +17,6 @@ package de.symeda.sormas.backend.audit;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
-import de.symeda.sormas.api.ConfigFacade;
 import org.hl7.fhir.r4.model.AuditEvent;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
@@ -27,7 +26,6 @@ import org.hl7.fhir.r4.model.codesystems.AuditSourceType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.naming.InitialContext;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Calendar;
@@ -56,10 +54,21 @@ public class AuditLogger {
     }
 
     public void logApplicationStart() {
+        Coding subtype = new Coding("https://hl7.org/fhir/R4/valueset-audit-event-sub-type.html", "110120", "Application Start");
+        String outcomeDesc = "Application starting";
+        logApplicationLifecycle(subtype, outcomeDesc);
+    }
+
+    public void logApplicationStop() {
+        Coding subtype = new Coding("https://hl7.org/fhir/R4/valueset-audit-event-sub-type.html", "110121", "Application Stop");
+        String outcomeDesc = "Application stopping";
+        logApplicationLifecycle(subtype, outcomeDesc);
+    }
+
+    private void logApplicationLifecycle(Coding subtype, String outcomeDesc) {
         AuditEvent applicationStartAudit = new AuditEvent();
         applicationStartAudit.setType(new Coding("https://hl7.org/fhir/R4/valueset-audit-event-type.html", "110100", "Application Activity"));
 
-        Coding subtype = new Coding("https://hl7.org/fhir/R4/valueset-audit-event-sub-type.html", "110120", "Application Start");
         applicationStartAudit.setSubtype(Collections.singletonList(subtype));
 
         applicationStartAudit.setAction(AuditEvent.AuditEventAction.E);
@@ -67,7 +76,7 @@ public class AuditLogger {
 
         // success
         applicationStartAudit.setOutcome(AuditEvent.AuditEventOutcome._0);
-        applicationStartAudit.setOutcomeDesc("Application starting");
+        applicationStartAudit.setOutcomeDesc(outcomeDesc);
 
         AuditEvent.AuditEventAgentComponent agent = new AuditEvent.AuditEventAgentComponent();
         CodeableConcept codeableConcept = new CodeableConcept();

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/audit/LogSink.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/audit/LogSink.java
@@ -31,62 +31,62 @@ import java.io.File;
  * Provides a configurable log sink for the SORMAS audit trail.
  */
 public class LogSink {
-    private static final Logger logger = LoggerFactory.getLogger(LogSink.class);
-    private static LogSink instance;
 
-    private Logger auditLogger;
+	private static final Logger logger = LoggerFactory.getLogger(LogSink.class);
+	private static LogSink instance;
 
-    private LogSink(String fileName) {
-        if (fileName == null || fileName.equals("")) {
-            setupNopLogger();
-            return;
-        }
+	private Logger auditLogger;
 
-        File file = new File(fileName);
-        JoranConfigurator configurator = new JoranConfigurator();
-        LoggerContext context = new LoggerContext();
-        configurator.setContext(context);
+	private LogSink(String fileName) {
+		if (fileName == null || fileName.equals("")) {
+			setupNopLogger();
+			return;
+		}
 
-        try {
-            configurator.doConfigure(file);
-        } catch (JoranException e) {
-            logger.error("Could not setup audit logger: ", e);
-            setupNopLogger();
-            return;
-        }
-        auditLogger = context.getLogger("Audit");
-    }
+		File file = new File(fileName);
+		JoranConfigurator configurator = new JoranConfigurator();
+		LoggerContext context = new LoggerContext();
+		configurator.setContext(context);
 
-    /**
-     * Issue a warning and make audit logging a NOP
-     */
-    private void setupNopLogger() {
-        logger.warn("Audit logger is disabled! Using NOP Logger instead!");
-        auditLogger = NOPLogger.NOP_LOGGER;
-    }
+		try {
+			configurator.doConfigure(file);
+		} catch (JoranException e) {
+			logger.error("Could not setup audit logger: ", e);
+			setupNopLogger();
+			return;
+		}
+		auditLogger = context.getLogger("Audit");
+	}
 
-    public static synchronized LogSink getInstance() {
-        String configPath = null;
+	/**
+	 * Issue a warning and make audit logging a NOP
+	 */
+	private void setupNopLogger() {
+		logger.warn("Audit logger is disabled! Using NOP Logger instead!");
+		auditLogger = NOPLogger.NOP_LOGGER;
+	}
 
-        if (instance == null) {
-            // initialize
-            try {
-                ConfigFacade configFacade = (ConfigFacade) new InitialContext().lookup("java:module/ConfigFacade");
-                // happy path
-                configPath = configFacade.getAuditLoggerConfig();
-            } catch (NamingException e) {
-                // constructor in finally block will set up NOPLogger
-                logger.error("Could not lookup ConfigFacade");
-            } finally {
-                instance = new LogSink(configPath);
-            }
-        }
+	public static synchronized LogSink getInstance() {
+		String configPath = null;
 
-        return instance;
-    }
+		if (instance == null) {
+			// initialize
+			try {
+				ConfigFacade configFacade = (ConfigFacade) new InitialContext().lookup("java:module/ConfigFacade");
+				// happy path
+				configPath = configFacade.getAuditLoggerConfig();
+			} catch (NamingException e) {
+				// constructor in finally block will set up NOPLogger
+				logger.error("Could not lookup ConfigFacade");
+			} finally {
+				instance = new LogSink(configPath);
+			}
+		}
 
-    public Logger getAuditLogger() {
-        return auditLogger;
-    }
+		return instance;
+	}
+
+	public Logger getAuditLogger() {
+		return auditLogger;
+	}
 }
-

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/ConfigFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/ConfigFacadeEjb.java
@@ -158,6 +158,7 @@ public class ConfigFacadeEjb implements ConfigFacade {
 	private static final String DASHBOARD_MAP_MARKER_LIMIT = "dashboardMapMarkerLimit";
 	private static final String AUDITOR_ATTRIBUTE_LOGGING = "auditor.attribute.logging";
 	private static final String AUDIT_LOGGER_CONFIG = "audit.logger.config";
+	private static final String AUDIT_SOURCE_SITE = "audit.source.site";
 
 	private static final String CREATE_DEFAULT_ENTITIES = "createDefaultEntities";
 	private static final String SKIP_DEFAULT_PASSWORD_CHECK = "skipDefaultPasswordCheck";
@@ -689,6 +690,11 @@ public class ConfigFacadeEjb implements ConfigFacade {
 	@Override
 	public String getAuditLoggerConfig(){
 		return getProperty(AUDIT_LOGGER_CONFIG,"");
+	}
+
+	@Override
+	public String getAuditSourceSite(){
+		return getProperty(AUDIT_SOURCE_SITE,"");
 	}
 
 	@Override

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/StartupShutdownService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/StartupShutdownService.java
@@ -55,6 +55,7 @@ import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 
+import de.symeda.sormas.backend.audit.AuditLogger;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -187,6 +188,7 @@ public class StartupShutdownService {
 
 	@PostConstruct
 	public void startup() {
+		AuditLogger.getInstance().logApplicationStart();
 		checkDatabaseConfig(em);
 
 		logger.info("Initiating automatic database update of main database...");

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/StartupShutdownService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/StartupShutdownService.java
@@ -864,7 +864,7 @@ public class StartupShutdownService {
 
 	@PreDestroy
 	public void shutdown() {
-
+		AuditLogger.getInstance().logApplicationStop();
 	}
 
 	@LocalBean

--- a/sormas-base/pom.xml
+++ b/sormas-base/pom.xml
@@ -27,7 +27,6 @@
 		<!-- *** Other dependency versions *** -->
 		<glassfish.jaxb.version>2.3.3</glassfish.jaxb.version>
 		<slf4j.version>1.7.36</slf4j.version>
-		<hapifhir.version>5.7</hapifhir.version>
 		<logback.version>1.2.10</logback.version>
 		<vaadin.version.warning>TODO: Remove bootstrap.js in widgetset</vaadin.version.warning>
 		<vaadin.version>8.14.3</vaadin.version>

--- a/sormas-base/pom.xml
+++ b/sormas-base/pom.xml
@@ -27,6 +27,7 @@
 		<!-- *** Other dependency versions *** -->
 		<glassfish.jaxb.version>2.3.3</glassfish.jaxb.version>
 		<slf4j.version>1.7.36</slf4j.version>
+		<hapifhir.version>5.7</hapifhir.version>
 		<logback.version>1.2.10</logback.version>
 		<vaadin.version.warning>TODO: Remove bootstrap.js in widgetset</vaadin.version.warning>
 		<vaadin.version>8.14.3</vaadin.version>
@@ -584,6 +585,13 @@
 				<version>${slf4j.version}</version>
 				<scope>provided</scope>
 			</dependency>
+			<dependency>
+				<groupId>ca.uhn.hapi.fhir</groupId>
+				<artifactId>hapi-fhir-structures-r4</artifactId>
+				<version>5.7.0</version>
+				<scope>runtime</scope>
+			</dependency>
+
 			<!-- *** Domain libs END *** -->
 
 			<!-- *** Compile dependencies *** -->

--- a/sormas-base/pom.xml
+++ b/sormas-base/pom.xml
@@ -584,10 +584,15 @@
 				<version>${slf4j.version}</version>
 				<scope>provided</scope>
 			</dependency>
-
 			<!-- *** Domain libs END *** -->
 
 			<!-- *** Compile dependencies *** -->
+			<dependency>
+				<groupId>ca.uhn.hapi.fhir</groupId>
+				<artifactId>org.hl7.fhir.r4</artifactId>
+				<version>5.6.36</version>
+				<scope>compile</scope>
+			</dependency>
 
 			<dependency>
 				<groupId>com.googlecode.libphonenumber</groupId>

--- a/sormas-base/setup/sormas.properties
+++ b/sormas-base/setup/sormas.properties
@@ -171,6 +171,11 @@ app.url=
 # Possible Values: any valid filesystem path, but prefer /opt/config/audit-logback.xml
 #audit.logger.config=
 
+# Identifies the SORMAS instance in the audit log
+# Default: ""
+# Possible Values: Any identifier, but prefer the hostname
+#audit.source.site=
+
 # Replacement for empty variables in generated documents.
 # Default: ./.
 #docgeneration.nullReplacement=./.


### PR DESCRIPTION
Fixes #8029 

```json
{
  "resourceType": "AuditEvent",
  "type": {
    "system": "https://hl7.org/fhir/R4/valueset-audit-event-type.html",
    "code": "110100",
    "display": "Application Activity"
  },
  "subtype": [
    {
      "system": "https://hl7.org/fhir/R4/valueset-audit-event-sub-type.html",
      "code": "110120",
      "display": "Application Start"
    }
  ],
  "action": "E",
  "recorded": "2022-03-10T13:21:46.875+01:00",
  "outcome": "0",
  "outcomeDesc": "Application starting",
  "agent": [
    {
      "type": {
        "coding": [
          {
            "system": "https://www.hl7.org/fhir/valueset-participation-role-type.html",
            "code": "110151",
            "display": "Application Launcher"
          }
        ]
      },
      "name": "SYSTEM"
    }
  ],
  "source": {
    "site": "sormas_b",
    "type": [
      {
        "system": "http://terminology.hl7.org/CodeSystem/security-source-type",
        "code": "4",
        "display": "Application Server"
      }
    ]
  },
  "entity": [
    {
      "what": {
        "reference": "StartupShutdownService"
      },
      "type": {
        "system": "http://terminology.hl7.org/CodeSystem/audit-entity-type",
        "code": "2",
        "display": "System Object"
      }
    }
  ]
}
```