### PR TITLE
[#9701] better user validation through annotations

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/BaseFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/BaseFacade.java
@@ -31,5 +31,5 @@ public interface BaseFacade<DTO extends EntityDto, INDEX_DTO extends Serializabl
 
 	List<String> getObsoleteUuidsSince(Date since);
 
-	void validate(DTO dto) throws ValidationRuntimeException;
+	void validate(@Valid DTO dto) throws ValidationRuntimeException;
 }

--- a/sormas-api/src/main/java/de/symeda/sormas/api/caze/CaseDataDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/caze/CaseDataDto.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import javax.validation.Valid;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 import org.apache.commons.lang3.StringUtils;
@@ -262,7 +263,7 @@ public class CaseDataDto extends SormasToSormasShareableDto {
 	@Required
 	private Date reportDate;
 	@Outbreaks
-	@Required
+	@NotNull(message = Validations.validReportingUser)
 	private UserReferenceDto reportingUser;
 	@HideForCountries(countries = {
 		COUNTRY_CODE_FRANCE,

--- a/sormas-api/src/main/java/de/symeda/sormas/api/contact/ContactDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/contact/ContactDto.java
@@ -23,6 +23,7 @@ import java.util.Date;
 import javax.validation.Valid;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 import de.symeda.sormas.api.Disease;
@@ -161,7 +162,7 @@ public class ContactDto extends SormasToSormasShareableDto {
 
 	@Required
 	private Date reportDateTime;
-	@Required
+	@NotNull(message = Validations.validReportingUser)
 	private UserReferenceDto reportingUser;
 	@SensitiveData
 	@Pseudonymizer(LatitudePseudonymizer.class)

--- a/sormas-api/src/main/java/de/symeda/sormas/api/event/EventParticipantDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/event/EventParticipantDto.java
@@ -1,6 +1,6 @@
 /*
  * SORMAS® - Surveillance Outbreak Response Management & Analysis System
- * Copyright © 2016-2021 Helmholtz-Zentrum für Infektionsforschung GmbH (HZI)
+ * Copyright © 2016-2022 Helmholtz-Zentrum für Infektionsforschung GmbH (HZI)
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -58,7 +58,7 @@ public class EventParticipantDto extends SormasToSormasShareableDto {
 	public static final String DELETION_REASON = "deletionReason";
 	public static final String OTHER_DELETION_REASON = "otherDeletionReason";
 
-	@NotNull
+	@NotNull(message = Validations.validReportingUser)
 	private UserReferenceDto reportingUser;
 	@Required
 	private EventReferenceDto event;

--- a/sormas-api/src/main/java/de/symeda/sormas/api/event/EventParticipantDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/event/EventParticipantDto.java
@@ -18,6 +18,7 @@ import de.symeda.sormas.api.common.DeletionReason;
 import de.symeda.sormas.api.feature.FeatureType;
 import de.symeda.sormas.api.utils.DependingOnFeatureType;
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 import de.symeda.sormas.api.Disease;
@@ -57,7 +58,7 @@ public class EventParticipantDto extends SormasToSormasShareableDto {
 	public static final String DELETION_REASON = "deletionReason";
 	public static final String OTHER_DELETION_REASON = "otherDeletionReason";
 
-	@Required
+	@NotNull
 	private UserReferenceDto reportingUser;
 	@Required
 	private EventReferenceDto event;

--- a/sormas-api/src/main/java/de/symeda/sormas/api/immunization/ImmunizationDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/immunization/ImmunizationDto.java
@@ -23,6 +23,7 @@ import java.util.Date;
 import java.util.List;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 import de.symeda.sormas.api.Disease;
@@ -103,6 +104,7 @@ public class ImmunizationDto extends SormasToSormasShareableDto {
 	private PersonReferenceDto person;
 	@Required
 	private Date reportDate;
+	@NotNull(message = Validations.validReportingUser)
 	private UserReferenceDto reportingUser;
 	private boolean archived;
 	@Required

--- a/sormas-api/src/test/java/de/symeda/sormas/api/utils/DataHelperTest.java
+++ b/sormas-api/src/test/java/de/symeda/sormas/api/utils/DataHelperTest.java
@@ -13,7 +13,6 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Date;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import de.symeda.sormas.api.Disease;
@@ -134,7 +133,6 @@ public class DataHelperTest {
 	}
 
 	@Test
-	@Ignore
 	public void testParseDateTimeWithExceptionForEnFormat() throws ParseException {
 		Date date = DateHelper.parseDate("4/21/2021 13:30", new SimpleDateFormat("M/dd/yyy HH:mm"));
 
@@ -155,7 +153,6 @@ public class DataHelperTest {
 	}
 
 	@Test
-	@Ignore
 	public void testParseDateTimeWithExceptionForDeFormat() throws ParseException {
 		Date date = DateHelper.parseDate("4/21/2021 13:30", new SimpleDateFormat("M/dd/yyy HH:mm"));
 

--- a/sormas-api/src/test/java/de/symeda/sormas/api/utils/DataHelperTest.java
+++ b/sormas-api/src/test/java/de/symeda/sormas/api/utils/DataHelperTest.java
@@ -13,6 +13,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Date;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import de.symeda.sormas.api.Disease;
@@ -133,6 +134,7 @@ public class DataHelperTest {
 	}
 
 	@Test
+	@Ignore
 	public void testParseDateTimeWithExceptionForEnFormat() throws ParseException {
 		Date date = DateHelper.parseDate("4/21/2021 13:30", new SimpleDateFormat("M/dd/yyy HH:mm"));
 
@@ -153,6 +155,7 @@ public class DataHelperTest {
 	}
 
 	@Test
+	@Ignore
 	public void testParseDateTimeWithExceptionForDeFormat() throws ParseException {
 		Date date = DateHelper.parseDate("4/21/2021 13:30", new SimpleDateFormat("M/dd/yyy HH:mm"));
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/campaign/CampaignFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/campaign/CampaignFacadeEjb.java
@@ -207,7 +207,7 @@ public class CampaignFacadeEjb
 		validate(getByUuid(campaignReferenceDto.getUuid()));
 	}
 
-	public void validate(CampaignDto campaignDto) {
+	public void validate(@Valid CampaignDto campaignDto) {
 		final List<CampaignDashboardElement> campaignDashboardElements = campaignDto.getCampaignDashboardElements();
 		if (campaignDashboardElements != null) {
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseFacadeEjb.java
@@ -1741,7 +1741,7 @@ public class CaseFacadeEjb extends AbstractCoreFacadeEjb<Case, CaseDataDto, Case
 	}
 
 	@Override
-	public void validate(CaseDataDto caze) throws ValidationRuntimeException {
+	public void validate(@Valid CaseDataDto caze) throws ValidationRuntimeException {
 
 		// Check whether any required field that does not have a not null constraint in
 		// the database is empty

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/contact/ContactFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/contact/ContactFacadeEjb.java
@@ -1817,14 +1817,11 @@ public class ContactFacadeEjb
 	}
 
 	@Override
-	public void validate(ContactDto contact) throws ValidationRuntimeException {
+	public void validate(@Valid ContactDto contact) throws ValidationRuntimeException {
 
 		// Check whether any required field that does not have a not null constraint in the database is empty
 		if (contact.getReportDateTime() == null) {
 			throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.validReportDateTime));
-		}
-		if (contact.getReportingUser() == null) {
-			throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.validReportingUser));
 		}
 		if (contact.getDisease() == null) {
 			throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.validDisease));

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/event/EventFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/event/EventFacadeEjb.java
@@ -991,7 +991,7 @@ public class EventFacadeEjb extends AbstractCoreFacadeEjb<Event, EventDto, Event
 	}
 
 	@Override
-	public void validate(EventDto event) throws ValidationRuntimeException {
+	public void validate(@Valid EventDto event) throws ValidationRuntimeException {
 
 		// Check whether any required field that does not have a not null constraint in
 		// the database is empty

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/event/EventParticipantFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/event/EventParticipantFacadeEjb.java
@@ -438,7 +438,7 @@ public class EventParticipantFacadeEjb
 	}
 
 	@Override
-	public void validate(EventParticipantDto eventParticipant) throws ValidationRuntimeException {
+	public void validate(@Valid EventParticipantDto eventParticipant) throws ValidationRuntimeException {
 
 		// Check whether any required field that does not have a not null constraint in the database is empty
 		if (eventParticipant.getPerson() == null) {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/immunization/ImmunizationFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/immunization/ImmunizationFacadeEjb.java
@@ -393,7 +393,7 @@ public class ImmunizationFacadeEjb
 	}
 
 	@Override
-	public void validate(ImmunizationDto immunizationDto) throws ValidationRuntimeException {
+	public void validate(@Valid ImmunizationDto immunizationDto) throws ValidationRuntimeException {
 		if (DateHelper.isStartDateBeforeEndDate(immunizationDto.getStartDate(), immunizationDto.getEndDate())) {
 			String validationError = String.format(
 				I18nProperties.getValidationError(Validations.afterDate),

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/AbstractInfrastructureFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/AbstractInfrastructureFacadeEjb.java
@@ -183,7 +183,7 @@ public abstract class AbstractInfrastructureFacadeEjb<ADO extends Infrastructure
 	// todo implement toDto() here
 
 	@Override
-	public void validate(DTO dto) throws ValidationRuntimeException {
+	public void validate(@Valid DTO dto) throws ValidationRuntimeException {
 		// todo we do not run any generic validation logic for infra yet
 	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/facility/FacilityFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/facility/FacilityFacadeEjb.java
@@ -34,6 +34,7 @@ import javax.persistence.criteria.JoinType;
 import javax.persistence.criteria.Order;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 import org.apache.commons.collections.CollectionUtils;
@@ -576,7 +577,7 @@ public class FacilityFacadeEjb
 	}
 
 	@Override
-	public void validate(FacilityDto dto) {
+	public void validate(@Valid FacilityDto dto) {
 		if (dto.getType() == null
 			&& !FacilityDto.OTHER_FACILITY_UUID.equals(dto.getUuid())
 			&& !FacilityDto.NONE_FACILITY_UUID.equals(dto.getUuid())) {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/pointofentry/PointOfEntryFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/pointofentry/PointOfEntryFacadeEjb.java
@@ -17,6 +17,7 @@ import javax.persistence.criteria.JoinType;
 import javax.persistence.criteria.Order;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 import org.apache.commons.collections.CollectionUtils;
@@ -162,7 +163,7 @@ public class PointOfEntryFacadeEjb
 	}
 
 	@Override
-	public void validate(PointOfEntryDto pointOfEntry) throws ValidationRuntimeException {
+	public void validate(@Valid PointOfEntryDto pointOfEntry) throws ValidationRuntimeException {
 
 		if (StringUtils.isEmpty(pointOfEntry.getName())) {
 			throw new ValidationRuntimeException(

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/travelentry/TravelEntryFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/travelentry/TravelEntryFacadeEjb.java
@@ -233,7 +233,7 @@ public class TravelEntryFacadeEjb
 	}
 
 	@Override
-	public void validate(TravelEntryDto travelEntryDto) {
+	public void validate(@Valid TravelEntryDto travelEntryDto) {
 		if (travelEntryDto.getPerson() == null) {
 			throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.validPerson));
 		}


### PR DESCRIPTION
Fixes #9701 
@MateStrysewske This PR adds a validation to the API, however, the reporting user was either already checked in the validate method or it has a not null constraint in the DB. 

I went through the general setup here and I think we should start to phase out `@Required` over time, I'm going to write a dedicated issue for that.
