### PR TITLE
#9121 Adjust selected epiWeek if selected year changes

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/utils/DateHelper.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/utils/DateHelper.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
@@ -753,6 +754,25 @@ public final class DateHelper {
 		secondCalendar.set(Calendar.WEEK_OF_YEAR, anotherEpiWeek.getWeek());
 
 		return secondCalendar.getTime().after(calendar.getTime());
+	}
+
+	/**
+	 * @return The same {@link EpiWeek} within the the given {@code options} (first matching week number),
+	 *         {@code null} if no option matches.
+	 */
+	public static EpiWeek getSameEpiWeek(EpiWeek epiWeek, List<EpiWeek> options) {
+
+		EpiWeek result = null;
+		if (epiWeek != null && CollectionUtils.isNotEmpty(options)) {
+			for (EpiWeek option : options) {
+				if (epiWeek.getWeek() == option.getWeek()) {
+					result = option;
+					break;
+				}
+			}
+		}
+
+		return result;
 	}
 
 	/**

--- a/sormas-api/src/test/java/de/symeda/sormas/api/utils/DateHelperTest.java
+++ b/sormas-api/src/test/java/de/symeda/sormas/api/utils/DateHelperTest.java
@@ -17,13 +17,16 @@
  *******************************************************************************/
 package de.symeda.sormas.api.utils;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.sql.Timestamp;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
@@ -107,6 +110,60 @@ public class DateHelperTest {
 
 		assertEquals(new Integer(1), epiWeek.getWeek());
 		assertEquals(new Integer(2019), epiWeek.getYear());
+	}
+
+	@Test
+	public void testGetSameEpiWeek() {
+
+		EpiWeek selectedEpiWeek = DateHelper.getEpiWeek(DateHelper.getDateZero(2022, Calendar.JANUARY, 17));
+
+		// 0. Edge cases concerning null/empty
+		{
+			assertNull(DateHelper.getSameEpiWeek(null, null));
+			assertNull(DateHelper.getSameEpiWeek(null, Collections.emptyList()));
+			assertNull(DateHelper.getSameEpiWeek(selectedEpiWeek, null));
+			assertNull(DateHelper.getSameEpiWeek(selectedEpiWeek, Collections.emptyList()));
+		}
+
+		int otherYear = 2021;
+
+		// 1a. Get another year with begin of year
+		{
+			EpiWeek result = DateHelper.getSameEpiWeek(selectedEpiWeek, DateHelper.createEpiWeekList(otherYear));
+			assertThat(selectedEpiWeek.getWeek(), equalTo(4));
+			assertThat(result.getWeek(), equalTo(selectedEpiWeek.getWeek()));
+			assertThat(result.getYear(), equalTo(otherYear));
+		}
+
+		selectedEpiWeek = DateHelper.getEpiWeek(DateHelper.getDateZero(2022, Calendar.DECEMBER, 24));
+
+		// 1b. Get another year with end of year
+		{
+			EpiWeek result = DateHelper.getSameEpiWeek(selectedEpiWeek, DateHelper.createEpiWeekList(otherYear));
+			assertThat(selectedEpiWeek.getWeek(), equalTo(52));
+			assertThat(result.getWeek(), equalTo(selectedEpiWeek.getWeek()));
+			assertThat(result.getYear(), equalTo(otherYear));
+		}
+
+		otherYear = 2023;
+
+		// 3. Get another year with 53 epiWeeks
+		{
+			EpiWeek result = DateHelper.getSameEpiWeek(selectedEpiWeek, DateHelper.createEpiWeekList(otherYear));
+			assertThat(selectedEpiWeek.getWeek(), equalTo(52));
+			assertThat(result.getWeek(), equalTo(selectedEpiWeek.getWeek()));
+			assertThat(result.getYear(), equalTo(otherYear));
+		}
+
+		otherYear = 2022;
+		selectedEpiWeek = DateHelper.getEpiWeek(DateHelper.getDateZero(2023, Calendar.DECEMBER, 26));
+
+		// 3. Get from year with 53 epiWeeks
+		{
+			EpiWeek result = DateHelper.getSameEpiWeek(selectedEpiWeek, DateHelper.createEpiWeekList(otherYear));
+			assertThat(selectedEpiWeek.getWeek(), equalTo(53));
+			assertNull(result);
+		}
 	}
 
 	@Test

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/reports/aggregate/AggregateReportsEditLayout.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/reports/aggregate/AggregateReportsEditLayout.java
@@ -428,7 +428,13 @@ public class AggregateReportsEditLayout extends VerticalLayout {
 		Integer year = comboBoxYear.getValue();
 
 		if (year != null) {
-			comboBoxEpiweek.setItems(DateHelper.createEpiWeekList(year));
+			EpiWeek selectedEpiWeek = comboBoxEpiweek.getValue();
+			List<EpiWeek> epiWeekOptions = DateHelper.createEpiWeekList(year);
+			comboBoxEpiweek.setItems(epiWeekOptions);
+			if (selectedEpiWeek != null) {
+				EpiWeek adjustedEpiWeek = DateHelper.getSameEpiWeek(selectedEpiWeek, epiWeekOptions);
+				comboBoxEpiweek.setValue(adjustedEpiWeek);
+			}
 		} else {
 			comboBoxEpiweek.clear();
 		}


### PR DESCRIPTION
<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #9121 
As it was not specified what "same epi week" means, I assumed it is the week number and not the same begin or end date of the epi week. Edge cases with 53 weeks are 2017 and 2023.