### PR TITLE
Fix LBDS

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/caze/CaseDataDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/caze/CaseDataDto.java
@@ -344,7 +344,6 @@ public class CaseDataDto extends SormasToSormasShareableDto {
 	private String healthFacilityDetails;
 
 	@Valid
-	@Required
 	private HealthConditionsDto healthConditions;
 
 	private YesNoUnknown pregnant;

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/LbdsRecevierComponent.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/LbdsRecevierComponent.java
@@ -92,6 +92,10 @@ public class LbdsRecevierComponent extends BroadcastReceiver {
 		HttpResult resultFromResponse = httpContainerResponse.getResult();
 
 		Log.i("SORMAS_LBDS", "Request: " + methodFromResponse);
+		if (resultFromResponse == null) {
+			Log.i("SORMAS_LBDS", "Result is null");
+			return;
+		}
 		Log.i("SORMAS_LBDS", "Result Headers: " + resultFromResponse.headers);
 		Log.i("SORMAS_LBDS", "Result Body: " + resultFromResponse.body);
 
@@ -139,6 +143,10 @@ public class LbdsRecevierComponent extends BroadcastReceiver {
 		HttpResult resultFromResponse = httpContainerResponse.getResult();
 
 		Log.i("SORMAS_LBDS", "Request: " + methodFromResponse);
+		if (resultFromResponse == null) {
+			Log.i("SORMAS_LBDS", "Result is null");
+			return;
+		}
 		Log.i("SORMAS_LBDS", "Result Headers: " + resultFromResponse.headers);
 		Log.i("SORMAS_LBDS", "Result Body: " + resultFromResponse.body);
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseFacadeEjb.java
@@ -1584,7 +1584,8 @@ public class CaseFacadeEjb extends AbstractCoreFacadeEjb<Case, CaseDataDto, Case
 		return caseSave(dto, handleChanges, existingCase, toDto(existingCase), checkChangeDate, internal);
 	}
 
-	@RolesAllowed({ UserRight._CASE_EDIT })
+	@RolesAllowed({
+		UserRight._CASE_EDIT })
 	public CaseDataDto updateFollowUpComment(@Valid @NotNull CaseDataDto dto) throws ValidationRuntimeException {
 		Pseudonymizer pseudonymizer = getPseudonymizerForDtoWithClinician("");
 		Case caze = service.getByUuid(dto.getUuid());
@@ -2941,6 +2942,9 @@ public class CaseFacadeEjb extends AbstractCoreFacadeEjb<Case, CaseDataDto, Case
 			source.setTherapy(TherapyDto.build());
 		}
 		target.setTherapy(therapyFacade.fromDto(source.getTherapy(), checkChangeDate));
+		if (source.getHealthConditions() == null) {
+			source.setHealthConditions(HealthConditionsDto.build());
+		}
 		target.setHealthConditions(healthConditionsMapper.fromDto(source.getHealthConditions(), checkChangeDate));
 		if (source.getClinicalCourse() == null) {
 			source.setClinicalCourse(ClinicalCourseDto.build());


### PR DESCRIPTION
- build healthconditions on the fly, remove Required annotation
- handle LBDS response null
#9004

Agreed with @MateStrysewske to remove the `@Required` annotation for `CaseDataDto.healthConditions`. This annotation (introduced in #8979) introduced a breaking chage in the REST API, which seems to have caused problems in other places as well.
Instead, the sub-entity is now built on the fly if null when saving the Dto (as this is handled for similar properties, e.g., `clinicalCourse`)

<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #9004