### PR TITLE
#7931 - Permanent deletion for Contact and Visit - update visit delet…

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/CronService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/CronService.java
@@ -217,7 +217,7 @@ public class CronService {
 		centralInfraSyncFacade.syncAll();
 	}
 
-	@Schedule(hour = "1", minute = "55", persistent = false)
+	@Schedule(hour = "*", minute = "*/2", persistent = false)
 	public void deleteExpiredEntities() {
 		coreEntityDeletionService.executeAutomaticDeletion();
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/contact/ContactFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/contact/ContactFacadeEjb.java
@@ -43,6 +43,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Resource;
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
+import javax.annotation.security.RunAs;
 import javax.ejb.EJB;
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
@@ -63,6 +64,7 @@ import javax.persistence.criteria.Selection;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
+import de.symeda.sormas.backend.deletionconfiguration.DeletionConfiguration;
 import de.symeda.sormas.backend.vaccination.VaccinationService;
 import org.apache.commons.collections.CollectionUtils;
 import org.slf4j.Logger;
@@ -555,6 +557,13 @@ public class ContactFacadeEjb
 		}
 		return deletedContactUuids;
 
+	}
+
+	@Override
+	@RolesAllowed(UserRight._SYSTEM)
+	public void executeAutomaticDeletion(DeletionConfiguration entityConfig, boolean deletePermanent, int batchSize) {
+		super.executeAutomaticDeletion(entityConfig, deletePermanent, batchSize);
+		visitService.permanentDeleteOrphanVisits(batchSize);
 	}
 
 	@Override


### PR DESCRIPTION
Visit permanent deletion was rewritten to cope with the situation when on the same day (transaction) 2 contacts having the same person and visits are deleted. Keeping the previous implementation was not possible as during the delete process, removing a row from join table conducts to an update of the related visits. When deletion of the second contact occurs and visit should be deleted this error is logged: "Row was updated or deleted by another transaction (or unsaved-value mapping was incorrect) : [de.symeda.sormas.backend.visit.Visit#142080]". 

<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #7931 