### PR TITLE
#8850 [User rights] Contact Supervisor cannot create new Event Group

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/event/EventGroupFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/event/EventGroupFacadeEjb.java
@@ -268,9 +268,6 @@ public class EventGroupFacadeEjb implements EventGroupFacade {
 		UserRight._EVENTGROUP_EDIT })
 	public EventGroupDto saveEventGroup(@Valid @NotNull EventGroupDto dto, boolean checkChangeDate) {
 		User currentUser = userService.getCurrentUser();
-		if (!userService.hasRight(UserRight.EVENTGROUP_EDIT)) {
-			throw new UnsupportedOperationException("User " + currentUser.getUuid() + " is not allowed to edit event groups.");
-		}
 
 		EventGroup eventGroup = fromDto(dto, checkChangeDate);
 
@@ -312,9 +309,6 @@ public class EventGroupFacadeEjb implements EventGroupFacade {
 	@RolesAllowed(UserRight._EVENTGROUP_LINK)
 	public void linkEventsToGroups(List<EventReferenceDto> eventReferences, List<EventGroupReferenceDto> eventGroupReferences) {
 		User currentUser = userService.getCurrentUser();
-		if (!userService.hasRight(UserRight.EVENTGROUP_LINK)) {
-			throw new UnsupportedOperationException("User " + currentUser.getUuid() + " is not allowed to link events.");
-		}
 
 		if (CollectionUtils.isEmpty(eventReferences)) {
 			return;
@@ -368,9 +362,6 @@ public class EventGroupFacadeEjb implements EventGroupFacade {
 	@RolesAllowed(UserRight._EVENTGROUP_LINK)
 	public void unlinkEventGroup(EventReferenceDto eventReference, EventGroupReferenceDto eventGroupReference) {
 		User currentUser = userService.getCurrentUser();
-		if (!userService.hasRight(UserRight.EVENTGROUP_LINK)) {
-			throw new UnsupportedOperationException("User " + currentUser.getUuid() + " is not allowed to unlink events.");
-		}
 
 		Event event = eventService.getByUuid(eventReference.getUuid());
 
@@ -406,9 +397,6 @@ public class EventGroupFacadeEjb implements EventGroupFacade {
 	@RolesAllowed(UserRight._EVENTGROUP_DELETE)
 	public void deleteEventGroup(String uuid) {
 		User currentUser = userService.getCurrentUser();
-		if (!userService.hasRight(UserRight.EVENTGROUP_DELETE)) {
-			throw new UnsupportedOperationException("User " + currentUser.getUuid() + " is not allowed to delete events.");
-		}
 
 		EventGroup eventGroup = eventGroupService.getByUuid(uuid);
 
@@ -435,10 +423,6 @@ public class EventGroupFacadeEjb implements EventGroupFacade {
 	@RolesAllowed(UserRight._EVENTGROUP_ARCHIVE)
 	public void archiveOrDearchiveEventGroup(String uuid, boolean archive) {
 		User currentUser = userService.getCurrentUser();
-		if (!userService.hasRight(UserRight.EVENTGROUP_ARCHIVE)) {
-			throw new UnsupportedOperationException(
-				"User " + currentUser.getUuid() + " is not allowed to " + (archive ? "" : "de") + "archive events.");
-		}
 
 		EventGroup eventGroup = eventGroupService.getByUuid(uuid);
 


### PR DESCRIPTION
<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #8850

The problem was that ContSup has EVENTGROUP_CREATE-right but not EDIT and in the code there was a check for EDIT right only. 
Removed all old right checks and kept only @RolesAllowed annotation