### PR TITLE
#7705: Avoid no valid EE environment

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/auditlog/api/Auditor.java
+++ b/sormas-backend/src/main/java/de/symeda/auditlog/api/Auditor.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.SortedMap;
 
 import javax.persistence.Embedded;
+import javax.transaction.TransactionScoped;
 
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -50,17 +51,22 @@ import de.symeda.sormas.api.HasUuid;
  * @author Oliver Milke
  * @since 13.01.2016
  */
+@TransactionScoped
 public class Auditor implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 
-	private final boolean auditorAttributeLoggingEnabled;
+	private boolean auditorAttributeLoggingEnabled;
 
 	public Auditor() {
 		this.auditorAttributeLoggingEnabled = true;
 	}
 
-	public Auditor(boolean auditorAttributeLoggingEnabled) {
+	public boolean isAuditorAttributeLoggingEnabled() {
+		return auditorAttributeLoggingEnabled;
+	}
+
+	public void setAuditorAttributeLoggingEnabled(boolean auditorAttributeLoggingEnabled) {
 		this.auditorAttributeLoggingEnabled = auditorAttributeLoggingEnabled;
 	}
 

--- a/sormas-backend/src/main/java/de/symeda/auditlog/api/TransactionId.java
+++ b/sormas-backend/src/main/java/de/symeda/auditlog/api/TransactionId.java
@@ -20,12 +20,15 @@ package de.symeda.auditlog.api;
 import java.io.Serializable;
 import java.util.Date;
 
+import javax.transaction.TransactionScoped;
+
 /**
  * Identifies the transaction in which a change has happened.
  * 
  * @author Oliver Milke
  * @since 15.01.2016
  */
+@TransactionScoped
 public class TransactionId implements Serializable {
 
 	private static final long serialVersionUID = 1L;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/auditlog/AuditContextProducer.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/auditlog/AuditContextProducer.java
@@ -23,7 +23,7 @@ import javax.ejb.SessionContext;
 import javax.ejb.Stateless;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Produces;
-import javax.transaction.TransactionScoped;
+import javax.inject.Inject;
 
 import de.symeda.auditlog.api.Auditor;
 import de.symeda.auditlog.api.Current;
@@ -46,6 +46,12 @@ public class AuditContextProducer {
 	@Resource
 	private SessionContext context;
 
+	@Inject
+	private Auditor auditor;
+
+	@Inject
+	private TransactionId transactionId;
+
 	/**
 	 * Returns the information which user a change should be associated with according to the EJB context.
 	 */
@@ -60,16 +66,18 @@ public class AuditContextProducer {
 
 	@Produces
 	@Current
-	@TransactionScoped
+	@Dependent
 	public Auditor provideAuditor() {
-		return new Auditor(configFacade.isAuditorAttributeLoggingEnabled());
+
+		auditor.setAuditorAttributeLoggingEnabled(configFacade.isAuditorAttributeLoggingEnabled());
+		return auditor;
 	}
 
 	@Produces
 	@Current
-	@TransactionScoped
+	@Dependent
 	public TransactionId provideTransactionId() {
 
-		return new TransactionId();
+		return transactionId;
 	}
 }


### PR DESCRIPTION
<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #7705

I reworked the usage of `@TransactionScoped` to not be mentioned directly on the producer method (which Payara claims to be not valid but still worked as expected) but following [this tutorial](https://www.byteslounge.com/tutorials/java-ee-cdi-transactionscoped-example) with one indirection via `@Inject`. 

1. A quick smoke tests showed that CREATE/UPDATE detection and shared transactionId still works. 
2. I did not test with splitted transactions within the same call.
3. I tested that `AuditContextProducer` is not bypassed for `Auditor` and `TransactionId`, `auditor.setAuditorAttributeLoggingEnabled(configFacade.isAuditorAttributeLoggingEnabled())` still works.

I retested this approach and found that the message `No valid EE environment for injection` does not disappear, so this approach does not help (but does not make it worse).