### PR TITLE
9044 sormas returns 403

### DIFF
--- a/sormas-rest/src/main/java/de/symeda/sormas/rest/RestConfig.java
+++ b/sormas-rest/src/main/java/de/symeda/sormas/rest/RestConfig.java
@@ -60,7 +60,6 @@ public class RestConfig extends ResourceConfig {
 		// Resources.
 		packages(getClass().getPackage().getName());
 
-		// as described in https://jersey.github.io/documentation/latest/security.html
 		register(JacksonFeature.class);
 
 		SwaggerConfig.init();

--- a/sormas-rest/src/main/java/de/symeda/sormas/rest/RestConfig.java
+++ b/sormas-rest/src/main/java/de/symeda/sormas/rest/RestConfig.java
@@ -40,7 +40,6 @@ import io.swagger.v3.oas.models.info.License;
 import org.apache.commons.collections4.SetUtils;
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature;
 
 import de.symeda.sormas.rest.swagger.SwaggerConfig;
 import org.slf4j.Logger;
@@ -62,7 +61,6 @@ public class RestConfig extends ResourceConfig {
 		packages(getClass().getPackage().getName());
 
 		// as described in https://jersey.github.io/documentation/latest/security.html
-		register(RolesAllowedDynamicFeature.class);
 		register(JacksonFeature.class);
 
 		SwaggerConfig.init();


### PR DESCRIPTION
<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #9044

Removed `RollesAllowedDynamicFeature`  from glassfish registered 'manually' as it sometimes conflicts with what payara provides with microprofile and causes the 403 result from Keycloak.

Not sure if this is this fixes the issue for good so it needs more testing