### PR TITLE
edit/view rights in mobile app synchronization #8989

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/InfrastructureChangeDatesDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/InfrastructureChangeDatesDto.java
@@ -21,8 +21,6 @@ public class InfrastructureChangeDatesDto implements Serializable {
 	private Date diseaseConfigurationChangeDate;
 	private Date userRoleConfigurationChangeDate;
 	private Date featureConfigurationChangeDate;
-	private Date campaignChangeDate;
-	private Date campaignFormMetaChangeDate;
 
 	public Date getContinentChangeDate() {
 		return continentChangeDate;
@@ -134,21 +132,5 @@ public class InfrastructureChangeDatesDto implements Serializable {
 
 	public void setFeatureConfigurationChangeDate(Date featureConfigurationChangeDate) {
 		this.featureConfigurationChangeDate = featureConfigurationChangeDate;
-	}
-
-	public Date getCampaignChangeDate() {
-		return campaignChangeDate;
-	}
-
-	public void setCampaignChangeDate(Date campaignChangeDate) {
-		this.campaignChangeDate = campaignChangeDate;
-	}
-
-	public Date getCampaignFormMetaChangeDate() {
-		return campaignFormMetaChangeDate;
-	}
-
-	public void setCampaignFormMetaChangeDate(Date campaignFormMetaChangeDate) {
-		this.campaignFormMetaChangeDate = campaignFormMetaChangeDate;
 	}
 }

--- a/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/InfrastructureSyncDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/InfrastructureSyncDto.java
@@ -41,8 +41,6 @@ public class InfrastructureSyncDto implements Serializable {
 	private List<String> deletedUserRoleConfigurationUuids;
 	private List<FeatureConfigurationDto> featureConfigurations;
 	private List<String> deletedFeatureConfigurationUuids;
-	private List<CampaignDto> campaigns;
-	private List<CampaignFormMetaDto> campaignFormMetas;
 
 	public boolean isInitialSyncRequired() {
 		return initialSyncRequired;
@@ -178,21 +176,5 @@ public class InfrastructureSyncDto implements Serializable {
 
 	public void setDeletedFeatureConfigurationUuids(List<String> deletedFeatureConfigurationUuids) {
 		this.deletedFeatureConfigurationUuids = deletedFeatureConfigurationUuids;
-	}
-
-	public List<CampaignDto> getCampaigns() {
-		return campaigns;
-	}
-
-	public void setCampaigns(List<CampaignDto> campaigns) {
-		this.campaigns = campaigns;
-	}
-
-	public List<CampaignFormMetaDto> getCampaignFormMetas() {
-		return campaignFormMetas;
-	}
-
-	public void setCampaignFormMetas(List<CampaignFormMetaDto> campaignFormMetas) {
-		this.campaignFormMetas = campaignFormMetas;
 	}
 }

--- a/sormas-api/src/main/java/de/symeda/sormas/api/user/DtoViewAndEditRights.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/user/DtoViewAndEditRights.java
@@ -75,7 +75,7 @@ public class DtoViewAndEditRights {
 		viewRights.put(PersonDto.class.getSimpleName(), UserRight.PERSON_VIEW);
 		editRights.put(PersonDto.class.getSimpleName(), UserRight.PERSON_EDIT);
 
-		// no explicit UserRight to view PrescriptionDto
+		viewRights.put(PrescriptionDto.class.getSimpleName(), UserRight.CASE_VIEW);
 		editRights.put(PrescriptionDto.class.getSimpleName(), UserRight.PRESCRIPTION_EDIT);
 
 		viewRights.put(SampleDto.class.getSimpleName(), UserRight.SAMPLE_VIEW);
@@ -84,10 +84,12 @@ public class DtoViewAndEditRights {
 		viewRights.put(TaskDto.class.getSimpleName(), UserRight.TASK_VIEW);
 		editRights.put(TaskDto.class.getSimpleName(), UserRight.TASK_EDIT);
 
-		// no explicit UserRight to view TreatmentDto
+		viewRights.put(TreatmentDto.class.getSimpleName(), UserRight.CASE_VIEW);
 		editRights.put(TreatmentDto.class.getSimpleName(), UserRight.TREATMENT_EDIT);
 
-		// no explicit UserRight to view VisitDto
+		// can be with CONTACT_VIEW, too. Currently all user roles that can view
+		// cases can also view contacts.
+		viewRights.put(VisitDto.class.getSimpleName(), UserRight.CASE_VIEW);
 		editRights.put(VisitDto.class.getSimpleName(), UserRight.VISIT_EDIT);
 
 		viewRights.put(WeeklyReportDto.class.getSimpleName(), UserRight.WEEKLYREPORT_VIEW);

--- a/sormas-api/src/main/java/de/symeda/sormas/api/user/DtoViewAndEditRights.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/user/DtoViewAndEditRights.java
@@ -16,6 +16,7 @@
 package de.symeda.sormas.api.user;
 
 import de.symeda.sormas.api.campaign.CampaignDto;
+import de.symeda.sormas.api.campaign.data.CampaignFormDataDto;
 import de.symeda.sormas.api.campaign.form.CampaignFormMetaDto;
 import java.util.HashMap;
 import java.util.Map;
@@ -97,14 +98,14 @@ public class DtoViewAndEditRights {
 		viewRights.put(WeeklyReportDto.class.getSimpleName(), UserRight.WEEKLYREPORT_VIEW);
 		// no explicit UserRight to edit WeeklyReportDto
 
-		viewRights.put(CampaignDto.class.getSimpleName(), UserRight.CAMPAIGN_VIEW);
-		editRights.put(CampaignDto.class.getSimpleName(), UserRight.CAMPAIGN_EDIT);
-
 		viewRights.put(CampaignFormMetaDto.class.getSimpleName(), UserRight.CAMPAIGN_VIEW);
 		editRights.put(CampaignFormMetaDto.class.getSimpleName(), UserRight.CAMPAIGN_EDIT);
 
 		viewRights.put(CampaignDto.class.getSimpleName(), UserRight.CAMPAIGN_VIEW);
 		editRights.put(CampaignDto.class.getSimpleName(), UserRight.CAMPAIGN_EDIT);
+
+		viewRights.put(CampaignFormDataDto.class.getSimpleName(), UserRight.CAMPAIGN_VIEW);
+		editRights.put(CampaignFormDataDto.class.getSimpleName(), UserRight.CAMPAIGN_EDIT);
 	}
 
 	public static UserRight getUserRightView(Class clazz) {

--- a/sormas-api/src/main/java/de/symeda/sormas/api/user/DtoViewAndEditRights.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/user/DtoViewAndEditRights.java
@@ -1,0 +1,104 @@
+/*
+ * SORMAS® - Surveillance Outbreak Response Management & Analysis System
+ * Copyright © 2016-2022 Helmholtz-Zentrum für Infektionsforschung GmbH (HZI)
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package de.symeda.sormas.api.user;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import de.symeda.sormas.api.caze.CaseDataDto;
+import de.symeda.sormas.api.clinicalcourse.ClinicalVisitDto;
+import de.symeda.sormas.api.contact.ContactDto;
+import de.symeda.sormas.api.event.EventDto;
+import de.symeda.sormas.api.event.EventParticipantDto;
+import de.symeda.sormas.api.immunization.ImmunizationDto;
+import de.symeda.sormas.api.outbreak.OutbreakDto;
+import de.symeda.sormas.api.person.PersonDto;
+import de.symeda.sormas.api.report.AggregateReportDto;
+import de.symeda.sormas.api.report.WeeklyReportDto;
+import de.symeda.sormas.api.sample.AdditionalTestDto;
+import de.symeda.sormas.api.sample.PathogenTestDto;
+import de.symeda.sormas.api.sample.SampleDto;
+import de.symeda.sormas.api.task.TaskDto;
+import de.symeda.sormas.api.therapy.PrescriptionDto;
+import de.symeda.sormas.api.therapy.TreatmentDto;
+import de.symeda.sormas.api.visit.VisitDto;
+
+public class DtoViewAndEditRights {
+
+	private static Map<String, UserRight> viewRights = new HashMap<>();
+	private static Map<String, UserRight> editRights = new HashMap<>();
+
+	static {
+		viewRights.put(AdditionalTestDto.class.getSimpleName(), UserRight.ADDITIONAL_TEST_VIEW);
+		editRights.put(AdditionalTestDto.class.getSimpleName(), UserRight.ADDITIONAL_TEST_EDIT);
+
+		viewRights.put(AggregateReportDto.class.getSimpleName(), UserRight.AGGREGATE_REPORT_VIEW);
+		editRights.put(AggregateReportDto.class.getSimpleName(), UserRight.AGGREGATE_REPORT_EDIT);
+
+		viewRights.put(CaseDataDto.class.getSimpleName(), UserRight.CASE_VIEW);
+		editRights.put(CaseDataDto.class.getSimpleName(), UserRight.CASE_EDIT);
+
+		viewRights.put(ClinicalVisitDto.class.getSimpleName(), UserRight.CLINICAL_COURSE_VIEW);
+		editRights.put(ClinicalVisitDto.class.getSimpleName(), UserRight.CLINICAL_VISIT_EDIT);
+
+		viewRights.put(ContactDto.class.getSimpleName(), UserRight.CONTACT_VIEW);
+		editRights.put(ContactDto.class.getSimpleName(), UserRight.CONTACT_EDIT);
+
+		viewRights.put(EventDto.class.getSimpleName(), UserRight.EVENT_VIEW);
+		editRights.put(EventDto.class.getSimpleName(), UserRight.EVENT_EDIT);
+
+		viewRights.put(EventParticipantDto.class.getSimpleName(), UserRight.EVENTPARTICIPANT_VIEW);
+		editRights.put(EventParticipantDto.class.getSimpleName(), UserRight.EVENTPARTICIPANT_EDIT);
+
+		viewRights.put(ImmunizationDto.class.getSimpleName(), UserRight.IMMUNIZATION_VIEW);
+		editRights.put(ImmunizationDto.class.getSimpleName(), UserRight.IMMUNIZATION_EDIT);
+
+		viewRights.put(OutbreakDto.class.getSimpleName(), UserRight.OUTBREAK_VIEW);
+		editRights.put(OutbreakDto.class.getSimpleName(), UserRight.OUTBREAK_EDIT);
+
+		// no explicit UserRight to view PathogenTestDto
+		editRights.put(PathogenTestDto.class.getSimpleName(), UserRight.PATHOGEN_TEST_EDIT);
+
+		viewRights.put(PersonDto.class.getSimpleName(), UserRight.PERSON_VIEW);
+		editRights.put(PersonDto.class.getSimpleName(), UserRight.PERSON_EDIT);
+
+		// no explicit UserRight to view PrescriptionDto
+		editRights.put(PrescriptionDto.class.getSimpleName(), UserRight.PRESCRIPTION_EDIT);
+
+		viewRights.put(SampleDto.class.getSimpleName(), UserRight.SAMPLE_VIEW);
+		editRights.put(SampleDto.class.getSimpleName(), UserRight.SAMPLE_EDIT);
+
+		viewRights.put(TaskDto.class.getSimpleName(), UserRight.TASK_VIEW);
+		editRights.put(TaskDto.class.getSimpleName(), UserRight.TASK_EDIT);
+
+		// no explicit UserRight to view TreatmentDto
+		editRights.put(TreatmentDto.class.getSimpleName(), UserRight.TREATMENT_EDIT);
+
+		// no explicit UserRight to view VisitDto
+		editRights.put(VisitDto.class.getSimpleName(), UserRight.VISIT_EDIT);
+
+		viewRights.put(WeeklyReportDto.class.getSimpleName(), UserRight.WEEKLYREPORT_VIEW);
+		// no explicit UserRight to edit WeeklyReportDto
+	}
+
+	public static UserRight getUserRightView(Class clazz) {
+		return viewRights.get(clazz.getSimpleName());
+	}
+
+	public static UserRight getUserRightEdit(Class clazz) {
+		return editRights.get(clazz.getSimpleName());
+	}
+}

--- a/sormas-api/src/main/java/de/symeda/sormas/api/user/DtoViewAndEditRights.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/user/DtoViewAndEditRights.java
@@ -15,6 +15,8 @@
 
 package de.symeda.sormas.api.user;
 
+import de.symeda.sormas.api.campaign.CampaignDto;
+import de.symeda.sormas.api.campaign.form.CampaignFormMetaDto;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -94,6 +96,15 @@ public class DtoViewAndEditRights {
 
 		viewRights.put(WeeklyReportDto.class.getSimpleName(), UserRight.WEEKLYREPORT_VIEW);
 		// no explicit UserRight to edit WeeklyReportDto
+
+		viewRights.put(CampaignDto.class.getSimpleName(), UserRight.CAMPAIGN_VIEW);
+		editRights.put(CampaignDto.class.getSimpleName(), UserRight.CAMPAIGN_EDIT);
+
+		viewRights.put(CampaignFormMetaDto.class.getSimpleName(), UserRight.CAMPAIGN_VIEW);
+		editRights.put(CampaignFormMetaDto.class.getSimpleName(), UserRight.CAMPAIGN_EDIT);
+
+		viewRights.put(CampaignDto.class.getSimpleName(), UserRight.CAMPAIGN_VIEW);
+		editRights.put(CampaignDto.class.getSimpleName(), UserRight.CAMPAIGN_EDIT);
 	}
 
 	public static UserRight getUserRightView(Class clazz) {

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/backend/common/AdoDtoHelper.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/backend/common/AdoDtoHelper.java
@@ -32,6 +32,7 @@ import android.util.Log;
 
 import de.symeda.sormas.api.EntityDto;
 import de.symeda.sormas.api.PushResult;
+import de.symeda.sormas.api.user.UserRight;
 import de.symeda.sormas.app.rest.NoConnectionException;
 import de.symeda.sormas.app.rest.RetroProvider;
 import de.symeda.sormas.app.rest.ServerCommunicationException;
@@ -73,6 +74,17 @@ public abstract class AdoDtoHelper<ADO extends AbstractDomainObject, DTO extends
 	protected abstract long getApproximateJsonSizeInBytes();
 
 	/**
+	 * Override if access to viewing /editing is restricted
+	 */
+	protected UserRight getUserRightView() {
+		return null;
+	}
+
+	protected UserRight getUserRightEdit() {
+		return null;
+	}
+
+	/**
 	 * @return another pull needed?
 	 * @param context
 	 */
@@ -86,6 +98,11 @@ public abstract class AdoDtoHelper<ADO extends AbstractDomainObject, DTO extends
 
 	public void pullEntities(final boolean markAsRead, Context context)
 		throws DaoException, ServerCommunicationException, ServerConnectionException, NoConnectionException {
+
+		if (!isViewAllowed()) {
+			return;
+		}
+
 		try {
 			final AbstractAdoDao<ADO> dao = DatabaseHelper.getAdoDao(getAdoClass());
 
@@ -124,6 +141,11 @@ public abstract class AdoDtoHelper<ADO extends AbstractDomainObject, DTO extends
 	}
 
 	public void repullEntities(Context context) throws DaoException, ServerCommunicationException, ServerConnectionException, NoConnectionException {
+
+		if (!isViewAllowed()) {
+			return;
+		}
+
 		try {
 			final AbstractAdoDao<ADO> dao = DatabaseHelper.getAdoDao(getAdoClass());
 
@@ -224,6 +246,11 @@ public abstract class AdoDtoHelper<ADO extends AbstractDomainObject, DTO extends
 	 */
 	public boolean pushEntities(boolean onlyNewEntities)
 		throws DaoException, ServerConnectionException, ServerCommunicationException, NoConnectionException {
+
+		if (!isEditAllowed()) {
+			return false;
+		}
+
 		final AbstractAdoDao<ADO> dao = DatabaseHelper.getAdoDao(getAdoClass());
 
 		final List<ADO> modifiedAdos = onlyNewEntities ? dao.queryForNew() : dao.queryForModified();
@@ -363,5 +390,21 @@ public abstract class AdoDtoHelper<ADO extends AbstractDomainObject, DTO extends
 		dto.setChangeDate(ado.getChangeDate());
 		dto.setCreationDate(ado.getCreationDate());
 		dto.setUuid(ado.getUuid());
+	}
+
+	public boolean isViewAllowed() {
+		try {
+			return DtoUserRightsHelper.isViewAllowed(getDtoClass());
+		} catch (UnsupportedOperationException e) {
+			return true;
+		}
+	}
+
+	public boolean isEditAllowed() {
+		try {
+			return DtoUserRightsHelper.isEditAllowed(getDtoClass());
+		} catch (UnsupportedOperationException e) {
+			return true;
+		}
 	}
 }

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/backend/common/DatabaseHelper.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/backend/common/DatabaseHelper.java
@@ -186,7 +186,7 @@ public class DatabaseHelper extends OrmLiteSqliteOpenHelper {
 	public static final String DATABASE_NAME = "sormas.db";
 	// any time you make changes to your database objects, you may have to increase the database version
 
-	public static final int DATABASE_VERSION = 334;
+	public static final int DATABASE_VERSION = 335;
 
 	private static DatabaseHelper instance = null;
 
@@ -2968,6 +2968,11 @@ public class DatabaseHelper extends OrmLiteSqliteOpenHelper {
 			case 333:
 				currentVersion = 333;
 				getDao(User.class).executeRaw("ALTER TABLE users ADD COLUMN jurisdictionLevel varchar(255);");
+				fillJurisdictionLevels();
+
+			case 334:
+				currentVersion = 334;
+				getDao(FeatureConfiguration.class).executeRaw("DELETE from featureConfiguration WHERE featureType = 'DELETE_PERMANENT';");
 				fillJurisdictionLevels();
 
 				// ATTENTION: break should only be done after last version

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/backend/common/DtoUserRightsHelper.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/backend/common/DtoUserRightsHelper.java
@@ -1,0 +1,37 @@
+/*
+ * SORMAS® - Surveillance Outbreak Response Management & Analysis System
+ * Copyright © 2016-2022 Helmholtz-Zentrum für Infektionsforschung GmbH (HZI)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package de.symeda.sormas.app.backend.common;
+
+import de.symeda.sormas.api.user.DtoViewAndEditRights;
+import de.symeda.sormas.api.user.UserRight;
+import de.symeda.sormas.app.backend.config.ConfigProvider;
+
+public class DtoUserRightsHelper {
+
+	public static boolean isViewAllowed(Class clazz) {
+		UserRight userRightView = DtoViewAndEditRights.getUserRightView(clazz);
+		return userRightView == null || ConfigProvider.hasUserRight(userRightView);
+	}
+
+	public static boolean isEditAllowed(Class clazz) {
+		UserRight userRightEdit = DtoViewAndEditRights.getUserRightEdit(clazz);
+		return userRightEdit == null || ConfigProvider.hasUserRight(userRightEdit);
+	}
+}

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/backend/infrastructure/InfrastructureHelper.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/backend/infrastructure/InfrastructureHelper.java
@@ -42,8 +42,6 @@ public class InfrastructureHelper {
 		changeDates.setDiseaseConfigurationChangeDate(DatabaseHelper.getDiseaseConfigurationDao().getLatestChangeDate());
 		changeDates.setUserRoleConfigurationChangeDate(DatabaseHelper.getUserRoleConfigDao().getLatestChangeDate());
 		changeDates.setFeatureConfigurationChangeDate(DatabaseHelper.getFeatureConfigurationDao().getLatestChangeDate());
-		changeDates.setCampaignChangeDate(DatabaseHelper.getCampaignDao().getLatestChangeDate());
-		changeDates.setCampaignFormMetaChangeDate(DatabaseHelper.getCampaignFormMetaDao().getLatestChangeDate());
 		changeDates.setAreaChangeDate(DatabaseHelper.getAreaDao().getLatestChangeDate());
 
 		return changeDates;
@@ -73,9 +71,5 @@ public class InfrastructureHelper {
 		DatabaseHelper.getFeatureConfigurationDao().delete(infrastructureData.getDeletedFeatureConfigurationUuids());
 		new FeatureConfigurationDtoHelper()
 			.handlePulledList(DatabaseHelper.getFeatureConfigurationDao(), infrastructureData.getFeatureConfigurations());
-		if (!DatabaseHelper.getFeatureConfigurationDao().isFeatureDisabled(FeatureType.CAMPAIGNS)) {
-			new CampaignDtoHelper().handlePulledList(DatabaseHelper.getCampaignDao(), infrastructureData.getCampaigns());
-			new CampaignFormMetaDtoHelper().handlePulledList(DatabaseHelper.getCampaignFormMetaDao(), infrastructureData.getCampaignFormMetas());
-		}
 	}
 }

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/backend/outbreak/OutbreakDtoHelper.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/backend/outbreak/OutbreakDtoHelper.java
@@ -34,11 +34,11 @@ public class OutbreakDtoHelper extends AdoDtoHelper<Outbreak, OutbreakDto> {
 
 	@Override
 	protected Class<OutbreakDto> getDtoClass() {
-		throw new UnsupportedOperationException();
+		return OutbreakDto.class;
 	}
 
 	@Override
-	protected Call<List<OutbreakDto>> pullAllSince(long since, Integer size, String lastSynchronizedUuid)  throws NoConnectionException {
+	protected Call<List<OutbreakDto>> pullAllSince(long since, Integer size, String lastSynchronizedUuid) throws NoConnectionException {
 		return RetroProvider.getOutbreakFacade().pullActiveSince(since);
 	}
 
@@ -67,8 +67,8 @@ public class OutbreakDtoHelper extends AdoDtoHelper<Outbreak, OutbreakDto> {
 		throw new UnsupportedOperationException("Entity is read-only");
 	}
 
-    @Override
-    protected long getApproximateJsonSizeInBytes() {
-        return 0;
-    }
+	@Override
+	protected long getApproximateJsonSizeInBytes() {
+		return 0;
+	}
 }

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/rest/SynchronizeDataAsync.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/rest/SynchronizeDataAsync.java
@@ -17,6 +17,7 @@ package de.symeda.sormas.app.rest;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
@@ -28,10 +29,27 @@ import android.content.Context;
 import android.os.AsyncTask;
 import android.util.Log;
 
+import de.symeda.sormas.api.caze.CaseDataDto;
+import de.symeda.sormas.api.clinicalcourse.ClinicalVisitDto;
+import de.symeda.sormas.api.contact.ContactDto;
+import de.symeda.sormas.api.event.EventDto;
+import de.symeda.sormas.api.event.EventParticipantDto;
 import de.symeda.sormas.api.feature.FeatureType;
+import de.symeda.sormas.api.immunization.ImmunizationDto;
 import de.symeda.sormas.api.infrastructure.InfrastructureChangeDatesDto;
 import de.symeda.sormas.api.infrastructure.InfrastructureSyncDto;
+import de.symeda.sormas.api.outbreak.OutbreakDto;
+import de.symeda.sormas.api.person.PersonDto;
+import de.symeda.sormas.api.report.AggregateReportDto;
+import de.symeda.sormas.api.report.WeeklyReportDto;
+import de.symeda.sormas.api.sample.AdditionalTestDto;
+import de.symeda.sormas.api.sample.PathogenTestDto;
+import de.symeda.sormas.api.sample.SampleDto;
+import de.symeda.sormas.api.task.TaskDto;
+import de.symeda.sormas.api.therapy.PrescriptionDto;
+import de.symeda.sormas.api.therapy.TreatmentDto;
 import de.symeda.sormas.api.utils.DateHelper;
+import de.symeda.sormas.api.visit.VisitDto;
 import de.symeda.sormas.app.R;
 import de.symeda.sormas.app.backend.campaign.CampaignDtoHelper;
 import de.symeda.sormas.app.backend.campaign.data.CampaignFormDataDtoHelper;
@@ -41,8 +59,8 @@ import de.symeda.sormas.app.backend.classification.DiseaseClassificationDtoHelpe
 import de.symeda.sormas.app.backend.clinicalcourse.ClinicalVisitDtoHelper;
 import de.symeda.sormas.app.backend.common.DaoException;
 import de.symeda.sormas.app.backend.common.DatabaseHelper;
+import de.symeda.sormas.app.backend.common.DtoUserRightsHelper;
 import de.symeda.sormas.app.backend.config.ConfigProvider;
-import de.symeda.sormas.app.backend.contact.Contact;
 import de.symeda.sormas.app.backend.contact.ContactDtoHelper;
 import de.symeda.sormas.app.backend.customizableenum.CustomizableEnumValueDtoHelper;
 import de.symeda.sormas.app.backend.disease.DiseaseConfigurationDtoHelper;
@@ -482,41 +500,54 @@ public class SynchronizeDataAsync extends AsyncTask<Void, Void, Void> {
 
 		try {
 			// Cases
-			List<String> caseUuids = executeUuidCall(RetroProvider.getCaseFacade().pullArchivedUuidsSince(since != null ? since.getTime() : 0));
-			for (String caseUuid : caseUuids) {
-				DatabaseHelper.getCaseDao().deleteCaseAndAllDependingEntities(caseUuid);
+			if (DtoUserRightsHelper.isViewAllowed(CaseDataDto.class)) {
+				List<String> caseUuids = executeUuidCall(RetroProvider.getCaseFacade().pullArchivedUuidsSince(since != null ? since.getTime() : 0));
+				for (String caseUuid : caseUuids) {
+					DatabaseHelper.getCaseDao().deleteCaseAndAllDependingEntities(caseUuid);
+				}
 			}
 
 			// Contacts
-			List<String> contactUuids = executeUuidCall(RetroProvider.getContactFacade().pullArchivedUuidsSince(since != null ? since.getTime() : 0));
-			for (String contactUuid : contactUuids) {
-				DatabaseHelper.getContactDao().deleteContactAndAllDependingEntities(contactUuid);
+			if (DtoUserRightsHelper.isViewAllowed(ContactDto.class)) {
+				List<String> contactUuids =
+					executeUuidCall(RetroProvider.getContactFacade().pullArchivedUuidsSince(since != null ? since.getTime() : 0));
+				for (String contactUuid : contactUuids) {
+					DatabaseHelper.getContactDao().deleteContactAndAllDependingEntities(contactUuid);
+				}
 			}
 
 			// Events
-			List<String> eventUuids = executeUuidCall(RetroProvider.getEventFacade().pullArchivedUuidsSince(since != null ? since.getTime() : 0));
-			for (String eventUuid : eventUuids) {
-				DatabaseHelper.getEventDao().deleteEventAndAllDependingEntities(eventUuid);
+			if (DtoUserRightsHelper.isViewAllowed(EventDto.class)) {
+				List<String> eventUuids = executeUuidCall(RetroProvider.getEventFacade().pullArchivedUuidsSince(since != null ? since.getTime() : 0));
+				for (String eventUuid : eventUuids) {
+					DatabaseHelper.getEventDao().deleteEventAndAllDependingEntities(eventUuid);
+				}
 			}
 
 			// EventParticipant
-			List<String> eventParticipantUuids =
-				executeUuidCall(RetroProvider.getEventParticipantFacade().pullArchivedUuidsSince(since != null ? since.getTime() : 0));
-			for (String eventParticipantUuid : eventParticipantUuids) {
-				DatabaseHelper.getEventParticipantDao().deleteEventParticipantAndAllDependingEntities(eventParticipantUuid);
+			if (DtoUserRightsHelper.isViewAllowed(EventParticipantDto.class)) {
+				List<String> eventParticipantUuids =
+					executeUuidCall(RetroProvider.getEventParticipantFacade().pullArchivedUuidsSince(since != null ? since.getTime() : 0));
+				for (String eventParticipantUuid : eventParticipantUuids) {
+					DatabaseHelper.getEventParticipantDao().deleteEventParticipantAndAllDependingEntities(eventParticipantUuid);
+				}
 			}
 
 			// Tasks
-			List<String> taskUuids = executeUuidCall(RetroProvider.getTaskFacade().pullArchivedUuidsSince(since != null ? since.getTime() : 0));
-			for (String taskUuid : taskUuids) {
-				DatabaseHelper.getTaskDao().deleteTaskAndAllDependingEntities(taskUuid);
+			if (DtoUserRightsHelper.isViewAllowed(TaskDto.class)) {
+				List<String> taskUuids = executeUuidCall(RetroProvider.getTaskFacade().pullArchivedUuidsSince(since != null ? since.getTime() : 0));
+				for (String taskUuid : taskUuids) {
+					DatabaseHelper.getTaskDao().deleteTaskAndAllDependingEntities(taskUuid);
+				}
 			}
 
 			// Inactive outbreaks
-			List<String> outbreakUuids =
-				executeUuidCall(RetroProvider.getOutbreakFacade().pullInactiveUuidsSince(since != null ? since.getTime() : 0));
-			for (String outbreakUuid : outbreakUuids) {
-				DatabaseHelper.getOutbreakDao().deleteOutbreakAndAllDependingEntities(outbreakUuid);
+			if (DtoUserRightsHelper.isViewAllowed(OutbreakDto.class)) {
+				List<String> outbreakUuids =
+					executeUuidCall(RetroProvider.getOutbreakFacade().pullInactiveUuidsSince(since != null ? since.getTime() : 0));
+				for (String outbreakUuid : outbreakUuids) {
+					DatabaseHelper.getOutbreakDao().deleteOutbreakAndAllDependingEntities(outbreakUuid);
+				}
 			}
 
 			ConfigProvider.setLastArchivedSyncDate(new Date());
@@ -531,41 +562,55 @@ public class SynchronizeDataAsync extends AsyncTask<Void, Void, Void> {
 
 		try {
 			// Cases
-			List<String> caseUuids = executeUuidCall(RetroProvider.getCaseFacade().pullDeletedUuidsSince(since != null ? since.getTime() : 0));
-			for (String caseUuid : caseUuids) {
-				DatabaseHelper.getCaseDao().deleteCaseAndAllDependingEntities(caseUuid);
+			if (DtoUserRightsHelper.isViewAllowed(CaseDataDto.class)) {
+				List<String> caseUuids = executeUuidCall(RetroProvider.getCaseFacade().pullDeletedUuidsSince(since != null ? since.getTime() : 0));
+				for (String caseUuid : caseUuids) {
+					DatabaseHelper.getCaseDao().deleteCaseAndAllDependingEntities(caseUuid);
+				}
 			}
 
 			// Immunization
-			List<String> immunizationUuids =
-				executeUuidCall(RetroProvider.getImmunizationFacade().pullDeletedUuidsSince(since != null ? since.getTime() : 0));
-			for (String immunizationUuid : immunizationUuids) {
-				DatabaseHelper.getImmunizationDao().deleteImmunizationAndAllDependingEntities(immunizationUuid);
+			if (DtoUserRightsHelper.isViewAllowed(ImmunizationDto.class)) {
+				List<String> immunizationUuids =
+					executeUuidCall(RetroProvider.getImmunizationFacade().pullDeletedUuidsSince(since != null ? since.getTime() : 0));
+				for (String immunizationUuid : immunizationUuids) {
+					DatabaseHelper.getImmunizationDao().deleteImmunizationAndAllDependingEntities(immunizationUuid);
+				}
 			}
 
 			// Events
-			List<String> eventUuids = executeUuidCall(RetroProvider.getEventFacade().pullDeletedUuidsSince(since != null ? since.getTime() : 0));
-			for (String eventUuid : eventUuids) {
-				DatabaseHelper.getEventDao().deleteEventAndAllDependingEntities(eventUuid);
+			if (DtoUserRightsHelper.isViewAllowed(EventDto.class)) {
+				List<String> eventUuids = executeUuidCall(RetroProvider.getEventFacade().pullDeletedUuidsSince(since != null ? since.getTime() : 0));
+				for (String eventUuid : eventUuids) {
+					DatabaseHelper.getEventDao().deleteEventAndAllDependingEntities(eventUuid);
+				}
 			}
 
 			//Event participants
-			List<String> eventParticipantUuids =
-				executeUuidCall(RetroProvider.getEventParticipantFacade().pullDeletedUuidsSince(since != null ? since.getTime() : 0));
-			for (String eventParticipantUuid : eventParticipantUuids) {
-				DatabaseHelper.getEventParticipantDao().deleteEventParticipant(eventParticipantUuid);
+			if (DtoUserRightsHelper.isViewAllowed(EventParticipantDto.class)) {
+				List<String> eventParticipantUuids =
+					executeUuidCall(RetroProvider.getEventParticipantFacade().pullDeletedUuidsSince(since != null ? since.getTime() : 0));
+				for (String eventParticipantUuid : eventParticipantUuids) {
+					DatabaseHelper.getEventParticipantDao().deleteEventParticipant(eventParticipantUuid);
+				}
 			}
 
 			// Contacts
-			List<String> contactUuids = executeUuidCall(RetroProvider.getContactFacade().pullDeletedUuidsSince(since != null ? since.getTime() : 0));
-			for (String contactUuid : contactUuids) {
-				DatabaseHelper.getContactDao().deleteContactAndAllDependingEntities(contactUuid);
+			if (DtoUserRightsHelper.isViewAllowed(ContactDto.class)) {
+				List<String> contactUuids =
+					executeUuidCall(RetroProvider.getContactFacade().pullDeletedUuidsSince(since != null ? since.getTime() : 0));
+				for (String contactUuid : contactUuids) {
+					DatabaseHelper.getContactDao().deleteContactAndAllDependingEntities(contactUuid);
+				}
 			}
 
 			// Samples
-			List<String> sampleUuids = executeUuidCall(RetroProvider.getSampleFacade().pullDeletedUuidsSince(since != null ? since.getTime() : 0));
-			for (String sampleUuid : sampleUuids) {
-				DatabaseHelper.getSampleDao().deleteSampleAndAllDependingEntities(sampleUuid);
+			if (DtoUserRightsHelper.isViewAllowed(SampleDto.class)) {
+				List<String> sampleUuids =
+					executeUuidCall(RetroProvider.getSampleFacade().pullDeletedUuidsSince(since != null ? since.getTime() : 0));
+				for (String sampleUuid : sampleUuids) {
+					DatabaseHelper.getSampleDao().deleteSampleAndAllDependingEntities(sampleUuid);
+				}
 			}
 
 			ConfigProvider.setLastDeletedSyncDate(new Date());
@@ -587,56 +632,75 @@ public class SynchronizeDataAsync extends AsyncTask<Void, Void, Void> {
 		// Example: Case is created using an existing person, meanwhile user loses access to the person
 		pushNewData();
 
+		boolean viewAllowed;
+
 		// weekly reports and entries
-		List<String> weeklyReportUuids = executeUuidCall(RetroProvider.getWeeklyReportFacade().pullUuids());
+		viewAllowed = DtoUserRightsHelper.isViewAllowed(WeeklyReportDto.class);
+		List<String> weeklyReportUuids = viewAllowed ? executeUuidCall(RetroProvider.getWeeklyReportFacade().pullUuids()) : new ArrayList<>();
 		DatabaseHelper.getWeeklyReportDao().deleteInvalid(weeklyReportUuids);
 		// aggregate reports
-		List<String> aggregateReportUuids = executeUuidCall(RetroProvider.getAggregateReportFacade().pullUuids());
+		viewAllowed = DtoUserRightsHelper.isViewAllowed(AggregateReportDto.class);
+		List<String> aggregateReportUuids = viewAllowed ? executeUuidCall(RetroProvider.getAggregateReportFacade().pullUuids()) : new ArrayList<>();
 		DatabaseHelper.getAggregateReportDao().deleteInvalid(aggregateReportUuids);
 		// tasks
-		List<String> taskUuids = executeUuidCall(RetroProvider.getTaskFacade().pullUuids());
+		viewAllowed = DtoUserRightsHelper.isViewAllowed(TaskDto.class);
+		List<String> taskUuids = viewAllowed ? executeUuidCall(RetroProvider.getTaskFacade().pullUuids()) : new ArrayList<>();
 		DatabaseHelper.getTaskDao().deleteInvalid(taskUuids);
 		// visits
-		List<String> visitUuids = executeUuidCall(RetroProvider.getVisitFacade().pullUuids());
+		viewAllowed = DtoUserRightsHelper.isViewAllowed(VisitDto.class);
+		List<String> visitUuids = viewAllowed ? executeUuidCall(RetroProvider.getVisitFacade().pullUuids()) : new ArrayList<>();
 		DatabaseHelper.getVisitDao().deleteInvalid(visitUuids);
 		// contacts
-		List<String> contactUuids = executeUuidCall(RetroProvider.getContactFacade().pullUuids());
+		viewAllowed = DtoUserRightsHelper.isViewAllowed(ContactDto.class);
+		List<String> contactUuids = viewAllowed ? executeUuidCall(RetroProvider.getContactFacade().pullUuids()) : new ArrayList<>();
 		DatabaseHelper.getContactDao().deleteInvalid(contactUuids);
 		// sample tests
-		List<String> sampleTestUuids = executeUuidCall(RetroProvider.getSampleTestFacade().pullUuids());
+		viewAllowed = DtoUserRightsHelper.isViewAllowed(PathogenTestDto.class);
+		List<String> sampleTestUuids = viewAllowed ? executeUuidCall(RetroProvider.getSampleTestFacade().pullUuids()) : new ArrayList<>();
 		DatabaseHelper.getSampleTestDao().deleteInvalid(sampleTestUuids);
 		// additional tests
-		List<String> additionalTestUuids = executeUuidCall(RetroProvider.getAdditionalTestFacade().pullUuids());
+		viewAllowed = DtoUserRightsHelper.isViewAllowed(AdditionalTestDto.class);
+		List<String> additionalTestUuids = viewAllowed ? executeUuidCall(RetroProvider.getAdditionalTestFacade().pullUuids()) : new ArrayList<>();
 		DatabaseHelper.getAdditionalTestDao().deleteInvalid(additionalTestUuids);
 		// samples
-		List<String> sampleUuids = executeUuidCall(RetroProvider.getSampleFacade().pullUuids());
+		viewAllowed = DtoUserRightsHelper.isViewAllowed(SampleDto.class);
+		List<String> sampleUuids = viewAllowed ? executeUuidCall(RetroProvider.getSampleFacade().pullUuids()) : new ArrayList<>();
 		DatabaseHelper.getSampleDao().deleteInvalid(sampleUuids);
 		// event participants
-		List<String> eventParticipantUuids = executeUuidCall(RetroProvider.getEventParticipantFacade().pullUuids());
+		viewAllowed = DtoUserRightsHelper.isViewAllowed(EventParticipantDto.class);
+		List<String> eventParticipantUuids = viewAllowed ? executeUuidCall(RetroProvider.getEventParticipantFacade().pullUuids()) : new ArrayList<>();
 		DatabaseHelper.getEventParticipantDao().deleteInvalid(eventParticipantUuids);
 		// events
-		List<String> eventUuids = executeUuidCall(RetroProvider.getEventFacade().pullUuids());
+		viewAllowed = DtoUserRightsHelper.isViewAllowed(EventDto.class);
+		List<String> eventUuids = viewAllowed ? executeUuidCall(RetroProvider.getEventFacade().pullUuids()) : new ArrayList<>();
 		DatabaseHelper.getEventDao().deleteInvalid(eventUuids);
 		// treatments
-		List<String> treatmentUuids = executeUuidCall(RetroProvider.getTreatmentFacade().pullUuids());
+		viewAllowed = DtoUserRightsHelper.isViewAllowed(TreatmentDto.class);
+		List<String> treatmentUuids = viewAllowed ? executeUuidCall(RetroProvider.getTreatmentFacade().pullUuids()) : new ArrayList<>();
 		DatabaseHelper.getTreatmentDao().deleteInvalid(treatmentUuids);
 		// prescriptions
-		List<String> prescriptionUuids = executeUuidCall(RetroProvider.getPrescriptionFacade().pullUuids());
+		viewAllowed = DtoUserRightsHelper.isViewAllowed(PrescriptionDto.class);
+		List<String> prescriptionUuids = viewAllowed ? executeUuidCall(RetroProvider.getPrescriptionFacade().pullUuids()) : new ArrayList<>();
 		DatabaseHelper.getPrescriptionDao().deleteInvalid(prescriptionUuids);
 		// clinical visits
-		List<String> clinicalVisitUuids = executeUuidCall(RetroProvider.getClinicalVisitFacade().pullUuids());
+		viewAllowed = DtoUserRightsHelper.isViewAllowed(ClinicalVisitDto.class);
+		List<String> clinicalVisitUuids = viewAllowed ? executeUuidCall(RetroProvider.getClinicalVisitFacade().pullUuids()) : new ArrayList<>();
 		DatabaseHelper.getClinicalVisitDao().deleteInvalid(clinicalVisitUuids);
 		// immunizations
-		List<String> immunizationUuids = executeUuidCall(RetroProvider.getImmunizationFacade().pullUuids());
+		viewAllowed = DtoUserRightsHelper.isViewAllowed(ImmunizationDto.class);
+		List<String> immunizationUuids = viewAllowed ? executeUuidCall(RetroProvider.getImmunizationFacade().pullUuids()) : new ArrayList<>();
 		DatabaseHelper.getImmunizationDao().deleteInvalid(immunizationUuids);
 		// cases
-		List<String> caseUuids = executeUuidCall(RetroProvider.getCaseFacade().pullUuids());
+		viewAllowed = DtoUserRightsHelper.isViewAllowed(CaseDataDto.class);
+		List<String> caseUuids = viewAllowed ? executeUuidCall(RetroProvider.getCaseFacade().pullUuids()) : new ArrayList<>();
 		DatabaseHelper.getCaseDao().deleteInvalid(caseUuids);
 		// persons
-		List<String> personUuids = executeUuidCall(RetroProvider.getPersonFacade().pullUuids());
+		viewAllowed = DtoUserRightsHelper.isViewAllowed(PersonDto.class);
+		List<String> personUuids = viewAllowed ? executeUuidCall(RetroProvider.getPersonFacade().pullUuids()) : new ArrayList<>();
 		DatabaseHelper.getPersonDao().deleteInvalid(personUuids);
 		// outbreak
-		List<String> outbreakUuids = executeUuidCall(RetroProvider.getOutbreakFacade().pullActiveUuids());
+		viewAllowed = DtoUserRightsHelper.isViewAllowed(OutbreakDto.class);
+		List<String> outbreakUuids = viewAllowed ? executeUuidCall(RetroProvider.getOutbreakFacade().pullActiveUuids()) : new ArrayList<>();
 		DatabaseHelper.getOutbreakDao().deleteInvalid(outbreakUuids);
 
 		// order is important, due to dependencies (e.g. case & person)

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/rest/SynchronizeDataAsync.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/rest/SynchronizeDataAsync.java
@@ -370,13 +370,15 @@ public class SynchronizeDataAsync extends AsyncTask<Void, Void, Void> {
 
 		// Campaigns
 		if (!DatabaseHelper.getFeatureConfigurationDao().isFeatureDisabled(FeatureType.CAMPAIGNS)) {
-			final CampaignDtoHelper campaignDtoHelper = new CampaignDtoHelper();
-			if (campaignDtoHelper.pullAndPushEntities(context))
-				campaignDtoHelper.pullEntities(true, context);
 
+			// meta first
 			final CampaignFormMetaDtoHelper campaignFormMetaDtoHelper = new CampaignFormMetaDtoHelper();
-			if (campaignFormMetaDtoHelper.pullAndPushEntities(context))
-				campaignFormMetaDtoHelper.pullEntities(true, context);
+			// no meta editing in mobile app - if (campaignFormMetaDtoHelper.pullAndPushEntities(context))
+			campaignFormMetaDtoHelper.pullEntities(true, context);
+
+			final CampaignDtoHelper campaignDtoHelper = new CampaignDtoHelper();
+			// no campaign editing yet - if (campaignDtoHelper.pullAndPushEntities(context))
+			campaignDtoHelper.pullEntities(true, context);
 
 			final CampaignFormDataDtoHelper campaignFormDataDtoHelper = new CampaignFormDataDtoHelper();
 			if (campaignFormDataDtoHelper.pullAndPushEntities(context))
@@ -431,11 +433,12 @@ public class SynchronizeDataAsync extends AsyncTask<Void, Void, Void> {
 
 		// Campaigns
 		if (!DatabaseHelper.getFeatureConfigurationDao().isFeatureDisabled(FeatureType.CAMPAIGNS)) {
-			final CampaignDtoHelper campaignDtoHelper = new CampaignDtoHelper();
-			campaignDtoHelper.repullEntities(context);
-
+			// meta first
 			final CampaignFormMetaDtoHelper campaignFormMetaDtoHelper = new CampaignFormMetaDtoHelper();
 			campaignFormMetaDtoHelper.repullEntities(context);
+
+			final CampaignDtoHelper campaignDtoHelper = new CampaignDtoHelper();
+			campaignDtoHelper.repullEntities(context);
 
 			final CampaignFormDataDtoHelper campaignFormDataDtoHelper = new CampaignFormDataDtoHelper();
 			campaignFormDataDtoHelper.repullEntities(context);
@@ -741,26 +744,24 @@ public class SynchronizeDataAsync extends AsyncTask<Void, Void, Void> {
 
 		// CampaignData
 		if (!DatabaseHelper.getFeatureConfigurationDao().isFeatureDisabled(FeatureType.CAMPAIGNS)) {
-			final CampaignDtoHelper campaignDtoHelper = new CampaignDtoHelper();
-			campaignDtoHelper.pushEntities(true);
+			// meta first
+			final CampaignFormMetaDtoHelper campaignFormMetaDtoHelper = new CampaignFormMetaDtoHelper();
+			// no editing of meta - campaignFormMetaDtoHelper.pushEntities(true);
+			viewAllowed = DtoUserRightsHelper.isViewAllowed(CampaignFormMetaDto.class);
+			final List<String> campaignFormMetaUuids =
+					viewAllowed ? executeUuidCall(RetroProvider.getCampaignFormMetaFacade().pullUuids()) : new ArrayList<>();
+			DatabaseHelper.getCampaignFormMetaDao().deleteInvalid(campaignFormMetaUuids);
+			campaignFormMetaDtoHelper.pullMissing(campaignFormMetaUuids);
 
+			final CampaignDtoHelper campaignDtoHelper = new CampaignDtoHelper();
+			// no editing of campaigns yet - campaignDtoHelper.pushEntities(true);
 			viewAllowed = DtoUserRightsHelper.isViewAllowed(CampaignDto.class);
 			final List<String> campaignUuids = viewAllowed ? executeUuidCall(RetroProvider.getCampaignFacade().pullUuids()) : new ArrayList<>();
 			DatabaseHelper.getCampaignDao().deleteInvalid(campaignUuids);
 			campaignDtoHelper.pullMissing(campaignUuids);
 
-			final CampaignFormMetaDtoHelper campaignFormMetaDtoHelper = new CampaignFormMetaDtoHelper();
-			campaignFormMetaDtoHelper.pushEntities(true);
-
-			viewAllowed = DtoUserRightsHelper.isViewAllowed(CampaignFormMetaDto.class);
-			final List<String> campaignFormMetaUuids =
-				viewAllowed ? executeUuidCall(RetroProvider.getCampaignFormMetaFacade().pullUuids()) : new ArrayList<>();
-			DatabaseHelper.getCampaignFormMetaDao().deleteInvalid(campaignFormMetaUuids);
-			campaignFormMetaDtoHelper.pullMissing(campaignFormMetaUuids);
-
 			final CampaignFormDataDtoHelper campaignFormDataDtoHelper = new CampaignFormDataDtoHelper();
 			campaignFormDataDtoHelper.pushEntities(true);
-
 			viewAllowed = DtoUserRightsHelper.isViewAllowed(CampaignFormDataDto.class);
 			final List<String> campaignFormDataUuids =
 				viewAllowed ? executeUuidCall(RetroProvider.getCampaignFormDataFacade().pullUuids()) : new ArrayList<>();

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/ClientInfraSyncFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/ClientInfraSyncFacadeEjb.java
@@ -99,10 +99,6 @@ public class ClientInfraSyncFacadeEjb implements ClientInfraSyncFacade {
 		if (featureConfigurationFacade.isFeatureEnabled(FeatureType.INFRASTRUCTURE_TYPE_AREA)) {
 			sync.setAreas(areaFacade.getAllAfter(changeDates.getAreaChangeDate()));
 		}
-		if (featureConfigurationFacade.isFeatureEnabled(FeatureType.CAMPAIGNS)) {
-			sync.setCampaigns(campaignFacade.getAllAfter(changeDates.getCampaignChangeDate()));
-			sync.setCampaignFormMetas(campaignFormMetaFacade.getAllAfter(changeDates.getCampaignFormMetaChangeDate()));
-		}
 
 		return sync;
 	}


### PR DESCRIPTION
<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #8989

The simple solution from comment https://github.com/hzi-braunschweig/SORMAS-Project/issues/8989#issuecomment-1112097217 was not workable (lack of separation between real 403 exceptions and intendedly catched ones, unclear interference with the overall synchronization mechanism), so I implemented the second option:
> I'd propose to do the following now:
> 
>     * [ ]  catch this exception for every entity type (can probably be put into a generic method) and ignore it for now. Instead go on with the next entity type
> 
> 
> Maybe in a separate issue that can go into the next sprint:
> 
>     1. Don't pull entity types the user cannot VIEW
> 
>     2. Don't push entity types the user cannot EDIT

Some Facades can be accessed with different UserRights, e.g., `VisitFacadeEjb` with `CONTACT_VIEW` and `CASE_VIEW`, but every UserRole having `CONTACT_VIEW` has also `CASE_VIEW`, so the separation can be avoided here (see comment in `DtoViewAndEditRights` l.90)
This should however refined later, such that the maps in `DtoViewAndEditRights` return lists of possible UserRights instead of only one.

Fixes #8295