### PR TITLE
#7844 hide paper form reception dates for specific countries in UI an…

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/caze/CaseDataDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/caze/CaseDataDto.java
@@ -15,6 +15,7 @@
 
 package de.symeda.sormas.api.caze;
 
+import static de.symeda.sormas.api.CountryHelper.COUNTRY_CODE_FRANCE;
 import static de.symeda.sormas.api.CountryHelper.COUNTRY_CODE_GERMANY;
 import static de.symeda.sormas.api.CountryHelper.COUNTRY_CODE_SWITZERLAND;
 import static de.symeda.sormas.api.utils.FieldConstraints.CHARACTER_LIMIT_BIG;
@@ -251,9 +252,21 @@ public class CaseDataDto extends SormasToSormasShareableDto {
 	@Outbreaks
 	@Required
 	private UserReferenceDto reportingUser;
+	@HideForCountries(countries = {
+		COUNTRY_CODE_FRANCE,
+		COUNTRY_CODE_GERMANY,
+		COUNTRY_CODE_SWITZERLAND })
 	private Date regionLevelDate;
+	@HideForCountries(countries = {
+		COUNTRY_CODE_FRANCE,
+		COUNTRY_CODE_GERMANY,
+		COUNTRY_CODE_SWITZERLAND })
 	private Date nationalLevelDate;
 	@Outbreaks
+	@HideForCountries(countries = {
+		COUNTRY_CODE_FRANCE,
+		COUNTRY_CODE_GERMANY,
+		COUNTRY_CODE_SWITZERLAND })
 	private Date districtLevelDate;
 	@Outbreaks
 	@Required

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/CaseDataForm.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/CaseDataForm.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import de.symeda.sormas.api.ConfigFacade;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -1248,9 +1249,11 @@ public class CaseDataForm extends AbstractEditForm<CaseDataDto> {
 			}
 		}
 
-		Label paperFormDatesLabel = new Label(I18nProperties.getString(Strings.headingPaperFormDates));
-		paperFormDatesLabel.addStyleName(H3);
-		getContent().addComponent(paperFormDatesLabel, PAPER_FORM_DATES_LOC);
+		if (shouldShowPaperFormDates()) {
+			Label paperFormDatesLabel = new Label(I18nProperties.getString(Strings.headingPaperFormDates));
+			paperFormDatesLabel.addStyleName(H3);
+			getContent().addComponent(paperFormDatesLabel, PAPER_FORM_DATES_LOC);
+		}
 
 		// Automatic case classification rules button - invisible for other diseases
 		DiseaseClassificationCriteriaDto diseaseClassificationCriteria = FacadeProvider.getCaseClassificationFacade().getByDisease(disease);
@@ -1751,9 +1754,7 @@ public class CaseDataForm extends AbstractEditForm<CaseDataDto> {
 
 	@Override
 	protected String createHtmlLayout() {
-		return MAIN_HTML_LAYOUT
-			+ (caseFollowUpEnabled ? FOLLOWUP_LAYOUT : "")
-			+ PAPER_FORM_DATES_AND_HEALTH_CONDITIONS_HTML_LAYOUT;
+		return MAIN_HTML_LAYOUT + (caseFollowUpEnabled ? FOLLOWUP_LAYOUT : "") + PAPER_FORM_DATES_AND_HEALTH_CONDITIONS_HTML_LAYOUT;
 	}
 
 	private void setEpidNumberError(TextField epidField, Button assignNewEpidNumberButton, Label epidNumberWarningLabel, String fieldValue) {
@@ -1776,6 +1777,12 @@ public class CaseDataForm extends AbstractEditForm<CaseDataDto> {
 					&& !CaseLogic.isEpidNumberPrefix(fieldValue)
 					&& !CaseLogic.isCompleteEpidNumber(fieldValue));
 		}
+	}
+
+	private boolean shouldShowPaperFormDates() {
+		return FacadeProvider.getConfigFacade().isConfiguredCountry(CountryHelper.COUNTRY_CODE_FRANCE)
+			&& FacadeProvider.getConfigFacade().isConfiguredCountry(CountryHelper.COUNTRY_CODE_GERMANY)
+			&& FacadeProvider.getConfigFacade().isConfiguredCountry(CountryHelper.COUNTRY_CODE_SWITZERLAND);
 	}
 
 	private static class DiseaseChangeListener implements ValueChangeListener {


### PR DESCRIPTION
…d Dto

<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #7844 

I created a larger commit to hide the fields in the data protection dictionary, but this was covered with https://github.com/hzi-braunschweig/SORMAS-Project/pull/8307 yesterday. So I removed it.