### PR TITLE
#8704 rewrite case tests results count

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/dashboard/DashboardFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/dashboard/DashboardFacade.java
@@ -25,8 +25,6 @@ public interface DashboardFacade {
 
 	String getLastReportedDistrictName(DashboardCriteria dashboardCriteria);
 
-	Map<PathogenTestResultType, Long> getTestResultCountByResultType(List<DashboardCaseDto> cases);
-
 	long countCasesConvertedFromContacts(DashboardCriteria dashboardCriteria);
 
 	Map<PresentCondition, Integer> getCasesCountPerPersonCondition(DashboardCriteria dashboardCriteria);

--- a/sormas-api/src/main/java/de/symeda/sormas/api/sample/SampleFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/sample/SampleFacade.java
@@ -73,8 +73,6 @@ public interface SampleFacade {
 
 	boolean isDeleted(String sampleUuid);
 
-	Map<PathogenTestResultType, Long> getNewTestResultCountByResultType(List<Long> caseIds);
-
 	List<SampleDto> getByCaseUuids(List<String> caseUuids);
 
 	Boolean isSampleEditAllowed(String sampleUuid);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseService.java
@@ -1079,13 +1079,21 @@ public class CaseService extends AbstractCoreAdoService<Case> {
 		return builder;
 	}
 
+	public Predicate createUserFilter(CaseQueryContext caseQueryContext) {
+		return createUserFilter(caseQueryContext, null);
+	}
+
 	@SuppressWarnings("rawtypes")
-	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Case> casePath, CaseUserFilterCriteria userFilterCriteria) {
+	public Predicate createUserFilter(CaseQueryContext caseQueryContext, CaseUserFilterCriteria userFilterCriteria) {
 
 		User currentUser = getCurrentUser();
 		if (currentUser == null) {
 			return null;
 		}
+
+		final CriteriaQuery<?> cq = caseQueryContext.getQuery();
+		final CriteriaBuilder cb = caseQueryContext.getCriteriaBuilder();
+		final From<?, Case> casePath = caseQueryContext.getRoot();
 
 		Predicate filterResponsible = null;
 		Predicate filter = null;
@@ -1195,10 +1203,17 @@ public class CaseService extends AbstractCoreAdoService<Case> {
 		return filter;
 	}
 
+	// XXX To be removed when merging with #8747
 	@SuppressWarnings("rawtypes")
 	@Override
 	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Case> casePath) {
-		return createUserFilter(cb, cq, casePath, null);
+		return createUserFilter(new CaseQueryContext(cb, cq, casePath));
+	}
+
+	// XXX To be removed when merging with #8747
+	@SuppressWarnings("rawtypes")
+	public Predicate createUserFilter(CriteriaBuilder cb, CriteriaQuery cq, From<?, Case> casePath, CaseUserFilterCriteria userFilterCriteria) {
+		return createUserFilter(new CaseQueryContext(cb, cq, casePath), userFilterCriteria);		
 	}
 
 	/**

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/dashboard/DashboardFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/dashboard/DashboardFacadeEjb.java
@@ -5,7 +5,6 @@ import static de.symeda.sormas.api.dashboard.DashboardContactStatisticDto.PREVIO
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Date;
 import java.util.EnumMap;
 import java.util.HashMap;
@@ -124,18 +123,8 @@ public class DashboardFacadeEjb implements DashboardFacade {
 	@RolesAllowed({
 		UserRight._DASHBOARD_SURVEILLANCE_VIEW,
 		UserRight._DASHBOARD_CONTACT_VIEW })
-	public Map<PathogenTestResultType, Long> getTestResultCountByResultType(List<DashboardCaseDto> cases) {
-		if (cases.isEmpty()) {
-			return Collections.emptyMap();
-		}
-		return sampleFacade.getNewTestResultCountByResultType(cases.stream().map(DashboardCaseDto::getId).collect(Collectors.toList()));
-	}
-
-	@RolesAllowed({
-		UserRight._DASHBOARD_SURVEILLANCE_VIEW,
-		UserRight._DASHBOARD_CONTACT_VIEW })
 	public Map<PathogenTestResultType, Long> getTestResultCountByResultType(DashboardCriteria dashboardCriteria) {
-		return getTestResultCountByResultType(getCases(dashboardCriteria));
+		return dashboardService.getNewTestResultCountByResultType(dashboardCriteria);
 	}
 
 	@RolesAllowed({

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/dashboard/PathogenTestResultDto.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/dashboard/PathogenTestResultDto.java
@@ -1,0 +1,45 @@
+package de.symeda.sormas.backend.dashboard;
+
+import java.io.Serializable;
+import java.util.Date;
+
+import de.symeda.sormas.api.sample.PathogenTestResultType;
+
+class PathogenTestResultDto implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private Long caseId;
+	private PathogenTestResultType pathogenTestResultType;
+	private Date sampleDateTime;
+
+	public PathogenTestResultDto(Long caseId, PathogenTestResultType pathogenTestResultType, Date sampleDateTime) {
+		this.caseId = caseId;
+		this.pathogenTestResultType = pathogenTestResultType;
+		this.sampleDateTime = sampleDateTime;
+	}
+
+	public Long getCaseId() {
+		return caseId;
+	}
+
+	public void setCaseId(Long caseId) {
+		this.caseId = caseId;
+	}
+
+	public PathogenTestResultType getPathogenTestResultType() {
+		return pathogenTestResultType;
+	}
+
+	public void setPathogenTestResultType(PathogenTestResultType pathogenTestResultType) {
+		this.pathogenTestResultType = pathogenTestResultType;
+	}
+
+	public Date getSampleDateTime() {
+		return sampleDateTime;
+	}
+
+	public void setSampleDateTime(Date sampleDateTime) {
+		this.sampleDateTime = sampleDateTime;
+	}
+}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/SampleFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/SampleFacadeEjb.java
@@ -727,11 +727,6 @@ public class SampleFacadeEjb implements SampleFacade {
 		return deletedSampleUuids;
 	}
 
-	@Override
-	public Map<PathogenTestResultType, Long> getNewTestResultCountByResultType(List<Long> caseIds) {
-		return sampleService.getNewTestResultCountByResultType(caseIds);
-	}
-
 	public Sample fromDto(@NotNull SampleDto source, boolean checkChangeDate) {
 
 		Sample target = DtoHelper.fillOrBuildEntity(source, sampleService.getByUuid(source.getUuid()), Sample::new, checkChangeDate);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/SampleService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/SampleService.java
@@ -569,36 +569,6 @@ public class SampleService extends AbstractDeletableAdoService<Sample> {
 		return em.createQuery(cq).getResultList();
 	}
 
-	@SuppressWarnings("unchecked")
-	public Map<PathogenTestResultType, Long> getNewTestResultCountByResultType(List<Long> caseIds) {
-
-		// Avoid parameter limit by joining caseIds to a String instead of n parameters 
-		StringBuilder queryBuilder = new StringBuilder();
-		//@formatter:off
-		queryBuilder.append("WITH sortedsamples AS (SELECT DISTINCT ON (").append(Sample.ASSOCIATED_CASE).append("_id) ")
-					.append(Sample.ASSOCIATED_CASE).append("_id, ").append(Sample.PATHOGEN_TEST_RESULT).append(", ").append(Sample.SAMPLE_DATE_TIME)
-					.append(" FROM ").append(Sample.TABLE_NAME).append(" WHERE (").append(Sample.SPECIMEN_CONDITION).append(" IS NULL OR ")
-					.append(Sample.SPECIMEN_CONDITION).append(" = '").append(SpecimenCondition.ADEQUATE.name()).append("') AND ").append(Sample.TABLE_NAME)
-					.append(".").append(Sample.DELETED).append(" = false ORDER BY ").append(Sample.ASSOCIATED_CASE).append("_id, ")
-					.append(Sample.SAMPLE_DATE_TIME).append(" desc) SELECT sortedsamples.").append(Sample.PATHOGEN_TEST_RESULT).append(", COUNT(")
-					.append(Sample.ASSOCIATED_CASE).append("_id) FROM sortedsamples JOIN ").append(Case.TABLE_NAME).append(" ON sortedsamples.")
-					.append(Sample.ASSOCIATED_CASE).append("_id = ").append(Case.TABLE_NAME).append(".id ")
-					.append(" WHERE sortedsamples.").append(Sample.ASSOCIATED_CASE).append("_id IN (:caseIds)")
-					.append(" GROUP BY sortedsamples." + Sample.PATHOGEN_TEST_RESULT);
-		//@formatter:on
-
-		List<Object[]> results = new LinkedList<>();
-		IterableHelper.executeBatched(caseIds, ModelConstants.PARAMETER_LIMIT, batchedCaseIds -> {
-			Query query = em.createNativeQuery(queryBuilder.toString());
-			query.setParameter("caseIds", batchedCaseIds);
-			results.addAll(query.getResultList());
-		});
-
-		return results.stream()
-			.filter(e -> e[0] != null)
-			.collect(Collectors.toMap(e -> PathogenTestResultType.valueOf((String) e[0]), e -> ((BigInteger) e[1]).longValue(), Long::sum));
-	}
-
 	@Override
 	@SuppressWarnings("rawtypes")
 	@Deprecated

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/dashboard/DashboardFacadeEjbTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/dashboard/DashboardFacadeEjbTest.java
@@ -6,8 +6,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-import de.symeda.sormas.api.person.PresentCondition;
-import de.symeda.sormas.api.user.UserReferenceDto;
+import org.junit.Assert;
 import org.junit.Test;
 
 import de.symeda.sormas.api.Disease;
@@ -23,9 +22,15 @@ import de.symeda.sormas.api.event.EventDto;
 import de.symeda.sormas.api.event.EventInvestigationStatus;
 import de.symeda.sormas.api.event.EventStatus;
 import de.symeda.sormas.api.event.TypeOfPlace;
-import de.symeda.sormas.api.person.PersonDto;
 import de.symeda.sormas.api.infrastructure.community.CommunityDto;
+import de.symeda.sormas.api.person.PersonDto;
+import de.symeda.sormas.api.person.PresentCondition;
+import de.symeda.sormas.api.sample.PathogenTestResultType;
+import de.symeda.sormas.api.sample.SampleDto;
+import de.symeda.sormas.api.sample.SampleMaterial;
+import de.symeda.sormas.api.sample.SpecimenCondition;
 import de.symeda.sormas.api.user.UserDto;
+import de.symeda.sormas.api.user.UserReferenceDto;
 import de.symeda.sormas.api.user.UserRole;
 import de.symeda.sormas.api.utils.DateHelper;
 import de.symeda.sormas.backend.AbstractBeanTest;
@@ -70,6 +75,81 @@ public class DashboardFacadeEjbTest extends AbstractBeanTest {
 
 		// List should have only one entry; shared case should not appear
 		assertEquals(1, dashboardCaseDtos.size());
+	}
+
+	@Test
+	public void testGetTestResultCountByResultType() {
+
+		TestDataCreator.RDCFEntities rdcf = creator.createRDCFEntities("Region", "District", "Community", "Facility");
+		UserDto user = creator
+			.createUser(rdcf.region.getUuid(), rdcf.district.getUuid(), rdcf.facility.getUuid(), "Surv", "Sup", UserRole.SURVEILLANCE_SUPERVISOR);
+		PersonDto cazePerson = creator.createPerson("Case", "Person");
+		Date reportAndOnsetDate = new Date();
+		CaseDataDto caze = creator.createCase(
+			user.toReference(),
+			cazePerson.toReference(),
+			Disease.EVD,
+			CaseClassification.PROBABLE,
+			InvestigationStatus.PENDING,
+			reportAndOnsetDate,
+			rdcf);
+
+		SampleDto sample = creator.createSample(caze.toReference(), new Date(), new Date(), user.toReference(), SampleMaterial.BLOOD, rdcf.facility);
+		sample.setPathogenTestResult(PathogenTestResultType.NEGATIVE);
+		sample.setSpecimenCondition(SpecimenCondition.ADEQUATE);
+
+		getSampleFacade().saveSample(sample);
+
+		DashboardCriteria dashboardCriteria = new DashboardCriteria().region(caze.getResponsibleRegion())
+			.district(caze.getDistrict())
+			.disease(caze.getDisease())
+			.newCaseDateType(NewCaseDateType.REPORT)
+			.dateBetween(DateHelper.subtractDays(reportAndOnsetDate, 1), DateHelper.addDays(reportAndOnsetDate, 1));
+
+		Map<PathogenTestResultType, Long> testResultCountByResultType = getDashboardFacade().getTestResultCountByResultType(dashboardCriteria);
+		Assert.assertNotNull(testResultCountByResultType);
+		Assert.assertEquals(1, (long) testResultCountByResultType.get(PathogenTestResultType.NEGATIVE));
+		Assert.assertNull(testResultCountByResultType.get(PathogenTestResultType.INDETERMINATE));
+		Assert.assertNull(testResultCountByResultType.get(PathogenTestResultType.NOT_DONE));
+		Assert.assertNull(testResultCountByResultType.get(PathogenTestResultType.PENDING));
+		Assert.assertNull(testResultCountByResultType.get(PathogenTestResultType.POSITIVE));
+
+		SampleDto sample2 = creator.createSample(caze.toReference(), new Date(), new Date(), user.toReference(), SampleMaterial.BLOOD, rdcf.facility);
+		sample2.setPathogenTestResult(PathogenTestResultType.POSITIVE);
+		sample2.setSpecimenCondition(SpecimenCondition.ADEQUATE);
+
+		getSampleFacade().saveSample(sample2);
+
+		Map<PathogenTestResultType, Long> testResultCountByResultType2 = getDashboardFacade().getTestResultCountByResultType(dashboardCriteria);
+		Assert.assertNotNull(testResultCountByResultType2);
+		Assert.assertNull(testResultCountByResultType2.get(PathogenTestResultType.NEGATIVE));
+		Assert.assertNull(testResultCountByResultType2.get(PathogenTestResultType.INDETERMINATE));
+		Assert.assertNull(testResultCountByResultType2.get(PathogenTestResultType.NOT_DONE));
+		Assert.assertNull(testResultCountByResultType2.get(PathogenTestResultType.PENDING));
+		Assert.assertEquals(1, (long) testResultCountByResultType2.get(PathogenTestResultType.POSITIVE));
+
+		CaseDataDto caze2 = creator.createCase(
+				user.toReference(),
+				cazePerson.toReference(),
+				Disease.EVD,
+				CaseClassification.PROBABLE,
+				InvestigationStatus.PENDING,
+				reportAndOnsetDate,
+				rdcf);
+
+		SampleDto sample3 = creator.createSample(caze2.toReference(), new Date(), new Date(), user.toReference(), SampleMaterial.BLOOD, rdcf.facility);
+		sample3.setPathogenTestResult(PathogenTestResultType.NEGATIVE);
+		sample3.setSpecimenCondition(SpecimenCondition.ADEQUATE);
+
+		getSampleFacade().saveSample(sample3);
+
+		Map<PathogenTestResultType, Long> testResultCountByResultType3 = getDashboardFacade().getTestResultCountByResultType(dashboardCriteria);
+		Assert.assertNotNull(testResultCountByResultType3);
+		Assert.assertEquals(1, (long) testResultCountByResultType3.get(PathogenTestResultType.NEGATIVE));
+		Assert.assertNull(testResultCountByResultType3.get(PathogenTestResultType.INDETERMINATE));
+		Assert.assertNull(testResultCountByResultType3.get(PathogenTestResultType.NOT_DONE));
+		Assert.assertNull(testResultCountByResultType3.get(PathogenTestResultType.PENDING));
+		Assert.assertEquals(1, (long) testResultCountByResultType3.get(PathogenTestResultType.POSITIVE));
 	}
 
 	@Test

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/sample/SampleFacadeEjbTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/sample/SampleFacadeEjbTest.java
@@ -529,67 +529,6 @@ public class SampleFacadeEjbTest extends AbstractBeanTest {
 	}
 
 	@Test
-	public void testGetNewTestResultCountByResultType() {
-
-		RDCFEntities rdcf = creator.createRDCFEntities();
-		UserReferenceDto user = creator.createUser(rdcf).toReference();
-		PersonReferenceDto person1 = creator.createPerson("Heinz", "First").toReference();
-		PersonReferenceDto person2 = creator.createPerson("Heinz", "Second").toReference();
-		CaseDataDto case1 = creator.createCase(user, person1, rdcf);
-		CaseDataDto case2 = creator.createCase(user, person2, rdcf);
-
-		Date date = new Date();
-		DashboardCriteria dashboardCriteria = new DashboardCriteria().region(case1.getResponsibleRegion())
-				.district(case1.getDistrict())
-				.disease(case1.getDisease())
-				.newCaseDateType(NewCaseDateType.REPORT)
-				.dateBetween(DateHelper.subtractDays(date, 1), DateHelper.addDays(date, 1));
-
-		DashboardFacade dashboardFacade = getDashboardFacade();
-		// no existing samples
-		Map<PathogenTestResultType, Long> resultMap = dashboardFacade.getTestResultCountByResultType(dashboardCriteria);
-		assertEquals(new Long(0), resultMap.values().stream().collect(Collectors.summingLong(Long::longValue)));
-		assertNull(resultMap.getOrDefault(PathogenTestResultType.INDETERMINATE, null));
-		assertNull(resultMap.getOrDefault(PathogenTestResultType.NEGATIVE, null));
-		assertNull(resultMap.getOrDefault(PathogenTestResultType.PENDING, null));
-		assertNull(resultMap.getOrDefault(PathogenTestResultType.POSITIVE, null));
-
-		// one pending sample with in one case
-		Facility lab = creator.createFacility("facility", rdcf.region, rdcf.district, rdcf.community);
-		creator.createSample(case1.toReference(), user, lab);
-
-		resultMap = dashboardFacade.getTestResultCountByResultType(dashboardCriteria);
-		assertEquals(new Long(1), resultMap.values().stream().collect(Collectors.summingLong(Long::longValue)));
-		assertNull(resultMap.getOrDefault(PathogenTestResultType.INDETERMINATE, null));
-		assertNull(resultMap.getOrDefault(PathogenTestResultType.NEGATIVE, null));
-		assertEquals(new Long(1), resultMap.getOrDefault(PathogenTestResultType.PENDING, null));
-		assertNull(resultMap.getOrDefault(PathogenTestResultType.POSITIVE, null));
-
-		// one pending sample in each of two cases
-		creator.createSample(case2.toReference(), user, lab);
-
-		resultMap = dashboardFacade.getTestResultCountByResultType(dashboardCriteria);
-		assertEquals(new Long(2), resultMap.values().stream().collect(Collectors.summingLong(Long::longValue)));
-		assertNull(resultMap.getOrDefault(PathogenTestResultType.INDETERMINATE, null));
-		assertNull(resultMap.getOrDefault(PathogenTestResultType.NEGATIVE, null));
-		assertEquals(new Long(2), resultMap.getOrDefault(PathogenTestResultType.PENDING, null));
-		assertNull(resultMap.getOrDefault(PathogenTestResultType.POSITIVE, null));
-
-		// one pending sample in each of two cases
-		// and one positive sample in one of the two cases
-		SampleDto sample = creator.createSample(case1.toReference(), user, lab);
-		sample.setPathogenTestResult(PathogenTestResultType.POSITIVE);
-		getSampleFacade().saveSample(sample);
-
-		resultMap = dashboardFacade.getTestResultCountByResultType(dashboardCriteria);
-		assertEquals(new Long(2), resultMap.values().stream().collect(Collectors.summingLong(Long::longValue)));
-		assertNull(resultMap.getOrDefault(PathogenTestResultType.INDETERMINATE, null));
-		assertNull(resultMap.getOrDefault(PathogenTestResultType.NEGATIVE, null));
-		assertEquals(new Long(1), resultMap.getOrDefault(PathogenTestResultType.PENDING, null));
-		assertEquals(new Long(1), resultMap.getOrDefault(PathogenTestResultType.POSITIVE, null));
-	}
-
-	@Test
 	public void testGetByCaseUuids() {
 
 		RDCFEntities rdcf = creator.createRDCFEntities("Region", "District", "Community", "Facility");

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/sample/SampleServiceTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/sample/SampleServiceTest.java
@@ -1,17 +1,10 @@
 package de.symeda.sormas.backend.sample;
 
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.LongStream;
 
 import org.junit.Test;
 
@@ -28,35 +21,6 @@ import de.symeda.sormas.backend.TestDataCreator;
  * @see SampleService
  */
 public class SampleServiceTest extends AbstractBeanTest {
-
-	@Test
-	public void testGetNewTestResultCountByResultTypeVariousInClauseCount() {
-
-		SampleService cut = getBean(SampleService.class);
-
-		// 0. Works for 0 cases
-		assertThat(cut.getNewTestResultCountByResultType(Collections.emptyList()).entrySet(), is(empty()));
-		assertThat(cut.getNewTestResultCountByResultType(null).entrySet(), is(empty()));
-
-		// 1a. Works for 1 case
-		assertThat(cut.getNewTestResultCountByResultType(Collections.singletonList(1001L)).entrySet(), is(empty()));
-
-		// 1b. Works for 2 cases
-		assertThat(cut.getNewTestResultCountByResultType(Arrays.asList(1L, 2L)).entrySet(), is(empty()));
-
-		// 1c. Works for 3 cases
-		assertThat(cut.getNewTestResultCountByResultType(Arrays.asList(1L, 2L, 1001L)).entrySet(), is(empty()));
-
-		// 2a. Works for 1_000 cases
-		assertThat(
-			cut.getNewTestResultCountByResultType(LongStream.rangeClosed(1, 1_000).boxed().collect(Collectors.toList())).entrySet(),
-			is(empty()));
-
-		// 2b. Works for 100_000 cases
-		assertThat(
-			cut.getNewTestResultCountByResultType(LongStream.rangeClosed(1, 100_000).boxed().collect(Collectors.toList())).entrySet(),
-			is(empty()));
-	}
 
 	@Test
 	public void testSamplePermanentDeletion() {

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/dashboard/DashboardDataProvider.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/dashboard/DashboardDataProvider.java
@@ -204,7 +204,7 @@ public class DashboardDataProvider {
 			setPreviousCases(FacadeProvider.getDashboardFacade().getCases(dashboardCriteria));
 
 			if (getDashboardType() != DashboardType.CONTACTS) {
-				setTestResultCountByResultType(FacadeProvider.getDashboardFacade().getTestResultCountByResultType(getCases()));
+				setTestResultCountByResultType(FacadeProvider.getDashboardFacade().getTestResultCountByResultType(dashboardCriteria));
 			}
 
 			dashboardCriteria.dateBetween(fromDate, toDate).includeNotACaseClassification(true);


### PR DESCRIPTION
<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #8704, replaces #8973.

Further improvements:

1. Fresh start from `development`, picked needed (and currently missing) method signature ` CaseService.createUserFilter(CaseQueryContext)`.
2. Removed some superfluous change noise on removed signatures.
3. Code comments within the new method `DashboardService.getNewTestResultCountByResultType`, some refactoring for better readable code.
4. Moved the DTO class out of the EJB (in favor for separate java file instead of inner class to have less cluttered EJB class code).
5. Documented SQL queries before/after here: https://github.com/hzi-braunschweig/SORMAS-Project/issues/8704#issuecomment-1112990750

I think we still need to move/integrate `SampleFacadeEjbTest.testGetNewTestResultCountByResultType` into `DashboardFacadeEjbTest`.