### PR TITLE
[#8674] validate shares after building them

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/BaseFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/BaseFacade.java
@@ -8,6 +8,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 import de.symeda.sormas.api.utils.SortProperty;
+import de.symeda.sormas.api.utils.ValidationRuntimeException;
 import de.symeda.sormas.api.utils.criteria.BaseCriteria;
 
 public interface BaseFacade<DTO extends EntityDto, INDEX_DTO extends Serializable, REF_DTO extends ReferenceDto, CRITERIA extends BaseCriteria> {
@@ -29,4 +30,6 @@ public interface BaseFacade<DTO extends EntityDto, INDEX_DTO extends Serializabl
 	List<DTO> getAllAfter(Date date);
 
 	List<String> getObsoleteUuidsSince(Date since);
+
+	void validate(DTO dto) throws ValidationRuntimeException;
 }

--- a/sormas-api/src/main/java/de/symeda/sormas/api/caze/CaseFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/caze/CaseFacade.java
@@ -102,8 +102,6 @@ public interface CaseFacade extends CoreFacade<CaseDataDto, CaseIndexDto, CaseRe
 
 	void setSampleAssociationsUnrelatedDisease(EventParticipantReferenceDto sourceEventParticipant, CaseReferenceDto cazeRef);
 
-	void validate(CaseDataDto dto) throws ValidationRuntimeException;
-
 	List<String> getAllActiveUuids();
 
 	List<CaseDataDto> getAllActiveCasesAfter(Date date, Integer batchSize, String lastSynchronizedUuid);

--- a/sormas-api/src/main/java/de/symeda/sormas/api/contact/ContactFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/contact/ContactFacade.java
@@ -136,8 +136,6 @@ public interface ContactFacade extends CoreFacade<ContactDto, ContactIndexDto, C
 	 */
 	int getNonSourceCaseCountForDashboard(List<String> caseUuids);
 
-	void validate(ContactDto contact);
-
 	List<SimilarContactDto> getMatchingContacts(ContactSimilarityCriteria criteria);
 
 	boolean doesExternalTokenExist(String externalToken, String contactUuid);

--- a/sormas-api/src/main/java/de/symeda/sormas/api/event/EventFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/event/EventFacade.java
@@ -33,7 +33,6 @@ import de.symeda.sormas.api.externaldata.ExternalDataDto;
 import de.symeda.sormas.api.externaldata.ExternalDataUpdateException;
 import de.symeda.sormas.api.infrastructure.region.RegionReferenceDto;
 import de.symeda.sormas.api.utils.SortProperty;
-import de.symeda.sormas.api.utils.ValidationRuntimeException;
 
 @Remote
 public interface EventFacade extends CoreFacade<EventDto, EventIndexDto, EventReferenceDto, EventCriteria> {
@@ -69,8 +68,6 @@ public interface EventFacade extends CoreFacade<EventDto, EventIndexDto, EventRe
 	Set<String> getAllEventUuidsByEventGroupUuid(String eventGroupUuid);
 
 	List<String> getEventUuidsWithOwnershipHandedOver(List<String> eventUuids);
-
-	void validate(EventDto dto) throws ValidationRuntimeException;
 
 	Set<RegionReferenceDto> getAllRegionsRelatedToEventUuids(List<String> uuids);
 

--- a/sormas-api/src/main/java/de/symeda/sormas/api/event/EventParticipantFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/event/EventParticipantFacade.java
@@ -56,8 +56,6 @@ public interface EventParticipantFacade
 
 	List<EventParticipantListEntryDto> getListEntries(EventParticipantCriteria eventParticipantCriteria, Integer first, Integer max);
 
-	void validate(EventParticipantDto eventParticipant);
-
 	Map<String, Long> getContactCountPerEventParticipant(List<String> eventParticipantUuids, EventParticipantCriteria eventParticipantCriteria);
 
 	boolean exists(String personUuid, String eventUUID);

--- a/sormas-api/src/main/java/de/symeda/sormas/api/immunization/ImmunizationFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/immunization/ImmunizationFacade.java
@@ -28,8 +28,6 @@ import de.symeda.sormas.api.utils.SortProperty;
 @Remote
 public interface ImmunizationFacade extends CoreFacade<ImmunizationDto, ImmunizationIndexDto, ImmunizationReferenceDto, ImmunizationCriteria> {
 
-	void validate(ImmunizationDto immunizationDto);
-
 	List<String> getArchivedUuidsSince(Date since);
 
 	void archiveAllArchivableImmunizations(int daysAfterImmunizationsGetsArchived);

--- a/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/pointofentry/PointOfEntryFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/infrastructure/pointofentry/PointOfEntryFacade.java
@@ -9,11 +9,9 @@ import de.symeda.sormas.api.common.Page;
 import de.symeda.sormas.api.infrastructure.InfrastructureFacade;
 import de.symeda.sormas.api.infrastructure.district.DistrictReferenceDto;
 import de.symeda.sormas.api.utils.SortProperty;
-import de.symeda.sormas.api.utils.ValidationRuntimeException;
 
 @Remote
-public interface PointOfEntryFacade
-	extends InfrastructureFacade<PointOfEntryDto, PointOfEntryDto, PointOfEntryReferenceDto, PointOfEntryCriteria> {
+public interface PointOfEntryFacade extends InfrastructureFacade<PointOfEntryDto, PointOfEntryDto, PointOfEntryReferenceDto, PointOfEntryCriteria> {
 
 	/**
 	 * @param includeOthers
@@ -21,8 +19,6 @@ public interface PointOfEntryFacade
 	 *            point of entry is not in the database.
 	 */
 	List<PointOfEntryReferenceDto> getAllActiveByDistrict(String districtUuid, boolean includeOthers);
-
-	void validate(PointOfEntryDto pointOfEntry) throws ValidationRuntimeException;
 
 	List<PointOfEntryReferenceDto> getByName(String name, DistrictReferenceDto district, boolean includeArchivedEntities);
 

--- a/sormas-api/src/main/java/de/symeda/sormas/api/location/LocationDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/location/LocationDto.java
@@ -147,12 +147,20 @@ public class LocationDto extends PseudonymizableDto {
 	@Size(max = FieldConstraints.CHARACTER_LIMIT_DEFAULT, message = Validations.textTooLong)
 	private String facilityDetails;
 	@Size(max = FieldConstraints.CHARACTER_LIMIT_TEXT, message = Validations.textTooLong)
+	@PersonalData
+	@SensitiveData
 	private String contactPersonFirstName;
 	@Size(max = FieldConstraints.CHARACTER_LIMIT_TEXT, message = Validations.textTooLong)
+	@PersonalData
+	@SensitiveData
 	private String contactPersonLastName;
 	@Size(max = FieldConstraints.CHARACTER_LIMIT_TEXT, message = Validations.textTooLong)
+	@PersonalData
+	@SensitiveData
 	private String contactPersonPhone;
 	@Size(max = FieldConstraints.CHARACTER_LIMIT_TEXT, message = Validations.textTooLong)
+	@PersonalData
+	@SensitiveData
 	private String contactPersonEmail;
 
 	public String getDetails() {

--- a/sormas-api/src/main/java/de/symeda/sormas/api/travelentry/TravelEntryFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/travelentry/TravelEntryFacade.java
@@ -11,8 +11,6 @@ import de.symeda.sormas.api.utils.SortProperty;
 @Remote
 public interface TravelEntryFacade extends CoreFacade<TravelEntryDto, TravelEntryIndexDto, TravelEntryReferenceDto, TravelEntryCriteria> {
 
-	void validate(TravelEntryDto travelEntryDto);
-
 	boolean isDeleted(String eventUuid);
 
 	long count(TravelEntryCriteria criteria, boolean ignoreUserFilter);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/AbstractCoreFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/AbstractCoreFacadeEjb.java
@@ -223,8 +223,6 @@ public abstract class AbstractCoreFacadeEjb<ADO extends CoreAdo, DTO extends Ent
 
 	protected abstract void restorePseudonymizedDto(DTO dto, DTO existingDto, ADO entity, Pseudonymizer pseudonymizer);
 
-	public abstract void validate(DTO dto) throws ValidationRuntimeException;
-
 	@DenyAll
 	public void archive(String entityUuid, Date endOfProcessingDate) {
 		service.archive(entityUuid, endOfProcessingDate);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/AbstractInfrastructureFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/AbstractInfrastructureFacadeEjb.java
@@ -165,7 +165,7 @@ public abstract class AbstractInfrastructureFacadeEjb<ADO extends Infrastructure
 		}
 	}
 
-	// todo this can be moved up later
+	// todo this can be moved up
 	public long count(CRITERIA criteria) {
 		return service.count((cb, root) -> service.buildCriteriaFilter(criteria, cb, root));
 	}
@@ -181,4 +181,9 @@ public abstract class AbstractInfrastructureFacadeEjb<ADO extends Infrastructure
 	protected abstract List<ADO> findDuplicates(DTO dto, boolean includeArchived);
 
 	// todo implement toDto() here
+
+	@Override
+	public void validate(DTO dto) throws ValidationRuntimeException {
+		// todo we do not run any generic validation logic for infra yet
+	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/facility/FacilityFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/facility/FacilityFacadeEjb.java
@@ -569,7 +569,8 @@ public class FacilityFacadeEjb
 		// facilities are excluded from infra. data locking for now...
 	}
 
-	private void validate(FacilityDto dto) {
+	@Override
+	public void validate(FacilityDto dto) {
 		if (dto.getType() == null
 			&& !FacilityDto.OTHER_FACILITY_UUID.equals(dto.getUuid())
 			&& !FacilityDto.NONE_FACILITY_UUID.equals(dto.getUuid())) {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/caze/CaseShareDataBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/caze/CaseShareDataBuilder.java
@@ -24,6 +24,7 @@ import de.symeda.sormas.api.caze.CaseDataDto;
 import de.symeda.sormas.api.person.PersonDto;
 import de.symeda.sormas.api.sormastosormas.caze.SormasToSormasCaseDto;
 import de.symeda.sormas.api.sormastosormas.sharerequest.SormasToSormasCasePreview;
+import de.symeda.sormas.api.sormastosormas.validation.ValidationErrors;
 import de.symeda.sormas.backend.caze.Case;
 import de.symeda.sormas.backend.caze.CaseFacadeEjb;
 import de.symeda.sormas.backend.infrastructure.community.CommunityFacadeEjb;
@@ -31,10 +32,13 @@ import de.symeda.sormas.backend.infrastructure.district.DistrictFacadeEjb;
 import de.symeda.sormas.backend.infrastructure.facility.FacilityFacadeEjb;
 import de.symeda.sormas.backend.infrastructure.pointofentry.PointOfEntryFacadeEjb;
 import de.symeda.sormas.backend.infrastructure.region.RegionFacadeEjb;
+import de.symeda.sormas.backend.person.PersonFacadeEjb;
 import de.symeda.sormas.backend.sormastosormas.share.ShareDataBuilder;
 import de.symeda.sormas.backend.sormastosormas.share.ShareDataBuilderHelper;
 import de.symeda.sormas.backend.sormastosormas.share.shareinfo.ShareRequestInfo;
 import de.symeda.sormas.backend.util.Pseudonymizer;
+
+import static de.symeda.sormas.backend.sormastosormas.ValidationHelper.buildCaseValidationGroupName;
 
 @Stateless
 @LocalBean
@@ -48,6 +52,9 @@ public class CaseShareDataBuilder
 
 	public CaseShareDataBuilder() {
 	}
+
+	@EJB
+	private PersonFacadeEjb.PersonFacadeEjbLocal personFacade;
 
 	@EJB
 	private CaseFacadeEjb.CaseFacadeEjbLocal caseFacade;
@@ -66,6 +73,12 @@ public class CaseShareDataBuilder
 		dataBuilderHelper.clearIgnoredProperties(cazeDto);
 
 		return new SormasToSormasCaseDto(personDto, cazeDto);
+	}
+
+	@Override
+	public void validateWithEjbShared(SormasToSormasCaseDto dto) {
+		personFacade.validate(dto.getPerson());
+		caseFacade.validate(dto.getEntity());
 	}
 
 	@Override

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/caze/CaseShareDataBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/caze/CaseShareDataBuilder.java
@@ -24,7 +24,6 @@ import de.symeda.sormas.api.caze.CaseDataDto;
 import de.symeda.sormas.api.person.PersonDto;
 import de.symeda.sormas.api.sormastosormas.caze.SormasToSormasCaseDto;
 import de.symeda.sormas.api.sormastosormas.sharerequest.SormasToSormasCasePreview;
-import de.symeda.sormas.api.sormastosormas.validation.ValidationErrors;
 import de.symeda.sormas.backend.caze.Case;
 import de.symeda.sormas.backend.caze.CaseFacadeEjb;
 import de.symeda.sormas.backend.infrastructure.community.CommunityFacadeEjb;
@@ -37,8 +36,6 @@ import de.symeda.sormas.backend.sormastosormas.share.ShareDataBuilder;
 import de.symeda.sormas.backend.sormastosormas.share.ShareDataBuilderHelper;
 import de.symeda.sormas.backend.sormastosormas.share.shareinfo.ShareRequestInfo;
 import de.symeda.sormas.backend.util.Pseudonymizer;
-
-import static de.symeda.sormas.backend.sormastosormas.ValidationHelper.buildCaseValidationGroupName;
 
 @Stateless
 @LocalBean

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/caze/CaseShareDataBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/caze/CaseShareDataBuilder.java
@@ -73,7 +73,7 @@ public class CaseShareDataBuilder
 	}
 
 	@Override
-	public void validateWithEjbShared(SormasToSormasCaseDto dto) {
+	public void doBusinessValidation(SormasToSormasCaseDto dto) {
 		personFacade.validate(dto.getPerson());
 		caseFacade.validate(dto.getEntity());
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/contact/ContactShareDataBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/contact/ContactShareDataBuilder.java
@@ -68,7 +68,7 @@ public class ContactShareDataBuilder
 	}
 
 	@Override
-	public void validateWithEjbShared(SormasToSormasContactDto dto) throws ValidationRuntimeException {
+	public void doBusinessValidation(SormasToSormasContactDto dto) throws ValidationRuntimeException {
 		personFacade.validate(dto.getPerson());
 		contactFacade.validate(dto.getEntity());
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/contact/ContactShareDataBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/contact/ContactShareDataBuilder.java
@@ -24,7 +24,10 @@ import de.symeda.sormas.api.contact.ContactDto;
 import de.symeda.sormas.api.person.PersonDto;
 import de.symeda.sormas.api.sormastosormas.contact.SormasToSormasContactDto;
 import de.symeda.sormas.api.sormastosormas.sharerequest.SormasToSormasContactPreview;
+import de.symeda.sormas.api.utils.ValidationRuntimeException;
 import de.symeda.sormas.backend.contact.Contact;
+import de.symeda.sormas.backend.contact.ContactFacadeEjb;
+import de.symeda.sormas.backend.person.PersonFacadeEjb;
 import de.symeda.sormas.backend.sormastosormas.share.ShareDataBuilder;
 import de.symeda.sormas.backend.sormastosormas.share.ShareDataBuilderHelper;
 import de.symeda.sormas.backend.sormastosormas.share.shareinfo.ShareRequestInfo;
@@ -37,6 +40,12 @@ public class ContactShareDataBuilder
 
 	@EJB
 	private ShareDataBuilderHelper dataBuilderHelper;
+
+	@EJB
+	private ContactFacadeEjb.ContactFacadeEjbLocal contactFacade;
+
+	@EJB
+	private PersonFacadeEjb.PersonFacadeEjbLocal personFacade;
 
 	@Inject
 	public ContactShareDataBuilder(SormasToSormasContactDtoValidator validator) {
@@ -56,6 +65,12 @@ public class ContactShareDataBuilder
 		ContactDto contactDto = dataBuilderHelper.getContactDto(contact, pseudonymizer);
 
 		return new SormasToSormasContactDto(personDto, contactDto);
+	}
+
+	@Override
+	public void validateWithEjbShared(SormasToSormasContactDto dto) throws ValidationRuntimeException {
+		personFacade.validate(dto.getPerson());
+		contactFacade.validate(dto.getEntity());
 	}
 
 	@Override

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/event/EventShareDataBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/event/EventShareDataBuilder.java
@@ -61,7 +61,7 @@ public class EventShareDataBuilder
 	}
 
 	@Override
-	public void validateWithEjbShared(SormasToSormasEventDto sormasToSormasEventDto) throws ValidationRuntimeException {
+	public void doBusinessValidation(SormasToSormasEventDto sormasToSormasEventDto) throws ValidationRuntimeException {
 		eventFacade.validate(sormasToSormasEventDto.getEntity());
 	}
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/event/EventShareDataBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/event/EventShareDataBuilder.java
@@ -23,6 +23,7 @@ import javax.inject.Inject;
 import de.symeda.sormas.api.event.EventDto;
 import de.symeda.sormas.api.sormastosormas.event.SormasToSormasEventDto;
 import de.symeda.sormas.api.sormastosormas.sharerequest.SormasToSormasEventPreview;
+import de.symeda.sormas.api.utils.ValidationRuntimeException;
 import de.symeda.sormas.backend.event.Event;
 import de.symeda.sormas.backend.event.EventFacadeEjb.EventFacadeEjbLocal;
 import de.symeda.sormas.backend.location.LocationFacadeEjb;
@@ -57,6 +58,11 @@ public class EventShareDataBuilder
 		EventDto eventDto = getEventDto(data, pseudonymizer);
 
 		return new SormasToSormasEventDto(eventDto);
+	}
+
+	@Override
+	public void validateWithEjbShared(SormasToSormasEventDto sormasToSormasEventDto) throws ValidationRuntimeException {
+		eventFacade.validate(sormasToSormasEventDto.getEntity());
 	}
 
 	@Override

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/eventparticipant/EventParticipantShareDataBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/eventparticipant/EventParticipantShareDataBuilder.java
@@ -23,6 +23,7 @@ import javax.inject.Inject;
 import de.symeda.sormas.api.event.EventParticipantDto;
 import de.symeda.sormas.api.sormastosormas.event.SormasToSormasEventParticipantDto;
 import de.symeda.sormas.api.sormastosormas.sharerequest.SormasToSormasEventParticipantPreview;
+import de.symeda.sormas.api.utils.ValidationRuntimeException;
 import de.symeda.sormas.backend.event.EventFacadeEjb;
 import de.symeda.sormas.backend.event.EventParticipant;
 import de.symeda.sormas.backend.event.EventParticipantFacadeEjb;
@@ -67,6 +68,11 @@ public class EventParticipantShareDataBuilder
 			requestInfo.isPseudonymizedSensitiveData());
 
 		return new SormasToSormasEventParticipantDto(eventParticipantDto);
+	}
+
+	@Override
+	public void validateWithEjbShared(SormasToSormasEventParticipantDto sormasToSormasEventParticipantDto) throws ValidationRuntimeException {
+		eventParticipantFacade.validate(sormasToSormasEventParticipantDto.getEntity());
 	}
 
 	@Override

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/eventparticipant/EventParticipantShareDataBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/eventparticipant/EventParticipantShareDataBuilder.java
@@ -71,7 +71,7 @@ public class EventParticipantShareDataBuilder
 	}
 
 	@Override
-	public void validateWithEjbShared(SormasToSormasEventParticipantDto sormasToSormasEventParticipantDto) throws ValidationRuntimeException {
+	public void doBusinessValidation(SormasToSormasEventParticipantDto sormasToSormasEventParticipantDto) throws ValidationRuntimeException {
 		eventParticipantFacade.validate(sormasToSormasEventParticipantDto.getEntity());
 	}
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/immunization/ImmunizationShareDataBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/immunization/ImmunizationShareDataBuilder.java
@@ -64,7 +64,7 @@ public class ImmunizationShareDataBuilder
 	}
 
 	@Override
-	public void validateWithEjbShared(SormasToSormasImmunizationDto sormasToSormasImmunizationDto) throws ValidationRuntimeException {
+	public void doBusinessValidation(SormasToSormasImmunizationDto sormasToSormasImmunizationDto) throws ValidationRuntimeException {
 		immunizationFacade.validate(sormasToSormasImmunizationDto.getEntity());
 	}
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/immunization/ImmunizationShareDataBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/immunization/ImmunizationShareDataBuilder.java
@@ -21,9 +21,9 @@ import javax.ejb.Stateless;
 import javax.inject.Inject;
 
 import de.symeda.sormas.api.immunization.ImmunizationDto;
-import de.symeda.sormas.api.sormastosormas.SormasToSormasEntityDto;
 import de.symeda.sormas.api.sormastosormas.immunization.SormasToSormasImmunizationDto;
 import de.symeda.sormas.api.sormastosormas.sharerequest.PreviewNotImplementedDto;
+import de.symeda.sormas.api.utils.ValidationRuntimeException;
 import de.symeda.sormas.backend.immunization.ImmunizationFacadeEjb.ImmunizationFacadeEjbLocal;
 import de.symeda.sormas.backend.immunization.entity.Immunization;
 import de.symeda.sormas.backend.sormastosormas.share.ShareDataBuilder;
@@ -61,6 +61,11 @@ public class ImmunizationShareDataBuilder
 		dataBuilderHelper.clearIgnoredProperties(immunizationDto);
 
 		return new SormasToSormasImmunizationDto(immunizationDto);
+	}
+
+	@Override
+	public void validateWithEjbShared(SormasToSormasImmunizationDto sormasToSormasImmunizationDto) throws ValidationRuntimeException {
+		immunizationFacade.validate(sormasToSormasImmunizationDto.getEntity());
 	}
 
 	@Override

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/sample/SampleShareDataBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/sample/SampleShareDataBuilder.java
@@ -26,6 +26,7 @@ import de.symeda.sormas.api.sample.PathogenTestDto;
 import de.symeda.sormas.api.sample.SampleDto;
 import de.symeda.sormas.api.sormastosormas.sample.SormasToSormasSampleDto;
 import de.symeda.sormas.api.sormastosormas.sharerequest.PreviewNotImplementedDto;
+import de.symeda.sormas.api.utils.ValidationRuntimeException;
 import de.symeda.sormas.backend.sample.AdditionalTestFacadeEjb;
 import de.symeda.sormas.backend.sample.PathogenTestFacadeEjb;
 import de.symeda.sormas.backend.sample.Sample;
@@ -71,6 +72,13 @@ public class SampleShareDataBuilder
 			return pathogenTestDto;
 		}).collect(Collectors.toList()),
 			data.getAdditionalTests().stream().map(t -> additionalTestFacade.convertToDto(t, pseudonymizer)).collect(Collectors.toList()));
+	}
+
+	@Override
+	public void validateWithEjbShared(SormasToSormasSampleDto sormasToSormasSampleDto) throws ValidationRuntimeException {
+		sampleFacade.validate(sormasToSormasSampleDto.getEntity());
+		sormasToSormasSampleDto.getPathogenTests().forEach(pathogenTestFacade::validate);
+		// additional test facade has no validation method
 	}
 
 	@Override

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/sample/SampleShareDataBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/sample/SampleShareDataBuilder.java
@@ -75,7 +75,7 @@ public class SampleShareDataBuilder
 	}
 
 	@Override
-	public void validateWithEjbShared(SormasToSormasSampleDto sormasToSormasSampleDto) throws ValidationRuntimeException {
+	public void doBusinessValidation(SormasToSormasSampleDto sormasToSormasSampleDto) throws ValidationRuntimeException {
 		sampleFacade.validate(sormasToSormasSampleDto.getEntity());
 		sormasToSormasSampleDto.getPathogenTests().forEach(pathogenTestFacade::validate);
 		// additional test facade has no validation method

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/share/ShareDataBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/share/ShareDataBuilder.java
@@ -58,8 +58,7 @@ public abstract class ShareDataBuilder<DTO extends SormasToSormasShareableDto, A
 
 	protected abstract PREVIEW doBuildShareDataPreview(ADO data, ShareRequestInfo requestInfo);
 
-	public PREVIEW buildShareDataPreview(ADO data, ShareRequestInfo requestInfo)
-		throws SormasToSormasValidationException, ValidationRuntimeException {
+	public PREVIEW buildShareDataPreview(ADO data, ShareRequestInfo requestInfo) throws SormasToSormasValidationException {
 		PREVIEW shared = doBuildShareDataPreview(data, requestInfo);
 		ValidationErrors errors = validator.validateOutgoingPreview(shared);
 		if (errors.hasError()) {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/share/ShareDataBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/share/ShareDataBuilder.java
@@ -22,6 +22,7 @@ import de.symeda.sormas.api.sormastosormas.SormasToSormasEntityDto;
 import de.symeda.sormas.api.sormastosormas.SormasToSormasShareableDto;
 import de.symeda.sormas.api.sormastosormas.validation.SormasToSormasValidationException;
 import de.symeda.sormas.api.sormastosormas.validation.ValidationErrors;
+import de.symeda.sormas.api.utils.ValidationRuntimeException;
 import de.symeda.sormas.api.utils.pseudonymization.PseudonymizableDto;
 import de.symeda.sormas.backend.sormastosormas.data.validation.SormasToSormasDtoValidator;
 import de.symeda.sormas.backend.sormastosormas.entities.SormasToSormasShareable;
@@ -40,9 +41,11 @@ public abstract class ShareDataBuilder<DTO extends SormasToSormasShareableDto, A
 
 	protected abstract SHARED doBuildShareData(ADO data, ShareRequestInfo requestInfo);
 
-	public SHARED buildShareData(ADO data, ShareRequestInfo requestInfo) throws SormasToSormasValidationException {
+	public SHARED buildShareData(ADO data, ShareRequestInfo requestInfo) throws SormasToSormasValidationException, ValidationRuntimeException {
 		SHARED shared = doBuildShareData(data, requestInfo);
+		validateWithEjbShared(shared);
 		ValidationErrors errors = validator.validateOutgoing(shared);
+
 		if (errors.hasError()) {
 			List<ValidationErrors> validationErrors = new ArrayList<>();
 			validationErrors.add(errors);
@@ -51,9 +54,12 @@ public abstract class ShareDataBuilder<DTO extends SormasToSormasShareableDto, A
 		return shared;
 	}
 
+	protected abstract void validateWithEjbShared(SHARED shared) throws ValidationRuntimeException;
+
 	protected abstract PREVIEW doBuildShareDataPreview(ADO data, ShareRequestInfo requestInfo);
 
-	public PREVIEW buildShareDataPreview(ADO data, ShareRequestInfo requestInfo) throws SormasToSormasValidationException {
+	public PREVIEW buildShareDataPreview(ADO data, ShareRequestInfo requestInfo)
+		throws SormasToSormasValidationException, ValidationRuntimeException {
 		PREVIEW shared = doBuildShareDataPreview(data, requestInfo);
 		ValidationErrors errors = validator.validateOutgoingPreview(shared);
 		if (errors.hasError()) {
@@ -63,4 +69,5 @@ public abstract class ShareDataBuilder<DTO extends SormasToSormasShareableDto, A
 		}
 		return shared;
 	}
+
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/share/ShareDataBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/share/ShareDataBuilder.java
@@ -48,7 +48,7 @@ public abstract class ShareDataBuilder<DTO extends SormasToSormasShareableDto, A
 		SHARED shared = doBuildShareData(data, requestInfo);
 		logger.info("Run validation for S2S shares based on BaseFacade::validate for {}", data.getUuid());
 		try {
-			validateWithEjbShared(shared);
+			doBusinessValidation(shared);
 		} catch (ValidationRuntimeException e){
 			logger.error("THIS IS A BUG: a share was constructed which properties does not pass the validation logic of their dedicated facade: %s ", e);
 			throw e;
@@ -64,7 +64,7 @@ public abstract class ShareDataBuilder<DTO extends SormasToSormasShareableDto, A
 		return shared;
 	}
 
-	protected abstract void validateWithEjbShared(SHARED shared) throws ValidationRuntimeException;
+	protected abstract void doBusinessValidation(SHARED shared) throws ValidationRuntimeException;
 
 	protected abstract PREVIEW doBuildShareDataPreview(ADO data, ShareRequestInfo requestInfo);
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/share/ShareDataBuilderHelper.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/share/ShareDataBuilderHelper.java
@@ -98,8 +98,8 @@ public class ShareDataBuilderHelper {
 	public ContactDto getContactDto(Contact contact, Pseudonymizer pseudonymizer) {
 		ContactDto contactDto = contactFacade.convertToDto(contact, pseudonymizer);
 
-		// todo reportingUser is expected to be not null in validate()
-		//contactDto.setReportingUser(null);
+		// reporting user is not set to null here as it would not pass the validation
+		// the receiver appears to set it to SORMAS2SORMAS Client anyway in the UI
 		contactDto.setContactOfficer(null);
 		contactDto.setResultingCaseUser(null);
 		contactDto.setSormasToSormasOriginInfo(null);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/share/ShareDataBuilderHelper.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/share/ShareDataBuilderHelper.java
@@ -98,7 +98,8 @@ public class ShareDataBuilderHelper {
 	public ContactDto getContactDto(Contact contact, Pseudonymizer pseudonymizer) {
 		ContactDto contactDto = contactFacade.convertToDto(contact, pseudonymizer);
 
-		contactDto.setReportingUser(null);
+		// todo reportingUser is expected to be not null in validate()
+		//contactDto.setReportingUser(null);
 		contactDto.setContactOfficer(null);
 		contactDto.setResultingCaseUser(null);
 		contactDto.setSormasToSormasOriginInfo(null);

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasTest.java
@@ -239,21 +239,20 @@ public abstract class SormasToSormasTest extends AbstractBeanTest {
 	}
 
 	protected void mockS2Snetwork() throws SormasToSormasException {
-		Mockito.when(MockProducer.getSormasToSormasClient().get(anyString(), eq("/sormasToSormas/cert"), any()))
-			.thenAnswer(invocation -> {
-				if (invocation.getArgument(0, String.class).equals(DEFAULT_SERVER_ID)) {
-					mockDefaultServerAccess();
-				} else {
-					mockSecondServerAccess();
-				}
-				X509Certificate cert = getSormasToSormasEncryptionFacade().loadOwnCertificate();
-				if (invocation.getArgument(0, String.class).equals(DEFAULT_SERVER_ID)) {
-					mockSecondServerAccess();
-				} else {
-					mockDefaultServerAccess();
-				}
-				return cert.getEncoded();
-			});
+		Mockito.when(MockProducer.getSormasToSormasClient().get(anyString(), eq("/sormasToSormas/cert"), any())).thenAnswer(invocation -> {
+			if (invocation.getArgument(0, String.class).equals(DEFAULT_SERVER_ID)) {
+				mockDefaultServerAccess();
+			} else {
+				mockSecondServerAccess();
+			}
+			X509Certificate cert = getSormasToSormasEncryptionFacade().loadOwnCertificate();
+			if (invocation.getArgument(0, String.class).equals(DEFAULT_SERVER_ID)) {
+				mockSecondServerAccess();
+			} else {
+				mockDefaultServerAccess();
+			}
+			return cert.getEncoded();
+		});
 	}
 
 	protected void mockDefaultServerAccess() {

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/entities/SormasToSormasContactFacadeEjbTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/entities/SormasToSormasContactFacadeEjbTest.java
@@ -120,8 +120,8 @@ public class SormasToSormasContactFacadeEjbTest extends SormasToSormasTest {
 				assertThat(sharedContact.getPerson().getLastName(), is(person.getLastName()));
 
 				assertThat(sharedContact.getEntity().getUuid(), is(contact.getUuid()));
-				// users should be cleaned up
-				assertThat(sharedContact.getEntity().getReportingUser(), is(nullValue()));
+				// todo what to do with this?
+				//assertThat(sharedContact.getEntity().getReportingUser(), is(nullValue()));
 				assertThat(sharedContact.getEntity().getContactOfficer(), is(nullValue()));
 				assertThat(sharedContact.getEntity().getResultingCaseUser(), is(nullValue()));
 

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/entities/SormasToSormasContactFacadeEjbTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/entities/SormasToSormasContactFacadeEjbTest.java
@@ -122,7 +122,7 @@ public class SormasToSormasContactFacadeEjbTest extends SormasToSormasTest {
 
 				assertThat(sharedContact.getEntity().getUuid(), is(contact.getUuid()));
 
-				assertThat(sharedContact.getEntity().getReportingUser(), isNotNull());
+				assertThat(sharedContact.getEntity().getReportingUser(), is(officer));
 				assertThat(sharedContact.getEntity().getContactOfficer(), is(nullValue()));
 				assertThat(sharedContact.getEntity().getResultingCaseUser(), is(nullValue()));
 

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/entities/SormasToSormasContactFacadeEjbTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/entities/SormasToSormasContactFacadeEjbTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNotNull;
 
 import java.util.Arrays;
 import java.util.Calendar;
@@ -120,8 +121,8 @@ public class SormasToSormasContactFacadeEjbTest extends SormasToSormasTest {
 				assertThat(sharedContact.getPerson().getLastName(), is(person.getLastName()));
 
 				assertThat(sharedContact.getEntity().getUuid(), is(contact.getUuid()));
-				// todo what to do with this?
-				//assertThat(sharedContact.getEntity().getReportingUser(), is(nullValue()));
+
+				assertThat(sharedContact.getEntity().getReportingUser(), isNotNull());
 				assertThat(sharedContact.getEntity().getContactOfficer(), is(nullValue()));
 				assertThat(sharedContact.getEntity().getResultingCaseUser(), is(nullValue()));
 

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/entities/SormasToSormasEventFacadeEjbTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/entities/SormasToSormasEventFacadeEjbTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 
 import javax.ws.rs.core.Response;
 
+import de.symeda.sormas.api.location.LocationDto;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatchers;
@@ -372,8 +373,7 @@ public class SormasToSormasEventFacadeEjbTest extends SormasToSormasTest {
 	public void testReturnEvent() throws SormasToSormasException {
 		useSurveillanceOfficerLogin(rdcf);
 
-		UserReferenceDto officer =
-			creator.createUser(rdcf, creator.getUserRoleReference(DefaultUserRole.SURVEILLANCE_OFFICER)).toReference();
+		UserReferenceDto officer = creator.createUser(rdcf, creator.getUserRoleReference(DefaultUserRole.SURVEILLANCE_OFFICER)).toReference();
 
 		EventDto event =
 			creator.createEvent(EventStatus.SCREENING, EventInvestigationStatus.ONGOING, "Test event title", "Test description", officer, (e) -> {
@@ -427,8 +427,7 @@ public class SormasToSormasEventFacadeEjbTest extends SormasToSormasTest {
 
 	@Test
 	public void testSaveReturnedEvent() throws SormasToSormasException, SormasToSormasValidationException {
-		UserReferenceDto officer =
-			creator.createUser(rdcf, creator.getUserRoleReference(DefaultUserRole.SURVEILLANCE_OFFICER)).toReference();
+		UserReferenceDto officer = creator.createUser(rdcf, creator.getUserRoleReference(DefaultUserRole.SURVEILLANCE_OFFICER)).toReference();
 
 		EventDto event = creator.createEvent(officer);
 		EventParticipantDto eventParticipant = creator.createEventParticipant(event.toReference(), creator.createPerson(), officer);
@@ -494,8 +493,7 @@ public class SormasToSormasEventFacadeEjbTest extends SormasToSormasTest {
 	public void testSyncEvent() throws SormasToSormasException {
 		useSurveillanceOfficerLogin(rdcf);
 
-		UserReferenceDto officer =
-			creator.createUser(rdcf, creator.getUserRoleReference(DefaultUserRole.SURVEILLANCE_OFFICER)).toReference();
+		UserReferenceDto officer = creator.createUser(rdcf, creator.getUserRoleReference(DefaultUserRole.SURVEILLANCE_OFFICER)).toReference();
 
 		EventDto event =
 			creator.createEvent(EventStatus.SCREENING, EventInvestigationStatus.ONGOING, "Test event title", "Test description", officer, e -> {
@@ -587,8 +585,7 @@ public class SormasToSormasEventFacadeEjbTest extends SormasToSormasTest {
 
 	@Test
 	public void testSaveSyncedEvent() throws SormasToSormasException, SormasToSormasValidationException {
-		UserReferenceDto officer =
-			creator.createUser(rdcf, creator.getUserRoleReference(DefaultUserRole.SURVEILLANCE_OFFICER)).toReference();
+		UserReferenceDto officer = creator.createUser(rdcf, creator.getUserRoleReference(DefaultUserRole.SURVEILLANCE_OFFICER)).toReference();
 
 		EventDto event =
 			creator.createEvent(EventStatus.SCREENING, EventInvestigationStatus.ONGOING, "Test event title", "Test description", officer, e -> {
@@ -644,8 +641,7 @@ public class SormasToSormasEventFacadeEjbTest extends SormasToSormasTest {
 
 	@Test
 	public void testSyncRecursively() throws SormasToSormasException, SormasToSormasValidationException {
-		UserReferenceDto officer =
-			creator.createUser(rdcf, creator.getUserRoleReference(DefaultUserRole.SURVEILLANCE_OFFICER)).toReference();
+		UserReferenceDto officer = creator.createUser(rdcf, creator.getUserRoleReference(DefaultUserRole.SURVEILLANCE_OFFICER)).toReference();
 
 		EventDto event =
 			creator.createEvent(EventStatus.SCREENING, EventInvestigationStatus.ONGOING, "Test event title", "Test description", officer, e -> {
@@ -691,6 +687,13 @@ public class SormasToSormasEventFacadeEjbTest extends SormasToSormasTest {
 		calendar.setTime(event.getChangeDate());
 		calendar.add(Calendar.DAY_OF_MONTH, 1);
 		event.setChangeDate(calendar.getTime());
+
+		LocationDto locationDto = new LocationDto();
+		locationDto.setRegion(rdcf.region);
+		locationDto.setDistrict(rdcf.district);
+		event.setEventLocation(locationDto);
+
+		getEventFacade().validate(event);
 
 		SormasToSormasDto shareData = new SormasToSormasDto();
 		SormasToSormasOriginInfoDto originInfo = createSormasToSormasOriginInfo(DEFAULT_SERVER_ID, false);


### PR DESCRIPTION
Fixes #8674

This PR ensures that the validation logic of the EJBs runs after the shares have been built to ensure that the remote instance can process them correctly (recall that the save method on the remote will call `validate` as well, so we avoid a network round trip other problems as well).

The underlying issue is that our pseudonymizers can return data which does not pass the `validate` method of the EJBs. I made  some adjustments and I would appreciate @MateStrysewske to comment on the changes to
* LocationDto.java (more PersonalData )
* ShareDataBuilderHelper (i.e., should a valid `ContactDto` contain a reporting user?)
* SormasToSormasContactFacadeEjbTest: same w.r.t. `ContactDto`

I'm quite certain that more pseudonymizers show this behaviour and I'm going to file an issue about it tomorrow.