### PR TITLE
Added a test for Person directory columns

### DIFF
--- a/sormas-e2e-tests/src/main/java/org/sormas/e2etests/pages/application/persons/PersonDirectoryPage.java
+++ b/sormas-e2e-tests/src/main/java/org/sormas/e2etests/pages/application/persons/PersonDirectoryPage.java
@@ -47,4 +47,6 @@ public class PersonDirectoryPage {
       By.cssSelector("v-grid-column-header-content v-grid-column-default-header-content");
   public static final By PRESENT_CONDITION_FILTER_COMBOBOX =
       By.cssSelector("#presentCondition div");
+  public static final By PERSON_DETAILED_COLUMN_HEADERS =
+      By.cssSelector("thead .v-grid-column-default-header-content");
 }

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/helpers/WebDriverHelpers.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/helpers/WebDriverHelpers.java
@@ -873,4 +873,14 @@ public class WebDriverHelpers {
               selector));
     }
   }
+
+  public String javascriptGetElementContent(String selector) {
+    JavascriptExecutor javascriptExecutor = baseSteps.getDriver();
+    String script =
+        "return window.getComputedStyle(document.querySelector("
+            + selector
+            + ").getPropertyValue('content')";
+    String content = javascriptExecutor.executeScript(script).toString();
+    return content;
+  }
 }

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/persons/PersonDetailedTableViewSteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/persons/PersonDetailedTableViewSteps.java
@@ -1,0 +1,160 @@
+package org.sormas.e2etests.steps.web.application.persons;
+
+import static org.sormas.e2etests.pages.application.persons.PersonDirectoryPage.PERSON_DETAILED_COLUMN_HEADERS;
+
+import cucumber.api.java8.En;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import org.openqa.selenium.By;
+import org.sormas.e2etests.helpers.WebDriverHelpers;
+import org.sormas.e2etests.steps.BaseSteps;
+import org.testng.asserts.SoftAssert;
+
+@Slf4j
+public class PersonDetailedTableViewSteps implements En {
+
+  private final WebDriverHelpers webDriverHelpers;
+  private static BaseSteps baseSteps;
+  static Map<String, Integer> headersMap;
+
+  @Inject
+  public PersonDetailedTableViewSteps(
+      WebDriverHelpers webDriverHelpers, BaseSteps baseSteps, SoftAssert softly) {
+    this.webDriverHelpers = webDriverHelpers;
+    this.baseSteps = baseSteps;
+
+    When(
+        "I check that the Person table structure is correct",
+        () -> {
+          headersMap = extractColumnHeadersHashMap();
+          String headers = headersMap.toString();
+          softly.assertTrue(
+              headers.contains("PERSON ID=0"), "The PERSON ID column is not correctly displayed!");
+          softly.assertTrue(
+              headers.contains("FIRST NAME=1"),
+              "The FIRST NAME column is not correctly displayed!");
+          softly.assertTrue(
+              headers.contains("LAST NAME=2"), "The LAST NAME column is not correctly displayed!");
+          softly.assertTrue(
+              headers.contains("AGE AND BIRTH DATE=3"),
+              "The PERSON ID column is not correctly displayed!");
+          softly.assertTrue(
+              headers.contains("SEX=4"), "The SEX column is not correctly displayed!");
+          softly.assertTrue(
+              headers.contains("DISTRICT=5"), "The DISTRICT column is not correctly displayed!");
+          softly.assertTrue(
+              headers.contains("STREET=6"), "The STREET column is not correctly displayed!");
+          softly.assertTrue(
+              headers.contains("HOUSE NUMBER=7"),
+              "The HOUSE NUMBER column is not correctly displayed!");
+          softly.assertTrue(
+              headers.contains("POSTAL CODE=8"),
+              "The POSTAL CODE column is not correctly displayed!");
+          softly.assertTrue(
+              headers.contains("CITY=9"), "The CITY column is not correctly displayed!");
+          softly.assertTrue(
+              headers.contains("PRIMARY PHONE NUMBER=10"),
+              "The PRIMARY PHONE NUMBER column is not correctly displayed!");
+          softly.assertTrue(
+              headers.contains("PRIMARY EMAIL ADDRESS=11"),
+              "The PRIMARY EMAIL ADDRESS column is not correctly displayed!");
+          softly.assertAll();
+        });
+
+    When(
+        "I click the header of column {int} in Person directory",
+        (Integer col) -> {
+          webDriverHelpers.clickOnWebElementBySelector(
+              By.xpath("//thead//tr//th[" + col.toString() + "]"));
+          webDriverHelpers.waitForPageLoadingSpinnerToDisappear(5);
+        });
+
+    When(
+        "I check that column {int} is sorted in ascending order",
+        (Integer col) -> {
+          List<String> rawColumnData = getTableColumnDataByIndex(col, 10);
+          List<String> ascColumnData = new ArrayList<>(rawColumnData);
+          ascColumnData.sort(Comparator.naturalOrder());
+          softly.assertEquals(
+              rawColumnData,
+              ascColumnData,
+              "Column " + col.toString() + " is not correctly sorted!");
+          softly.assertAll();
+        });
+
+    When(
+        "I check that column {int} is sorted in descending order",
+        (Integer col) -> {
+          List<String> rawColumnData = getTableColumnDataByIndex(col, 10);
+          List<String> desColumnData = new ArrayList<>(rawColumnData);
+          desColumnData.sort(Comparator.reverseOrder());
+          softly.assertEquals(
+              rawColumnData,
+              desColumnData,
+              "Column " + col.toString() + " is not correctly sorted!");
+          softly.assertAll();
+        });
+
+    When(
+        "I check that an upwards arrow appears in the header of column {int}",
+        (Integer col) -> {
+          String upArrowBytes = "[34, -17, -125, -98, 32, 34]";
+          String content =
+              webDriverHelpers.javascriptGetElementContent(
+                  "'table > thead > tr > th:nth-of-type(" + col + ")'),'::after'");
+          byte[] array = content.getBytes(StandardCharsets.UTF_8);
+          softly.assertEquals(
+              Arrays.toString(array), upArrowBytes, "The upwards arrow is not displayed!");
+          softly.assertAll();
+        });
+
+    When(
+        "I check that a downwards arrow appears in the header of column {int}",
+        (Integer col) -> {
+          String downArrowBytes = "[34, -17, -125, -99, 32, 34]";
+          String content =
+              webDriverHelpers.javascriptGetElementContent(
+                  "'table > thead > tr > th:nth-of-type(" + col + ")'),'::after'");
+          byte[] array = content.getBytes(StandardCharsets.UTF_8);
+          softly.assertEquals(
+              Arrays.toString(array), downArrowBytes, "The downwards arrow is not displayed!");
+          softly.assertAll();
+        });
+  }
+
+  private Map<String, Integer> extractColumnHeadersHashMap() {
+    AtomicInteger atomicInt = new AtomicInteger();
+    HashMap<String, Integer> headerHashmap = new HashMap<>();
+    webDriverHelpers.waitUntilIdentifiedElementIsVisibleAndClickable(
+        PERSON_DETAILED_COLUMN_HEADERS);
+    webDriverHelpers.waitUntilAListOfWebElementsAreNotEmpty(PERSON_DETAILED_COLUMN_HEADERS);
+    webDriverHelpers.scrollToElementUntilIsVisible(PERSON_DETAILED_COLUMN_HEADERS);
+    baseSteps
+        .getDriver()
+        .findElements(PERSON_DETAILED_COLUMN_HEADERS)
+        .forEach(
+            webElement -> {
+              webDriverHelpers.scrollToElementUntilIsVisible(webElement);
+              headerHashmap.put(webElement.getText(), atomicInt.getAndIncrement());
+            });
+    return headerHashmap;
+  }
+
+  private List<String> getTableColumnDataByIndex(int col, int maxRows) {
+    List<String> list = new ArrayList<>();
+    for (int i = 1; i < maxRows + 1; i++) {
+      list.add(
+          webDriverHelpers.getTextFromWebElement(
+              By.xpath("//tbody//tr[" + i + "]//td[" + col + "]")));
+    }
+    return list;
+  }
+}

--- a/sormas-e2e-tests/src/test/resources/features/sanity/web/Persons.feature
+++ b/sormas-e2e-tests/src/test/resources/features/sanity/web/Persons.feature
@@ -139,3 +139,32 @@ Feature: Edit Persons
     And I click on Edit Immunization button for Immunization created through API from Immunization card on Edit Person page
     Then I navigate to the last created via api Person page via URL
 
+  @issue=SORDEV-8467 @env_main
+  Scenario: Test for columns in Person directory
+    Given I log in with National User
+    And I click on the Persons button from navbar
+    Then I check that the Person table structure is correct
+    When I click the header of column 1 in Person directory
+    Then I check that column 1 is sorted in ascending order
+    And I check that an upwards arrow appears in the header of column 1
+    When I click the header of column 1 in Person directory
+    And I check that column 1 is sorted in descending order
+    Then I check that a downwards arrow appears in the header of column 1
+    When I click the header of column 2 in Person directory
+    Then I check that column 2 is sorted in ascending order
+    And I check that an upwards arrow appears in the header of column 2
+    When I click the header of column 2 in Person directory
+    And I check that column 2 is sorted in descending order
+    Then I check that a downwards arrow appears in the header of column 2
+    When I click the header of column 3 in Person directory
+    Then I check that column 3 is sorted in ascending order
+    And I check that an upwards arrow appears in the header of column 3
+    When I click the header of column 3 in Person directory
+    And I check that column 3 is sorted in descending order
+    Then I check that a downwards arrow appears in the header of column 3
+    When I click the header of column 5 in Person directory
+    Then I check that column 5 is sorted in ascending order
+    And I check that an upwards arrow appears in the header of column 5
+    When I click the header of column 5 in Person directory
+    And I check that column 5 is sorted in descending order
+    Then I check that a downwards arrow appears in the header of column 5


### PR DESCRIPTION
https://jira.sormas-tools.de/browse/SORQA-121

Please note that this test differs slightly from the manual scenario - instead of clicking on a black arrow in the column header we click on the column header itself. This is due to the fact that said arrow is a pseudo-element, which are by definition non-clickable. A click on the arrow would register as a click on the header anyway.

![image](https://user-images.githubusercontent.com/96250163/163174800-f685f84a-54bb-46c6-a209-a79449d46bbd.png)
