### PR TITLE
#8909 only set filter when not null

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/labmessage/LabMessageFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/labmessage/LabMessageFacadeEjb.java
@@ -73,6 +73,7 @@ public class LabMessageFacadeEjb implements LabMessageFacade {
 
 	public static final List<String> VALID_SORT_PROPERTY_NAMES = Arrays.asList(
 		LabMessageIndexDto.UUID,
+		LabMessageIndexDto.TYPE,
 		LabMessageIndexDto.PERSON_FIRST_NAME,
 		LabMessageIndexDto.PERSON_LAST_NAME,
 		LabMessageIndexDto.PERSON_POSTAL_CODE,
@@ -312,12 +313,15 @@ public class LabMessageFacadeEjb implements LabMessageFacade {
 			userJoin.get(User.FIRST_NAME),
 			userJoin.get(User.LAST_NAME));
 
-		Predicate whereFilter = null;
+		Predicate filter = null;
+
 		if (criteria != null) {
-			whereFilter = labMessageService.buildCriteriaFilter(cb, labMessage, criteria);
+			filter = labMessageService.buildCriteriaFilter(cb, labMessage, criteria);
 		}
 
-		cq.where(whereFilter);
+		if (filter != null) {
+			cq.where(filter);
+		}
 
 		// Distinct is necessary here to avoid duplicate results due to the user role join in taskService.createAssigneeFilter
 		cq.distinct(true);


### PR DESCRIPTION
<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #8909 

For a while I was wondering, whether it should be allowed to call LabMessageFacadeEjb.getIndexList(...) with null criteria.
I could not find a clear answer, so I left the current behaviour as is. Alternatively, one could not check `if (criteria != null)`.

This should only be merged after the hotfix was released.