### PR TITLE
#7986 - ['Create new sample' form] Hide specific enum values based on…

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/sample/SampleDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/sample/SampleDto.java
@@ -66,7 +66,6 @@ public class SampleDto extends SormasToSormasShareableDto {
 	public static final String PATHOGEN_TESTING_REQUESTED = "pathogenTestingRequested";
 	public static final String ADDITIONAL_TESTING_REQUESTED = "additionalTestingRequested";
 	public static final String REQUESTED_PATHOGEN_TESTS = "requestedPathogenTests";
-	public static final String REQUESTED_PATHOGEN_TESTS_FILTERED = "requestedPathogenTestsFiltered";
 	public static final String REQUESTED_ADDITIONAL_TESTS = "requestedAdditionalTests";
 	public static final String PATHOGEN_TEST_RESULT = "pathogenTestResult";
 	public static final String REQUESTED_OTHER_PATHOGEN_TESTS = "requestedOtherPathogenTests";
@@ -132,7 +131,6 @@ public class SampleDto extends SormasToSormasShareableDto {
 	private Boolean pathogenTestingRequested;
 	private Boolean additionalTestingRequested;
 	private Set<PathogenTestType> requestedPathogenTests;
-	private PathogenTestType requestedPathogenTestsFiltered;
 	private Set<AdditionalTestType> requestedAdditionalTests;
 	@Size(max = FieldConstraints.CHARACTER_LIMIT_DEFAULT, message = Validations.textTooLong)
 	private String requestedOtherPathogenTests;
@@ -370,16 +368,6 @@ public class SampleDto extends SormasToSormasShareableDto {
 	}
 
 	@ImportIgnore
-	public PathogenTestType getRequestedPathogenTestsFiltered() {
-		return requestedPathogenTestsFiltered;
-	}
-
-	public void setRequestedPathogenTestsFiltered(PathogenTestType requestedPathogenTestsFiltered) {
-		this.requestedPathogenTestsFiltered = requestedPathogenTestsFiltered;
-	}
-
-
-	@ImportIgnore
 	public Set<AdditionalTestType> getRequestedAdditionalTests() {
 		return requestedAdditionalTests;
 	}
@@ -492,7 +480,6 @@ public class SampleDto extends SormasToSormasShareableDto {
 		target.setPathogenTestingRequested(source.getPathogenTestingRequested());
 		target.setAdditionalTestingRequested(source.getAdditionalTestingRequested());
 		target.setRequestedPathogenTests(source.getRequestedPathogenTests());
-		target.setRequestedPathogenTestsFiltered(source.getRequestedPathogenTestsFiltered());
 		target.setRequestedAdditionalTests(source.getRequestedAdditionalTests());
 		target.setFieldSampleID(source.getFieldSampleID());
 		target.setSamplingReason(source.getSamplingReason());

--- a/sormas-api/src/main/java/de/symeda/sormas/api/sample/SampleDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/sample/SampleDto.java
@@ -66,6 +66,7 @@ public class SampleDto extends SormasToSormasShareableDto {
 	public static final String PATHOGEN_TESTING_REQUESTED = "pathogenTestingRequested";
 	public static final String ADDITIONAL_TESTING_REQUESTED = "additionalTestingRequested";
 	public static final String REQUESTED_PATHOGEN_TESTS = "requestedPathogenTests";
+	public static final String REQUESTED_PATHOGEN_TESTS_FILTERED = "requestedPathogenTestsFiltered";
 	public static final String REQUESTED_ADDITIONAL_TESTS = "requestedAdditionalTests";
 	public static final String PATHOGEN_TEST_RESULT = "pathogenTestResult";
 	public static final String REQUESTED_OTHER_PATHOGEN_TESTS = "requestedOtherPathogenTests";
@@ -131,6 +132,7 @@ public class SampleDto extends SormasToSormasShareableDto {
 	private Boolean pathogenTestingRequested;
 	private Boolean additionalTestingRequested;
 	private Set<PathogenTestType> requestedPathogenTests;
+	private PathogenTestType requestedPathogenTestsFiltered;
 	private Set<AdditionalTestType> requestedAdditionalTests;
 	@Size(max = FieldConstraints.CHARACTER_LIMIT_DEFAULT, message = Validations.textTooLong)
 	private String requestedOtherPathogenTests;
@@ -367,6 +369,16 @@ public class SampleDto extends SormasToSormasShareableDto {
 		this.requestedPathogenTests = requestedPathogenTests;
 	}
 
+	public PathogenTestType getRequestedPathogenTestsFiltered() {
+		return requestedPathogenTestsFiltered;
+	}
+
+	@ImportIgnore
+	public void setRequestedPathogenTestsFiltered(PathogenTestType requestedPathogenTestsFiltered) {
+		this.requestedPathogenTestsFiltered = requestedPathogenTestsFiltered;
+	}
+
+
 	@ImportIgnore
 	public Set<AdditionalTestType> getRequestedAdditionalTests() {
 		return requestedAdditionalTests;
@@ -480,6 +492,7 @@ public class SampleDto extends SormasToSormasShareableDto {
 		target.setPathogenTestingRequested(source.getPathogenTestingRequested());
 		target.setAdditionalTestingRequested(source.getAdditionalTestingRequested());
 		target.setRequestedPathogenTests(source.getRequestedPathogenTests());
+		target.setRequestedPathogenTestsFiltered(source.getRequestedPathogenTestsFiltered());
 		target.setRequestedAdditionalTests(source.getRequestedAdditionalTests());
 		target.setFieldSampleID(source.getFieldSampleID());
 		target.setSamplingReason(source.getSamplingReason());

--- a/sormas-api/src/main/java/de/symeda/sormas/api/sample/SampleDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/sample/SampleDto.java
@@ -369,11 +369,11 @@ public class SampleDto extends SormasToSormasShareableDto {
 		this.requestedPathogenTests = requestedPathogenTests;
 	}
 
+	@ImportIgnore
 	public PathogenTestType getRequestedPathogenTestsFiltered() {
 		return requestedPathogenTestsFiltered;
 	}
 
-	@ImportIgnore
 	public void setRequestedPathogenTestsFiltered(PathogenTestType requestedPathogenTestsFiltered) {
 		this.requestedPathogenTestsFiltered = requestedPathogenTestsFiltered;
 	}

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/samples/AbstractSampleForm.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/samples/AbstractSampleForm.java
@@ -356,10 +356,11 @@ public abstract class AbstractSampleForm extends AbstractEditForm<SampleDto> {
 		additionalTestingRequestedField.addValueChangeListener(e -> updateRequestedTestFields());
 
 		// CheckBox groups to select the requested pathogen/additional tests
+		ComboBox comboBox = addField(SampleDto.REQUESTED_PATHOGEN_TESTS_FILTERED, ComboBox.class);
 		OptionGroup requestedPathogenTestsField = addField(SampleDto.REQUESTED_PATHOGEN_TESTS, OptionGroup.class);
 		CssStyles.style(requestedPathogenTestsField, CssStyles.OPTIONGROUP_CHECKBOXES_HORIZONTAL);
 		requestedPathogenTestsField.setMultiSelect(true);
-		requestedPathogenTestsField.addItems((Object[]) PathogenTestType.values());
+		requestedPathogenTestsField.addItems(comboBox.getItemIds());
 		requestedPathogenTestsField.removeItem(PathogenTestType.OTHER);
 		requestedPathogenTestsField.setCaption(null);
 

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/samples/AbstractSampleForm.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/samples/AbstractSampleForm.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.vaadin.ui.CssLayout;
 import com.vaadin.ui.Label;
@@ -356,11 +357,13 @@ public abstract class AbstractSampleForm extends AbstractEditForm<SampleDto> {
 		additionalTestingRequestedField.addValueChangeListener(e -> updateRequestedTestFields());
 
 		// CheckBox groups to select the requested pathogen/additional tests
-		ComboBox comboBox = addField(SampleDto.REQUESTED_PATHOGEN_TESTS_FILTERED, ComboBox.class);
 		OptionGroup requestedPathogenTestsField = addField(SampleDto.REQUESTED_PATHOGEN_TESTS, OptionGroup.class);
 		CssStyles.style(requestedPathogenTestsField, CssStyles.OPTIONGROUP_CHECKBOXES_HORIZONTAL);
 		requestedPathogenTestsField.setMultiSelect(true);
-		requestedPathogenTestsField.addItems(comboBox.getItemIds());
+		requestedPathogenTestsField.addItems(
+				Arrays.stream(PathogenTestType.values())
+						.filter( c -> fieldVisibilityCheckers.isVisible(PathogenTestType.class, c.name()))
+						.collect(Collectors.toList()));
 		requestedPathogenTestsField.removeItem(PathogenTestType.OTHER);
 		requestedPathogenTestsField.setCaption(null);
 


### PR DESCRIPTION
… the related disease

Problem consist in @Diseases annotation which cannot filter a Set of enum.
Due to that, was added an intermediate variable which took the filtered disease value.
This filtered disease value is assigned to needed components.

Fixes #7986