### PR TITLE
#9097 Removed group by clause, reuse Joins

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/event/EventParticipantFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/event/EventParticipantFacadeEjb.java
@@ -1058,15 +1058,13 @@ public class EventParticipantFacadeEjb
 		final CriteriaBuilder cb = em.getCriteriaBuilder();
 		final CriteriaQuery<SimilarEventParticipantDto> cq = cb.createQuery(SimilarEventParticipantDto.class);
 		final Root<EventParticipant> eventParticipantRoot = cq.from(EventParticipant.class);
-		cq.distinct(true);
 
-		Join<Object, Object> personJoin = eventParticipantRoot.join(EventParticipant.PERSON, JoinType.LEFT);
-		Join<Object, Object> userJoin = eventParticipantRoot.join(EventParticipant.REPORTING_USER, JoinType.LEFT);
-		Join<Object, Object> eventJoin = eventParticipantRoot.join(EventParticipant.EVENT, JoinType.LEFT);
 		EventParticipantQueryContext eventParticipantQueryContext = new EventParticipantQueryContext(cb, cq, eventParticipantRoot);
+		Join<EventParticipant, Person> personJoin = eventParticipantQueryContext.getJoins().getPerson();
+		Join<EventParticipant, Event> eventJoin = eventParticipantQueryContext.getJoins().getEvent();
 
 		Expression<Object> jurisdictionSelector =
-			JurisdictionHelper.booleanSelector(cb, service.inJurisdictionOrOwned(new EventParticipantQueryContext(cb, cq, eventParticipantRoot)));
+			JurisdictionHelper.booleanSelector(cb, service.inJurisdictionOrOwned(eventParticipantQueryContext));
 		cq.multiselect(
 			eventParticipantRoot.get(EventParticipant.UUID),
 			personJoin.get(Person.FIRST_NAME),
@@ -1077,18 +1075,7 @@ public class EventParticipantFacadeEjb
 			eventJoin.get(Event.EVENT_TITLE),
 			eventJoin.get(Event.START_DATE),
 			jurisdictionSelector);
-		cq.groupBy(
-			eventParticipantRoot.get(EventParticipant.UUID),
-			personJoin.get(Person.FIRST_NAME),
-			personJoin.get(Person.LAST_NAME),
-			eventParticipantRoot.get(EventParticipant.INVOLVEMENT_DESCRIPTION),
-			eventJoin.get(Event.UUID),
-			eventJoin.get(Event.EVENT_STATUS),
-			eventJoin.get(Event.EVENT_TITLE),
-			eventJoin.get(Event.START_DATE),
-			userJoin.get(User.ID),
-			eventParticipantRoot.get(EventParticipant.ID),
-			jurisdictionSelector);
+		cq.distinct(true);
 
 		final Predicate defaultFilter = service.createDefaultFilter(cb, eventParticipantRoot);
 		final Predicate userFilter = service.createUserFilter(eventParticipantQueryContext);

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/event/EventParticipantFacadeEjbTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/event/EventParticipantFacadeEjbTest.java
@@ -167,6 +167,7 @@ public class EventParticipantFacadeEjbTest extends AbstractBeanTest {
 
 	@Test
 	public void testGetMatchingEventParticipants() {
+
 		TestDataCreator.RDCF rdcf = creator.createRDCF();
 		UserDto user = creator.createUser(rdcf, creator.getUserRoleReference(DefaultUserRole.LAB_USER));
 		user.setLaboratory(rdcf.facility);


### PR DESCRIPTION
- Distinct already was present: grouping not needed and might fail with
different user filter or jurisdiction selection

<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #9097