### PR TITLE
#8352 - Authorize generic facade api methods [2]

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/event/EventParticipantFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/event/EventParticipantFacade.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import javax.ejb.Remote;
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 
 import de.symeda.sormas.api.CoreFacade;
 import de.symeda.sormas.api.EditPermissionType;
@@ -44,7 +45,7 @@ public interface EventParticipantFacade
 
 	EventParticipantDto getEventParticipantByUuid(String uuid);
 
-	EventParticipantDto saveEventParticipant(@Valid EventParticipantDto dto);
+	EventParticipantDto save(@Valid @NotNull EventParticipantDto dto);
 
 	List<String> getAllActiveUuids();
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/campaign/CampaignFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/campaign/CampaignFacadeEjb.java
@@ -419,6 +419,24 @@ public class CampaignFacadeEjb
 		return service.getEditPermissionType(campaign);
 	}
 
+	@Override
+	@RolesAllowed(UserRight._CAMPAIGN_ARCHIVE)
+	public void archive(String entityUuid, Date endOfProcessingDate) {
+		super.archive(entityUuid, endOfProcessingDate);
+	}
+
+	@Override
+	@RolesAllowed(UserRight._CAMPAIGN_ARCHIVE)
+	public void archive(List<String> entityUuids) {
+		super.archive(entityUuids);
+	}
+
+	@Override
+	@RolesAllowed(UserRight._CAMPAIGN_ARCHIVE)
+	public void dearchive(List<String> entityUuids, String dearchiveReason) {
+		super.dearchive(entityUuids, dearchiveReason);
+	}
+
 	@LocalBean
 	@Stateless
 	public static class CampaignFacadeEjbLocal extends CampaignFacadeEjb {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/AbstractCoreFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/AbstractCoreFacadeEjb.java
@@ -21,6 +21,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import javax.annotation.security.DenyAll;
 import javax.ejb.EJB;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
@@ -94,8 +95,8 @@ public abstract class AbstractCoreFacadeEjb<ADO extends CoreAdo, DTO extends Ent
 			.collect(Collectors.toList());
 	}
 
-	@Override
-	public DTO save(@Valid @NotNull DTO dto) {
+	@DenyAll
+	public DTO doSave(@Valid @NotNull DTO dto) {
 		ADO existingAdo = dto.getUuid() != null ? service.getByUuid(dto.getUuid()) : null;
 
 		if (existingAdo != null && !service.getEditPermissionType(existingAdo).equals(EditPermissionType.ALLOWED)) {
@@ -119,6 +120,7 @@ public abstract class AbstractCoreFacadeEjb<ADO extends CoreAdo, DTO extends Ent
 		return service.exists(uuid);
 	}
 
+	@DenyAll
 	public void delete(String uuid) {
 		ADO ado = service.getByUuid(uuid);
 		service.delete(ado);
@@ -208,14 +210,17 @@ public abstract class AbstractCoreFacadeEjb<ADO extends CoreAdo, DTO extends Ent
 
 	public abstract void validate(DTO dto) throws ValidationRuntimeException;
 
+	@DenyAll
 	public void archive(String entityUuid, Date endOfProcessingDate) {
 		service.archive(entityUuid, endOfProcessingDate);
 	}
 
+	@DenyAll
 	public void archive(List<String> entityUuids) {
 		service.archive(entityUuids);
 	}
 
+	@DenyAll
 	public void dearchive(List<String> entityUuids, String dearchiveReason) {
 		service.dearchive(entityUuids, dearchiveReason);
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/event/EventParticipantFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/event/EventParticipantFacadeEjb.java
@@ -310,7 +310,7 @@ public class EventParticipantFacadeEjb
 	@RolesAllowed({
 		UserRight._EVENTPARTICIPANT_CREATE,
 		UserRight._EVENTPARTICIPANT_EDIT })
-	public EventParticipantDto saveEventParticipant(@Valid EventParticipantDto dto) {
+	public EventParticipantDto save(@Valid @NotNull EventParticipantDto dto) {
 		return saveEventParticipant(dto, true, true);
 	}
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/event/eventimport/EventImportFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/event/eventimport/EventImportFacadeEjb.java
@@ -154,7 +154,7 @@ public class EventImportFacadeEjb implements EventImportFacade {
 				if (existingPerson == null) {
 					personFacade.savePerson(eventParticipant.getPerson());
 				}
-				eventParticipantFacade.saveEventParticipant(eventParticipant);
+				eventParticipantFacade.save(eventParticipant);
 			}
 
 			eventGroupFacade.linkEventToGroups(event.toReference(), eventGroupReferences);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/AbstractSormasToSormasInterface.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/AbstractSormasToSormasInterface.java
@@ -48,6 +48,7 @@ import de.symeda.sormas.api.sormastosormas.validation.SormasToSormasValidationEx
 import de.symeda.sormas.api.sormastosormas.validation.ValidationErrorGroup;
 import de.symeda.sormas.api.sormastosormas.validation.ValidationErrorMessage;
 import de.symeda.sormas.api.sormastosormas.validation.ValidationErrors;
+import de.symeda.sormas.api.user.UserRight;
 import de.symeda.sormas.api.utils.DataHelper;
 import de.symeda.sormas.backend.caze.Case;
 import de.symeda.sormas.backend.caze.CaseService;
@@ -100,6 +101,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import javax.annotation.security.RolesAllowed;
 import javax.ejb.EJB;
 import javax.inject.Inject;
 import javax.transaction.Transactional;
@@ -195,6 +197,7 @@ public abstract class AbstractSormasToSormasInterface<ADO extends AbstractDomain
 	@Override
 	@Transactional(rollbackOn = {
 		Exception.class })
+	@RolesAllowed(UserRight._SORMAS_TO_SORMAS_SHARE)
 	public void share(List<String> entityUuids, @Valid SormasToSormasOptionsDto options) throws SormasToSormasException {
 		if (featureConfigurationFacade.isFeatureEnabled(FeatureType.SORMAS_TO_SORMAS_ACCEPT_REJECT)) {
 			sendShareRequest(entityUuids, options);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/travelentry/TravelEntryFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/travelentry/TravelEntryFacadeEjb.java
@@ -2,6 +2,7 @@ package de.symeda.sormas.backend.travelentry;
 
 import java.sql.Timestamp;
 import java.time.LocalDate;
+import java.util.Date;
 import java.util.List;
 
 import javax.annotation.security.RolesAllowed;
@@ -14,6 +15,7 @@ import javax.inject.Inject;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 import de.symeda.sormas.api.EditPermissionType;
@@ -185,7 +187,7 @@ public class TravelEntryFacadeEjb
 
 	@Override
 	@TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
-	@RolesAllowed(UserRight._SYSTEM)
+	@RolesAllowed(UserRight._TRAVEL_ENTRY_ARCHIVE)
 	public void archiveAllArchivableTravelEntries(int daysAfterTravelEntryGetsArchived) {
 		archiveAllArchivableTravelEntry(daysAfterTravelEntryGetsArchived, LocalDate.now());
 	}
@@ -378,6 +380,30 @@ public class TravelEntryFacadeEjb
 			return TravelEntry.DATE_OF_ARRIVAL;
 		}
 		return super.getDeleteReferenceField(deletionReference);
+	}
+
+	@Override
+	@RolesAllowed(UserRight._TRAVEL_ENTRY_ARCHIVE)
+	public void archive(String entityUuid, Date endOfProcessingDate) {
+		super.archive(entityUuid, endOfProcessingDate);
+	}
+
+	@Override
+	@RolesAllowed(UserRight._TRAVEL_ENTRY_ARCHIVE)
+	public void archive(List<String> entityUuids) {
+		super.archive(entityUuids);
+	}
+
+	@Override
+	@RolesAllowed(UserRight._TRAVEL_ENTRY_ARCHIVE)
+	public void dearchive(List<String> entityUuids, String dearchiveReason) {
+		super.dearchive(entityUuids, dearchiveReason);
+	}
+
+	@Override
+	@RolesAllowed(UserRight._TRAVEL_ENTRY_EDIT)
+	public TravelEntryDto save(@Valid @NotNull TravelEntryDto travelEntryDto) {
+		return doSave(travelEntryDto);
 	}
 
 	@LocalBean

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/TestDataCreator.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/TestDataCreator.java
@@ -1049,7 +1049,7 @@ public class TestDataCreator {
 			eventParticipant.setDistrict(rdcf.district);
 		}
 
-		eventParticipant = beanTest.getEventParticipantFacade().saveEventParticipant(eventParticipant);
+		eventParticipant = beanTest.getEventParticipantFacade().save(eventParticipant);
 		return eventParticipant;
 	}
 

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/caze/CaseFacadeEjbTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/caze/CaseFacadeEjbTest.java
@@ -683,7 +683,7 @@ public class CaseFacadeEjbTest extends AbstractBeanTest {
 			new Date(),
 			rdcf);
 		event1Participant1.setResultingCase(case1.toReference());
-		getEventParticipantFacade().saveEventParticipant(event1Participant1);
+		getEventParticipantFacade().save(event1Participant1);
 
 		Assert.assertEquals(2, getCaseFacade().getIndexList(null, 0, 100, null).size());
 		Assert.assertEquals(1, getCaseFacade().getIndexList(new CaseCriteria().eventLike("signal"), 0, 100, null).size());
@@ -1465,18 +1465,17 @@ public class CaseFacadeEjbTest extends AbstractBeanTest {
 		getEventFacade().save(event);
 		EventParticipantDto otherCaseEventParticipant = creator.createEventParticipant(event.toReference(), otherPerson, otherUserReference);
 		otherCaseEventParticipant.setResultingCase(otherCaseReference);
-		getEventParticipantFacade().saveEventParticipant(otherCaseEventParticipant);
+		getEventParticipantFacade().save(otherCaseEventParticipant);
 
 		creator.createSurveillanceReport(otherUserReference, otherCaseReference);
 		TravelEntryDto travelEntry = creator.createTravelEntry(
-			otherPersonReference,
-			otherUserReference,
-			otherCase.getDisease(),
-			otherRdcf.region,
-			otherRdcf.district,
-			otherRdcf.pointOfEntry);
-		travelEntry.setResultingCase(otherCaseReference);
-		travelEntry = getTravelEntryFacade().save(travelEntry);
+				otherPersonReference,
+				otherUserReference,
+				otherRdcf,
+				(t)->{
+					t.setDisease(otherCase.getDisease());
+					t.setResultingCase(otherCaseReference);
+				});
 
 		DocumentDto document = creator.createDocument(
 			leadUserReference,

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/contact/ContactFacadeEjbTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/contact/ContactFacadeEjbTest.java
@@ -760,7 +760,7 @@ public class ContactFacadeEjbTest extends AbstractBeanTest {
 			rdcf);
 
 		event1Participant1.setResultingCase(case1.toReference());
-		getEventParticipantFacade().saveEventParticipant(event1Participant1);
+		getEventParticipantFacade().save(event1Participant1);
 
 		creator.createContact(user.toReference(), person1.toReference(), case1);
 		creator.createContact(user.toReference(), person1.toReference(), case2);

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/docgeneration/EventDocumentFacadeEjbTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/docgeneration/EventDocumentFacadeEjbTest.java
@@ -76,7 +76,7 @@ public class EventDocumentFacadeEjbTest extends AbstractDocGenerationTest {
 		EventParticipantDto eventParticipantDto1 = EventParticipantDto.build(eventDto.toReference(), user.toReference());
 		eventParticipantDto1.setPerson(personDto1);
 		eventParticipantDto1.setInvolvementDescription("involved");
-		getEventParticipantFacade().saveEventParticipant(eventParticipantDto1);
+		getEventParticipantFacade().save(eventParticipantDto1);
 
 		PersonDto personDto2 = PersonDto.build();
 		personDto2.setFirstName("Guy");
@@ -89,7 +89,7 @@ public class EventDocumentFacadeEjbTest extends AbstractDocGenerationTest {
 		EventParticipantDto eventParticipantDto2 = EventParticipantDto.build(eventDto.toReference(), user.toReference());
 		eventParticipantDto2.setPerson(personDto2);
 		eventParticipantDto2.setInvolvementDescription("involved");
-		getEventParticipantFacade().saveEventParticipant(eventParticipantDto2);
+		getEventParticipantFacade().save(eventParticipantDto2);
 
 		PersonDto personDto3 = PersonDto.build();
 		personDto3.setFirstName("Georges");
@@ -102,7 +102,7 @@ public class EventDocumentFacadeEjbTest extends AbstractDocGenerationTest {
 		EventParticipantDto eventParticipantDto3 = EventParticipantDto.build(eventDto.toReference(), user.toReference());
 		eventParticipantDto3.setPerson(personDto3);
 		eventParticipantDto3.setInvolvementDescription("involved");
-		getEventParticipantFacade().saveEventParticipant(eventParticipantDto3);
+		getEventParticipantFacade().save(eventParticipantDto3);
 
 		ActionDto actionDto1 = new ActionDto();
 		actionDto1.setTitle("An action");

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/event/EventParticipantFacadeEjbPseudonymizationTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/event/EventParticipantFacadeEjbPseudonymizationTest.java
@@ -126,7 +126,7 @@ public class EventParticipantFacadeEjbPseudonymizationTest extends AbstractBeanT
 		assertThat(savedPerson.getAddress().getAdditionalInformation(), is(nullValue()));
 		assertThat(savedPerson.getAddress().getCity(), is(nullValue()));
 
-		getEventParticipantFacade().saveEventParticipant(participant);
+		getEventParticipantFacade().save(participant);
 		EventParticipant savedParticipant = getEventParticipantService().getByUuid(participant.getUuid());
 
 //		assertThat(savedParticipant.getInvolvementDescription(), is("Test involvement descr"));
@@ -148,7 +148,7 @@ public class EventParticipantFacadeEjbPseudonymizationTest extends AbstractBeanT
 		participant.getPerson().getAddress().setAdditionalInformation(null);
 		participant.getPerson().getAddress().setCity(null);
 
-		getEventParticipantFacade().saveEventParticipant(participant);
+		getEventParticipantFacade().save(participant);
 
 		EventParticipant saved = getEventParticipantService().getByUuid(participant.getUuid());
 

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/event/EventParticipantFacadeEjbTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/event/EventParticipantFacadeEjbTest.java
@@ -160,7 +160,7 @@ public class EventParticipantFacadeEjbTest extends AbstractBeanTest {
 		eventParticipant.setPerson(creator.createPerson());
 		eventParticipant.setReportingUser(user.toReference());
 
-		EventParticipantDto savedEventParticipant = getEventParticipantFacade().saveEventParticipant(eventParticipant);
+		EventParticipantDto savedEventParticipant = getEventParticipantFacade().save(eventParticipant);
 
 		MatcherAssert.assertThat(savedEventParticipant.getUuid(), not(isEmptyOrNullString()));
 	}

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/person/PersonFacadeEjbTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/person/PersonFacadeEjbTest.java
@@ -656,9 +656,7 @@ public class PersonFacadeEjbTest extends AbstractBeanTest {
 		PersonDto person3 = creator.createPerson();
 		person3 = getPersonFacade().savePerson(person3);
 
-		TravelEntryDto travelEntry = creator
-			.createTravelEntry(person3.toReference(), nationalUser.toReference(), Disease.CORONAVIRUS, rdcf.region, rdcf.district, rdcf.pointOfEntry);
-		getTravelEntryFacade().save(travelEntry);
+		creator.createTravelEntry(person3.toReference(), nationalUser.toReference(), Disease.CORONAVIRUS, rdcf.region, rdcf.district, rdcf.pointOfEntry);
 
 		personsAfterT1 = getPersonFacade().getPersonsAfter(t1);
 		assertEquals(3, personsAfterT1.size());

--- a/sormas-rest/src/main/java/de/symeda/sormas/rest/EventParticipantResource.java
+++ b/sormas-rest/src/main/java/de/symeda/sormas/rest/EventParticipantResource.java
@@ -99,7 +99,7 @@ public class EventParticipantResource extends EntityDtoResource {
 	@Path("/push")
 	public List<PushResult> postEventParticipants(@Valid List<EventParticipantDto> dtos) {
 
-		List<PushResult> result = savePushedDto(dtos, FacadeProvider.getEventParticipantFacade()::saveEventParticipant);
+		List<PushResult> result = savePushedDto(dtos, FacadeProvider.getEventParticipantFacade()::save);
 		return result;
 	}
 

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/CaseController.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/CaseController.java
@@ -404,7 +404,7 @@ public class CaseController {
 			List<EventParticipantDto> eventParticipants = FacadeProvider.getEventParticipantFacade().getByUuids(eventParticipantUuids);
 			for (EventParticipantDto eventParticipant : eventParticipants) {
 				eventParticipant.setResultingCase(caze.toReference());
-				FacadeProvider.getEventParticipantFacade().saveEventParticipant(eventParticipant);
+				FacadeProvider.getEventParticipantFacade().save(eventParticipant);
 			}
 		}
 
@@ -702,7 +702,7 @@ public class CaseController {
 							if (unrelatedDisease == null) {
 								// set resulting case on event participant and save it
 								updatedEventParticipant.setResultingCase(dto.toReference());
-								FacadeProvider.getEventParticipantFacade().saveEventParticipant(updatedEventParticipant);
+								FacadeProvider.getEventParticipantFacade().save(updatedEventParticipant);
 								FacadeProvider.getCaseFacade().setSampleAssociations(updatedEventParticipant.toReference(), dto.toReference());
 							} else {
 								FacadeProvider.getCaseFacade()
@@ -715,7 +715,7 @@ public class CaseController {
 							if (unrelatedDisease == null && convertedEventParticipant.getResultingCase() == null) {
 								convertedEventParticipant.setResultingCase(FacadeProvider.getCaseFacade().getReferenceByUuid(uuid));
 							}
-							FacadeProvider.getEventParticipantFacade().saveEventParticipant(convertedEventParticipant);
+							FacadeProvider.getEventParticipantFacade().save(convertedEventParticipant);
 							if (!createdFromLabMessage) {
 								navigateToView(CaseDataView.VIEW_NAME, uuid, null);
 							}

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/configuration/DevModeView.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/configuration/DevModeView.java
@@ -1375,7 +1375,7 @@ public class DevModeView extends AbstractConfigurationView {
 					}
 				}
 
-				FacadeProvider.getEventParticipantFacade().saveEventParticipant(eventParticipant);
+				FacadeProvider.getEventParticipantFacade().save(eventParticipant);
 				generatedParticipants++;
 			}
 		}

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/events/EventController.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/events/EventController.java
@@ -290,7 +290,7 @@ public class EventController {
 					personByUuid.get(caseDataDto.getPerson().getUuid()),
 					eventReferenceDto,
 					UserProvider.getCurrent().getUserReference());
-				FacadeProvider.getEventParticipantFacade().saveEventParticipant(ep);
+				FacadeProvider.getEventParticipantFacade().save(ep);
 			});
 		}
 
@@ -337,7 +337,7 @@ public class EventController {
 					personByUuid.get(contactDataDto.getPerson().getUuid()),
 					eventReferenceDto,
 					UserProvider.getCurrent().getUserReference());
-				FacadeProvider.getEventParticipantFacade().saveEventParticipant(ep);
+				FacadeProvider.getEventParticipantFacade().save(ep);
 			});
 		}
 
@@ -473,7 +473,7 @@ public class EventController {
 
 		EventParticipantDto eventParticipantDto = FacadeProvider.getEventParticipantFacade().getEventParticipantByUuid(eventParticipantRef.getUuid());
 		eventParticipantDto.setResultingCase(null);
-		FacadeProvider.getEventParticipantFacade().saveEventParticipant(eventParticipantDto);
+		FacadeProvider.getEventParticipantFacade().save(eventParticipantDto);
 
 		Notification.show(notificationMessage, Type.TRAY_NOTIFICATION);
 	}
@@ -499,7 +499,7 @@ public class EventController {
 			EventParticipantDto eventParticipant =
 				FacadeProvider.getEventParticipantFacade().getEventParticipantByUuid(eventParticipantRef.getUuid());
 			eventParticipant.setResultingCase(caseRef);
-			FacadeProvider.getEventParticipantFacade().saveEventParticipant(eventParticipant);
+			FacadeProvider.getEventParticipantFacade().save(eventParticipant);
 			Notification notification =
 				new Notification(I18nProperties.getString(Strings.messagePersonAlreadyEventParticipant), "", Type.HUMANIZED_MESSAGE);
 			notification.setDelayMsec(10000);

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/events/EventParticipantsController.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/events/EventParticipantsController.java
@@ -114,7 +114,7 @@ public class EventParticipantsController {
 										throw new Validator.InvalidValueException(I18nProperties.getString(Strings.messageAlreadyEventParticipant));
 									} else {
 										dto.setPerson(FacadeProvider.getPersonFacade().getPersonByUuid(selectedPerson.getUuid()));
-										EventParticipantDto savedDto = eventParticipantFacade.saveEventParticipant(dto);
+										EventParticipantDto savedDto = eventParticipantFacade.save(dto);
 
 										Notification notification = new Notification(
 											I18nProperties.getString(Strings.messagePersonAddedAsEventParticipant),
@@ -137,7 +137,7 @@ public class EventParticipantsController {
 					if (FacadeProvider.getEventParticipantFacade().exists(dto.getPerson().getUuid(), eventRef.getUuid())) {
 						throw new Validator.InvalidValueException(I18nProperties.getString(Strings.messageAlreadyEventParticipant));
 					}
-					EventParticipantDto savedDto = eventParticipantFacade.saveEventParticipant(dto);
+					EventParticipantDto savedDto = eventParticipantFacade.save(dto);
 					Notification.show(I18nProperties.getString(Strings.messageEventParticipantCreated), Type.ASSISTIVE_NOTIFICATION);
 					if (navigateOnCommit) {
 						navigateToData(savedDto.getUuid());
@@ -308,7 +308,7 @@ public class EventParticipantsController {
 
 	private void savePersonAndEventParticipant(Consumer<EventParticipantReferenceDto> doneConsumer, EventParticipantDto dto) {
 		personFacade.savePerson(dto.getPerson());
-		eventParticipantFacade.saveEventParticipant(dto);
+		eventParticipantFacade.save(dto);
 		Notification.show(I18nProperties.getString(Strings.messageEventParticipantSaved), Type.WARNING_MESSAGE);
 		if (doneConsumer != null)
 			doneConsumer.accept(null);

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/events/eventparticipantimporter/EventParticipantImporter.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/events/eventparticipantimporter/EventParticipantImporter.java
@@ -256,7 +256,7 @@ public class EventParticipantImporter extends DataImporter {
 					final PersonDto savedPerson = personFacade.savePerson(newPerson, skipPersonValidation);
 					newEventParticipant.setPerson(savedPerson);
 					newEventParticipant.setChangeDate(new Date());
-					eventParticipantFacade.saveEventParticipant(newEventParticipant);
+					eventParticipantFacade.save(newEventParticipant);
 
 					for (VaccinationDto vaccination : vaccinations) {
 						FacadeProvider.getVaccinationFacade()

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/labmessage/LabMessageController.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/labmessage/LabMessageController.java
@@ -526,7 +526,7 @@ public class LabMessageController {
 				final EventParticipantDto dto = createForm.getValue();
 
 				FacadeProvider.getPersonFacade().savePerson(dto.getPerson());
-				EventParticipantDto savedDto = FacadeProvider.getEventParticipantFacade().saveEventParticipant(dto);
+				EventParticipantDto savedDto = FacadeProvider.getEventParticipantFacade().save(dto);
 				Notification.show(I18nProperties.getString(Strings.messageEventParticipantCreated), Notification.Type.ASSISTIVE_NOTIFICATION);
 				createSample(
 					SampleDto.build(UserProvider.getCurrent().getUserReference(), savedDto.toReference()),

--- a/sormas-ui/src/test/java/de/symeda/sormas/ui/TestDataCreator.java
+++ b/sormas-ui/src/test/java/de/symeda/sormas/ui/TestDataCreator.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import de.symeda.sormas.api.Disease;
 import de.symeda.sormas.api.FacadeProvider;
@@ -159,7 +158,7 @@ public class TestDataCreator {
 		eventParticipant.setPerson(eventPerson);
 		eventParticipant.setInvolvementDescription(involvementDescription);
 
-		eventParticipant = FacadeProviderMock.getEventParticipantFacade().saveEventParticipant(eventParticipant);
+		eventParticipant = FacadeProviderMock.getEventParticipantFacade().save(eventParticipant);
 		return eventParticipant;
 	}
 


### PR DESCRIPTION
- Were fixed 2 tests which failed due to novatec.beantest framework which is used(and outdated): PersonFacadeEjbTest.testGetPersonsAfter & CaseFacadeEjbTest.testMergeCase - in one of the tests save is called twice however entity is saved at creation.
- Me and Levi did not get really the point about `save` method with @DenyAll annotation why it is not working as expected. As for archive and other methods all is working fine.
- Performed some manual test to be sure that save/archive for case/events/contacts are working.

Fixes #8352