### PR TITLE
[#8500] remove geocoding template from check as it is not an URL

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/ConfigFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/ConfigFacadeEjb.java
@@ -570,8 +570,7 @@ public class ConfigFacadeEjb implements ConfigFacade {
 			getExternalSurveillanceToolGatewayUrl(),
 			getMapTilersUrl(),
 			getAppUrl(),
-			getUiUrl(),
-			getGeocodingServiceUrlTemplate());
+			getUiUrl());
 
 		// separately as they are interpolated
 		if (!StringUtils.isBlank(s2sConfig.getOidcServer())) {


### PR DESCRIPTION
Fixes #8500 
@syntakker Pointed the error out to me, will likely cause the latest deployment to fail.