### PR TITLE
SORQA-203fix

### DIFF
--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/events/EventDirectorySteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/events/EventDirectorySteps.java
@@ -967,6 +967,8 @@ public class EventDirectorySteps implements En {
     When(
         "I check that four new events have appeared in Events directory",
         () -> {
+          TimeUnit.SECONDS.sleep(2); // wait for spinner
+          webDriverHelpers.waitForPageLoadingSpinnerToDisappear(50);
           List<String> eventUUIDs = new ArrayList<>();
           List<String> eventTitles = new ArrayList<>();
           List<Map<String, String>> tableRowsData = getTableRowsData();


### PR DESCRIPTION
Added wait for spinner as a sleep, and waiting for spinner disappear with 50 seconds timeout. It was needed because tests started to check unloaded records in event tab

![image](https://user-images.githubusercontent.com/96249076/165082149-cc9bfad3-e92b-457d-ade3-f0f7cf825be6.png)
