### PR TITLE
#4461: only create external system users on startup if userroles are found

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/StartupShutdownService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/StartupShutdownService.java
@@ -556,7 +556,7 @@ public class StartupShutdownService {
 
 		User existingUser = userService.getByUserName(username);
 
-		boolean allUserRolesExist = !CollectionUtils.isEmpty(userRoles) && !userRoles.stream().noneMatch(Objects::isNull);
+		boolean allUserRolesExist = !CollectionUtils.isEmpty(userRoles) && userRoles.stream().noneMatch(Objects::isNull);
 		if (existingUser == null) {
 			if (!allUserRolesExist) {
 				logger.warn(

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/StartupShutdownService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/StartupShutdownService.java
@@ -28,6 +28,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Scanner;
 import java.util.Set;
@@ -555,7 +556,7 @@ public class StartupShutdownService {
 
 		User existingUser = userService.getByUserName(username);
 
-		boolean allUserRolesExist = !CollectionUtils.isEmpty(userRoles) && !userRoles.stream().anyMatch(userRole -> userRole == null);
+		boolean allUserRolesExist = !CollectionUtils.isEmpty(userRoles) && !userRoles.stream().noneMatch(Objects::isNull);
 		if (existingUser == null) {
 			if (!allUserRolesExist) {
 				logger.warn(


### PR DESCRIPTION
only update external system users on startup if userroles are found

This is the suggested solution for #4461 finding no. 31 (https://wiki.vitagroup.ag/pages/viewpage.action?pageId=87001413)
<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #