### PR TITLE
#8799 - assignee filter in the lab message directory is reset after p…

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/labmessage/LabMessagesView.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/labmessage/LabMessagesView.java
@@ -157,6 +157,7 @@ public class LabMessagesView extends AbstractView {
 			this.navigateTo(null, true);
 		});
 		filterForm.addApplyHandler(e -> {
+			SormasUI.get().getNavigator().navigateTo(LabMessagesView.VIEW_NAME);
 			grid.reload();
 		});
 		filterLayout.addComponent(filterForm);


### PR DESCRIPTION
…rocessing a lab message

Only 1 line of code was changed. A lot of understanding why in debugging it is working and without debug it is not working, which result to a single line change.
This line will populate URL with right assignee user filter. As in some cases it got populated and all was working as expected, but after processing lab message, form was initialized with data from URL were assignee filtered user was missing which lead to current bug.

Fixes #8799