### PR TITLE
increase combobox width in contact line listing #9530

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/contact/components/linelisting/contactfield/ContactLineField.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/contact/components/linelisting/contactfield/ContactLineField.java
@@ -61,13 +61,13 @@ public class ContactLineField extends CustomField<ContactLineFieldDto> {
 		binder.forField(multiDay).bind(ContactLineFieldDto.MULTI_DAY_SELECTOR);
 
 		typeOfContact.setId("typeOfContact");
-		typeOfContact.setWidth(150, Unit.PIXELS);
+		typeOfContact.setWidth(270, Unit.PIXELS);
 		typeOfContact.addStyleName(CssStyles.CAPTION_OVERFLOW);
 		binder.forField(typeOfContact).bind(ContactLineFieldDto.TYPE_OF_CONTACT);
 
 		relationToCase.setId("relationToCase");
 		relationToCase.setItems(ContactRelation.values());
-		relationToCase.setWidth(150, Unit.PIXELS);
+		relationToCase.setWidth(270, Unit.PIXELS);
 		relationToCase.addStyleName(CssStyles.CAPTION_OVERFLOW);
 		binder.forField(relationToCase).bind(ContactLineFieldDto.RELATION_TO_CASE);
 


### PR DESCRIPTION
<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #9530

The tooltip feature for hovering over combo box items is not available for Vaadin 8.:
https://vaadin.com/forum/thread/17044583/mouseover-tooltip-for-combobox-items

Due to the end of the sprint and the planned release, this PR provides a preliminary fix which increases readability of the combo box texts by increasing the width of the affected input fields.
Possibilities to provide the tooltip-on-hover feature within Vaadin 8 will be further investigated.