### PR TITLE
[#9838] contact editable for not handed over case

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/audit/Constants.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/audit/Constants.java
@@ -28,8 +28,7 @@ public class Constants {
 				"load",
 				"check",
 				"uses",
-				"fetch",
-				"can")));
+				"fetch")));
 	public static final Set<String> updatePrefix = Collections.unmodifiableSet(
 		new HashSet<>(
 			Arrays.asList(

--- a/sormas-api/src/main/java/de/symeda/sormas/api/audit/Constants.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/audit/Constants.java
@@ -28,7 +28,8 @@ public class Constants {
 				"load",
 				"check",
 				"uses",
-				"fetch")));
+				"fetch",
+				"can")));
 	public static final Set<String> updatePrefix = Collections.unmodifiableSet(
 		new HashSet<>(
 			Arrays.asList(

--- a/sormas-api/src/main/java/de/symeda/sormas/api/caze/CaseFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/caze/CaseFacade.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import de.symeda.sormas.api.CaseMeasure;
 import de.symeda.sormas.api.CoreFacade;
 import de.symeda.sormas.api.Disease;
+import de.symeda.sormas.api.EditPermissionType;
 import de.symeda.sormas.api.Language;
 import de.symeda.sormas.api.common.DeletionDetails;
 import de.symeda.sormas.api.common.Page;
@@ -232,4 +233,5 @@ public interface CaseFacade extends CoreFacade<CaseDataDto, CaseIndexDto, CaseRe
 	void dearchive(List<String> entityUuids, String dearchiveReason, boolean includeContacts);
 
 	void setResultingCase(EventParticipantReferenceDto eventParticipantReferenceDto, CaseReferenceDto caseReferenceDto);
+	EditPermissionType isEditAllowedCaseContact(String uuid);
 }

--- a/sormas-api/src/main/java/de/symeda/sormas/api/caze/CaseFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/caze/CaseFacade.java
@@ -233,5 +233,5 @@ public interface CaseFacade extends CoreFacade<CaseDataDto, CaseIndexDto, CaseRe
 	void dearchive(List<String> entityUuids, String dearchiveReason, boolean includeContacts);
 
 	void setResultingCase(EventParticipantReferenceDto eventParticipantReferenceDto, CaseReferenceDto caseReferenceDto);
-	EditPermissionType canEditContact(String uuid);
+	EditPermissionType isEditContactAllowed(String uuid);
 }

--- a/sormas-api/src/main/java/de/symeda/sormas/api/caze/CaseFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/caze/CaseFacade.java
@@ -233,5 +233,5 @@ public interface CaseFacade extends CoreFacade<CaseDataDto, CaseIndexDto, CaseRe
 	void dearchive(List<String> entityUuids, String dearchiveReason, boolean includeContacts);
 
 	void setResultingCase(EventParticipantReferenceDto eventParticipantReferenceDto, CaseReferenceDto caseReferenceDto);
-	EditPermissionType isEditAllowedCaseContact(String uuid);
+	EditPermissionType canEditContact(String uuid);
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseFacadeEjb.java
@@ -2598,9 +2598,9 @@ public class CaseFacadeEjb extends AbstractCoreFacadeEjb<Case, CaseDataDto, Case
 	}
 
 	@Override
-	public EditPermissionType isEditAllowedCaseContact(String uuid) {
+	public EditPermissionType canEditContact(String uuid) {
 		Case ado = service.getByUuid(uuid);
-		return service.getEditPermissionTypeCaseContact(ado);
+		return service.canAddContact(ado);
 	}
 
 	@Override

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseFacadeEjb.java
@@ -2598,9 +2598,9 @@ public class CaseFacadeEjb extends AbstractCoreFacadeEjb<Case, CaseDataDto, Case
 	}
 
 	@Override
-	public EditPermissionType canEditContact(String uuid) {
+	public EditPermissionType isEditContactAllowed(String uuid) {
 		Case ado = service.getByUuid(uuid);
-		return service.canAddContact(ado);
+		return service.isAddContactAllowed(ado);
 	}
 
 	@Override

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseFacadeEjb.java
@@ -2598,6 +2598,12 @@ public class CaseFacadeEjb extends AbstractCoreFacadeEjb<Case, CaseDataDto, Case
 	}
 
 	@Override
+	public EditPermissionType isEditAllowedCaseContact(String uuid) {
+		Case ado = service.getByUuid(uuid);
+		return service.getEditPermissionTypeCaseContact(ado);
+	}
+
+	@Override
 	public List<String> getArchivedUuidsSince(Date since) {
 
 		if (userService.getCurrentUser() == null) {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseService.java
@@ -1505,7 +1505,7 @@ public class CaseService extends AbstractCoreAdoService<Case> {
 			.getFollowUpEndDate();
 	}
 
-	public EditPermissionType canAddContact(Case caze) {
+	public EditPermissionType isAddContactAllowed(Case caze) {
 		// we allow CaseContactViewEdit independently of the origin info
 
 		if (!inJurisdictionOrOwned(caze) || sormasToSormasShareInfoService.isCaseOwnershipHandedOver(caze)) {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseService.java
@@ -1505,6 +1505,16 @@ public class CaseService extends AbstractCoreAdoService<Case> {
 			.getFollowUpEndDate();
 	}
 
+	public EditPermissionType getEditPermissionTypeCaseContact(Case caze) {
+		// we allow CaseContactViewEdit independently of the ownership handover
+
+		if (!inJurisdictionOrOwned(caze) || sormasToSormasShareInfoService.isCaseOwnershipHandedOver(caze)) {
+			return EditPermissionType.REFUSED;
+		}
+
+		return super.getEditPermissionType(caze);
+	}
+
 	@Override
 	public EditPermissionType getEditPermissionType(Case caze) {
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseService.java
@@ -1505,8 +1505,8 @@ public class CaseService extends AbstractCoreAdoService<Case> {
 			.getFollowUpEndDate();
 	}
 
-	public EditPermissionType getEditPermissionTypeCaseContact(Case caze) {
-		// we allow CaseContactViewEdit independently of the ownership handover
+	public EditPermissionType canAddContact(Case caze) {
+		// we allow CaseContactViewEdit independently of the origin info
 
 		if (!inJurisdictionOrOwned(caze) || sormasToSormasShareInfoService.isCaseOwnershipHandedOver(caze)) {
 			return EditPermissionType.REFUSED;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseService.java
@@ -1506,9 +1506,9 @@ public class CaseService extends AbstractCoreAdoService<Case> {
 	}
 
 	public EditPermissionType isAddContactAllowed(Case caze) {
-		// we allow CaseContactViewEdit independently of the origin info
+		// we allow CaseContactViewEdit independently of ownership or similar
 
-		if (!inJurisdictionOrOwned(caze) || sormasToSormasShareInfoService.isCaseOwnershipHandedOver(caze)) {
+		if (!inJurisdictionOrOwned(caze)) {
 			return EditPermissionType.REFUSED;
 		}
 

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/CaseContactsView.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/CaseContactsView.java
@@ -1,20 +1,17 @@
-/*******************************************************************************
+/*
  * SORMAS® - Surveillance Outbreak Response Management & Analysis System
- * Copyright © 2016-2018 Helmholtz-Zentrum für Infektionsforschung GmbH (HZI)
- *
+ * Copyright © 2016-2022 Helmholtz-Zentrum für Infektionsforschung GmbH (HZI)
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
- *******************************************************************************/
+ */
 package de.symeda.sormas.ui.caze;
 
 import java.util.Collections;
@@ -39,6 +36,7 @@ import com.vaadin.ui.themes.ValoTheme;
 import com.vaadin.v7.ui.ComboBox;
 import com.vaadin.v7.ui.TextField;
 
+import de.symeda.sormas.api.EditPermissionType;
 import de.symeda.sormas.api.FacadeProvider;
 import de.symeda.sormas.api.caze.CaseDataDto;
 import de.symeda.sormas.api.contact.ContactClassification;
@@ -396,8 +394,11 @@ public class CaseContactsView extends AbstractCaseView {
 		updateFilterComponents();
 
 		grid.reload();
-
 		setCaseEditPermission(gridLayout);
+	}
+
+	protected boolean isCaseEditAllowed() {
+		return FacadeProvider.getCaseFacade().isEditAllowedCaseContact(getReference().getUuid()).equals(EditPermissionType.ALLOWED);
 	}
 
 	public void updateFilterComponents() {

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/CaseContactsView.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/CaseContactsView.java
@@ -398,7 +398,7 @@ public class CaseContactsView extends AbstractCaseView {
 	}
 
 	protected boolean isCaseEditAllowed() {
-		return FacadeProvider.getCaseFacade().isEditAllowedCaseContact(getReference().getUuid()).equals(EditPermissionType.ALLOWED);
+		return FacadeProvider.getCaseFacade().canEditContact(getReference().getUuid()).equals(EditPermissionType.ALLOWED);
 	}
 
 	public void updateFilterComponents() {

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/CaseContactsView.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/CaseContactsView.java
@@ -398,7 +398,7 @@ public class CaseContactsView extends AbstractCaseView {
 	}
 
 	protected boolean isCaseEditAllowed() {
-		return FacadeProvider.getCaseFacade().canEditContact(getReference().getUuid()).equals(EditPermissionType.ALLOWED);
+		return FacadeProvider.getCaseFacade().isEditContactAllowed(getReference().getUuid()).equals(EditPermissionType.ALLOWED);
 	}
 
 	public void updateFilterComponents() {


### PR DESCRIPTION
Fixes #9838

This allows users to edit the contact of cases when received via S2S, independently of the handover status.