### PR TITLE
Change/9701 s2s reporting user

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/sample/SampleFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/sample/SampleFacade.java
@@ -67,7 +67,7 @@ public interface SampleFacade {
 
 	List<String> deleteSamples(List<String> sampleUuids, DeletionDetails deletionDetails);
 
-	void validate(SampleDto sample, boolean checkAssociatedEntities) throws ValidationRuntimeException;
+	void validate(@Valid SampleDto sample, boolean checkAssociatedEntities) throws ValidationRuntimeException;
 
 	List<String> getDeletedUuidsSince(Date since);
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/SampleFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sample/SampleFacadeEjb.java
@@ -432,7 +432,7 @@ public class SampleFacadeEjb implements SampleFacade {
 	}
 
 	@Override
-	public void validate(SampleDto sample, boolean checkAssociatedEntities) throws ValidationRuntimeException {
+	public void validate(@Valid SampleDto sample, boolean checkAssociatedEntities) throws ValidationRuntimeException {
 
 		if (sample.getAssociatedCase() == null && sample.getAssociatedContact() == null && sample.getAssociatedEventParticipant() == null) {
 			throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.validCaseContactOrEventParticipant));

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/AbstractSormasToSormasInterface.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/AbstractSormasToSormasInterface.java
@@ -406,7 +406,7 @@ public abstract class AbstractSormasToSormasInterface<ADO extends AbstractDomain
 		SyncDataDto syncData = sormasToSormasEncryptionEjb.decryptAndVerify(encryptedData, SyncDataDto.class);
 
 		ShareDataExistingEntities existingEntities = loadExistingEntities(syncData.getShareData());
-		perisist(
+		persist(
 			syncData.getShareData(),
 			(data, existinCase) -> processedEntitiesPersister
 				.persistSyncData(data, syncData.getShareData().getOriginInfo(), syncData.getCriteria(), existingEntities));
@@ -436,10 +436,10 @@ public abstract class AbstractSormasToSormasInterface<ADO extends AbstractDomain
 
 		SormasToSormasDto receivedData = sormasToSormasEncryptionEjb.decryptAndVerify(encryptedData, SormasToSormasDto.class);
 
-		perisist(receivedData, persister);
+		persist(receivedData, persister);
 	}
 
-	private void perisist(@Valid SormasToSormasDto receivedData, Persister persister) throws SormasToSormasValidationException {
+	private void persist(@Valid SormasToSormasDto receivedData, Persister persister) throws SormasToSormasValidationException {
 		ShareDataExistingEntities existingEntities = loadExistingEntities(receivedData);
 		List<ValidationErrors> validationErrors = receivedEntitiesProcessor.processReceivedData(receivedData, existingEntities);
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/caze/CaseShareDataBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/caze/CaseShareDataBuilder.java
@@ -86,7 +86,8 @@ public class CaseShareDataBuilder
 	private CaseDataDto getCazeDto(Case caze, Pseudonymizer pseudonymizer) {
 		CaseDataDto cazeDto = caseFacade.convertToDto(caze, pseudonymizer);
 
-		cazeDto.setReportingUser(null);
+		// reporting user is not set to null here as it would not pass the validation
+		// the receiver appears to set it to SORMAS2SORMAS Client anyway
 		cazeDto.setClassificationUser(null);
 		cazeDto.setSurveillanceOfficer(null);
 		cazeDto.setCaseOfficer(null);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/caze/CaseShareDataBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/caze/CaseShareDataBuilder.java
@@ -61,9 +61,8 @@ public class CaseShareDataBuilder
 	@Override
 	protected SormasToSormasCaseDto doBuildShareData(Case caze, ShareRequestInfo requestInfo, boolean ownerShipHandedOver) {
 		Pseudonymizer pseudonymizer = dataBuilderHelper.createPseudonymizer(requestInfo);
-
 		PersonDto personDto = dataBuilderHelper.getPersonDto(caze.getPerson(), pseudonymizer, requestInfo);
-		CaseDataDto cazeDto = getCazeDto(caze, pseudonymizer);
+		CaseDataDto cazeDto = getDto(caze, pseudonymizer);
 
 		dataBuilderHelper.clearIgnoredProperties(cazeDto);
 
@@ -83,9 +82,10 @@ public class CaseShareDataBuilder
 		return getCasePreview(caze, pseudonymizer);
 	}
 
-	private CaseDataDto getCazeDto(Case caze, Pseudonymizer pseudonymizer) {
-		CaseDataDto cazeDto = caseFacade.convertToDto(caze, pseudonymizer);
+	@Override
+	protected CaseDataDto getDto(Case caze, Pseudonymizer pseudonymizer) {
 
+		CaseDataDto cazeDto = caseFacade.convertToDto(caze, pseudonymizer);
 		// reporting user is not set to null here as it would not pass the validation
 		// the receiver appears to set it to SORMAS2SORMAS Client anyway
 		cazeDto.setClassificationUser(null);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/contact/ContactShareDataBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/contact/ContactShareDataBuilder.java
@@ -57,14 +57,26 @@ public class ContactShareDataBuilder
 
 	@Override
 	protected SormasToSormasContactDto doBuildShareData(Contact contact, ShareRequestInfo requestInfo, boolean ownerShipHandedOver) {
-		Pseudonymizer pseudonymizer =
-			dataBuilderHelper.createPseudonymizer(requestInfo);
+		Pseudonymizer pseudonymizer = dataBuilderHelper.createPseudonymizer(requestInfo);
 
-		PersonDto personDto = dataBuilderHelper
-			.getPersonDto(contact.getPerson(), pseudonymizer, requestInfo);
-		ContactDto contactDto = dataBuilderHelper.getContactDto(contact, pseudonymizer);
+		PersonDto personDto = dataBuilderHelper.getPersonDto(contact.getPerson(), pseudonymizer, requestInfo);
+		ContactDto contactDto = getDto(contact, pseudonymizer);
 
 		return new SormasToSormasContactDto(personDto, contactDto);
+	}
+
+	@Override
+	protected ContactDto getDto(Contact contact, Pseudonymizer pseudonymizer) {
+
+		ContactDto contactDto = contactFacade.convertToDto(contact, pseudonymizer);
+		// reporting user is not set to null here as it would not pass the validation
+		// the receiver appears to set it to SORMAS2SORMAS Client anyway
+		contactDto.setContactOfficer(null);
+		contactDto.setResultingCaseUser(null);
+		contactDto.setSormasToSormasOriginInfo(null);
+		dataBuilderHelper.clearIgnoredProperties(contactDto);
+
+		return contactDto;
 	}
 
 	@Override
@@ -75,8 +87,7 @@ public class ContactShareDataBuilder
 
 	@Override
 	public SormasToSormasContactPreview doBuildShareDataPreview(Contact contact, ShareRequestInfo requestInfo) {
-		Pseudonymizer pseudonymizer =
-			dataBuilderHelper.createPseudonymizer(requestInfo);
+		Pseudonymizer pseudonymizer = dataBuilderHelper.createPseudonymizer(requestInfo);
 
 		return dataBuilderHelper.getContactPreview(contact, pseudonymizer);
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/event/EventShareDataBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/event/EventShareDataBuilder.java
@@ -52,11 +52,8 @@ public class EventShareDataBuilder
 
 	@Override
 	protected SormasToSormasEventDto doBuildShareData(Event data, ShareRequestInfo requestInfo, boolean ownerShipHandedOver) {
-		Pseudonymizer pseudonymizer =
-			dataBuilderHelper.createPseudonymizer(requestInfo);
-
-		EventDto eventDto = getEventDto(data, pseudonymizer);
-
+		Pseudonymizer pseudonymizer = dataBuilderHelper.createPseudonymizer(requestInfo);
+		EventDto eventDto = getDto(data, pseudonymizer);
 		return new SormasToSormasEventDto(eventDto);
 	}
 
@@ -67,21 +64,18 @@ public class EventShareDataBuilder
 
 	@Override
 	public SormasToSormasEventPreview doBuildShareDataPreview(Event event, ShareRequestInfo requestInfo) {
-		Pseudonymizer pseudonymizer =
-			dataBuilderHelper.createPseudonymizer(requestInfo);
-
+		Pseudonymizer pseudonymizer = dataBuilderHelper.createPseudonymizer(requestInfo);
 		return getEventPreview(event, pseudonymizer);
 	}
 
-	private EventDto getEventDto(Event event, Pseudonymizer pseudonymizer) {
-		EventDto eventDto = eventFacade.convertToDto(event, pseudonymizer);
+	@Override
+	protected EventDto getDto(Event event, Pseudonymizer pseudonymizer) {
 
+		EventDto eventDto = eventFacade.convertToDto(event, pseudonymizer);
 		// reporting user is not set to null here as it would not pass the validation
 		// the receiver appears to set it to SORMAS2SORMAS Client anyway
 		eventDto.setSormasToSormasOriginInfo(null);
-
 		dataBuilderHelper.clearIgnoredProperties(eventDto);
-
 		return eventDto;
 	}
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/event/EventShareDataBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/event/EventShareDataBuilder.java
@@ -76,7 +76,8 @@ public class EventShareDataBuilder
 	private EventDto getEventDto(Event event, Pseudonymizer pseudonymizer) {
 		EventDto eventDto = eventFacade.convertToDto(event, pseudonymizer);
 
-		eventDto.setReportingUser(null);
+		// reporting user is not set to null here as it would not pass the validation
+		// the receiver appears to set it to SORMAS2SORMAS Client anyway
 		eventDto.setSormasToSormasOriginInfo(null);
 
 		dataBuilderHelper.clearIgnoredProperties(eventDto);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/eventparticipant/EventParticipantShareDataBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/eventparticipant/EventParticipantShareDataBuilder.java
@@ -52,18 +52,28 @@ public class EventParticipantShareDataBuilder
 	}
 
 	@Override
-	public SormasToSormasEventParticipantDto doBuildShareData(EventParticipant data, ShareRequestInfo requestInfo, boolean ownerShipHandedOver) {
+	public SormasToSormasEventParticipantDto doBuildShareData(
+		EventParticipant eventParticipant,
+		ShareRequestInfo requestInfo,
+		boolean ownerShipHandedOver) {
 		Pseudonymizer pseudonymizer = dataBuilderHelper.createPseudonymizer(requestInfo);
 
-		EventParticipantDto eventParticipantDto = eventParticipantFacade.convertToDto(data, pseudonymizer);
+		EventParticipantDto eventParticipantDto = getDto(eventParticipant, pseudonymizer);
+		dataBuilderHelper.pseudonymizePerson(eventParticipantDto.getPerson(), requestInfo);
 
-		eventParticipantDto.setReportingUser(null);
+		return new SormasToSormasEventParticipantDto(eventParticipantDto);
+	}
+
+	@Override
+	protected EventParticipantDto getDto(EventParticipant eventParticipant, Pseudonymizer pseudonymizer) {
+
+		EventParticipantDto eventParticipantDto = eventParticipantFacade.convertToDto(eventParticipant, pseudonymizer);
+		// reporting user is not set to null here as it would not pass the validation
+		// the receiver appears to set it to SORMAS2SORMAS Client anyway
 		eventParticipantDto.setSormasToSormasOriginInfo(null);
 		dataBuilderHelper.clearIgnoredProperties(eventParticipantDto.getPerson());
 
-		dataBuilderHelper.pseudonymiePerson(eventParticipantDto.getPerson(), requestInfo);
-
-		return new SormasToSormasEventParticipantDto(eventParticipantDto);
+		return eventParticipantDto;
 	}
 
 	@Override

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/immunization/ImmunizationShareDataBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/immunization/ImmunizationShareDataBuilder.java
@@ -56,7 +56,9 @@ public class ImmunizationShareDataBuilder
 			dataBuilderHelper.createPseudonymizer(requestInfo);
 
 		ImmunizationDto immunizationDto = immunizationFacade.convertToDto(immunization, pseudonymizer);
-		immunizationDto.setReportingUser(null);
+
+		// reporting user is not set to null here as it would not pass the validation
+		// the receiver appears to set it to SORMAS2SORMAS Client anyway
 		immunizationDto.setSormasToSormasOriginInfo(null);
 		dataBuilderHelper.clearIgnoredProperties(immunizationDto);
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/immunization/ImmunizationShareDataBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/immunization/ImmunizationShareDataBuilder.java
@@ -52,17 +52,21 @@ public class ImmunizationShareDataBuilder
 
 	@Override
 	protected SormasToSormasImmunizationDto doBuildShareData(Immunization immunization, ShareRequestInfo requestInfo, boolean ownerShipHandedOver) {
-		Pseudonymizer pseudonymizer =
-			dataBuilderHelper.createPseudonymizer(requestInfo);
+		Pseudonymizer pseudonymizer = dataBuilderHelper.createPseudonymizer(requestInfo);
+		ImmunizationDto immunizationDto = getDto(immunization, pseudonymizer);
+		return new SormasToSormasImmunizationDto(immunizationDto);
+	}
+
+	@Override
+	protected ImmunizationDto getDto(Immunization immunization, Pseudonymizer pseudonymizer) {
 
 		ImmunizationDto immunizationDto = immunizationFacade.convertToDto(immunization, pseudonymizer);
-
 		// reporting user is not set to null here as it would not pass the validation
 		// the receiver appears to set it to SORMAS2SORMAS Client anyway
 		immunizationDto.setSormasToSormasOriginInfo(null);
 		dataBuilderHelper.clearIgnoredProperties(immunizationDto);
 
-		return new SormasToSormasImmunizationDto(immunizationDto);
+		return immunizationDto;
 	}
 
 	@Override

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/sample/SampleShareDataBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/sample/SampleShareDataBuilder.java
@@ -67,26 +67,24 @@ public class SampleShareDataBuilder
 	}
 
 	@Override
-	protected SormasToSormasSampleDto doBuildShareData(Sample data, ShareRequestInfo requestInfo, boolean ownerShipHandedOver) {
+	protected SormasToSormasSampleDto doBuildShareData(Sample sample, ShareRequestInfo requestInfo, boolean ownerShipHandedOver) {
 		Pseudonymizer pseudonymizer =
 			dataBuilderHelper.createPseudonymizer(requestInfo);
 
-		SampleDto sampleDto = sampleFacade.convertToDto(data, pseudonymizer);
-		sampleDto.setReportingUser(null);
-		sampleDto.setSormasToSormasOriginInfo(null);
+		SampleDto sampleDto = getDto(sample, pseudonymizer);
 
-		List<PathogenTestDto> pathogenTests = data.getPathogenTests().stream().map(t -> {
+		List<PathogenTestDto> pathogenTests = sample.getPathogenTests().stream().map(t -> {
 			PathogenTestDto pathogenTestDto = pathogenTestFacade.convertToDto(t, pseudonymizer);
 			dataBuilderHelper.clearIgnoredProperties(pathogenTestDto);
 			return pathogenTestDto;
 		}).collect(Collectors.toList());
 
 		List<AdditionalTestDto> additionalTests =
-			data.getAdditionalTests().stream().map(t -> additionalTestFacade.convertToDto(t, pseudonymizer)).collect(Collectors.toList());
+				sample.getAdditionalTests().stream().map(t -> additionalTestFacade.convertToDto(t, pseudonymizer)).collect(Collectors.toList());
 
 		List<SormasToSormasExternalMessageDto> externalMessages = Collections.emptyList();
 		if (ownerShipHandedOver) {
-			externalMessages = data.getExternalMessages().stream().map(m -> {
+			externalMessages = sample.getExternalMessages().stream().map(m -> {
 				ExternalMessageDto externalMessageDto = externalMessageFacade.toDto(m);
 				externalMessageDto.setAssignee(null);
 
@@ -98,11 +96,21 @@ public class SampleShareDataBuilder
 	}
 
 	@Override
+	protected SampleDto getDto(Sample sample, Pseudonymizer pseudonymizer) {
+
+		SampleDto sampleDto = sampleFacade.convertToDto(sample, pseudonymizer);
+		sampleDto.setReportingUser(null);
+		sampleDto.setSormasToSormasOriginInfo(null);
+		// todo no dataBuilderHelper.clearIgnoredProperties(sampleDto); ?
+		return sampleDto;
+	}
+
+	@Override
 	public void doBusinessValidation(SormasToSormasSampleDto sormasToSormasSampleDto) throws ValidationRuntimeException {
 		sampleFacade.validate(sormasToSormasSampleDto.getEntity(), true);
 		sormasToSormasSampleDto.getPathogenTests().forEach(pathogenTestFacade::validate);
-		// additional test facade has no validation method
-		// external messages facade has no validation method
+		// todo additional test facade has no validation method. Add them here if they are available
+		// todo external messages facade has no validation method. Add them if they are available
 	}
 
 	@Override

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/share/ShareDataBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/share/ShareDataBuilder.java
@@ -18,6 +18,7 @@ package de.symeda.sormas.backend.sormastosormas.share;
 import java.util.ArrayList;
 import java.util.List;
 
+import de.symeda.sormas.backend.util.Pseudonymizer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,6 +66,7 @@ public abstract class ShareDataBuilder<DTO extends SormasToSormasShareableDto, A
 		}
 		return shared;
 	}
+	protected abstract DTO getDto(ADO ado, Pseudonymizer pseudonymizer);
 
 	protected abstract void doBusinessValidation(SHARED shared) throws ValidationRuntimeException;
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/share/ShareDataBuilderHelper.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/share/ShareDataBuilderHelper.java
@@ -1,6 +1,6 @@
 /*
  * SORMAS® - Surveillance Outbreak Response Management & Analysis System
- * Copyright © 2016-2021 Helmholtz-Zentrum für Infektionsforschung GmbH (HZI)
+ * Copyright © 2016-2022 Helmholtz-Zentrum für Infektionsforschung GmbH (HZI)
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -24,7 +24,6 @@ import javax.ejb.Stateless;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import de.symeda.sormas.api.contact.ContactDto;
 import de.symeda.sormas.api.i18n.Captions;
 import de.symeda.sormas.api.i18n.I18nProperties;
 import de.symeda.sormas.api.person.PersonDto;
@@ -81,32 +80,18 @@ public class ShareDataBuilderHelper {
 	public PersonDto getPersonDto(Person person, Pseudonymizer pseudonymizer, ShareRequestInfo requestInfo) {
 		PersonDto personDto = personFacade.convertToDto(person, pseudonymizer, true);
 
-		pseudonymiePerson(personDto, requestInfo);
+		pseudonymizePerson(personDto, requestInfo);
 
 		clearIgnoredProperties(personDto);
 
 		return personDto;
 	}
 
-	public void pseudonymiePerson(PersonDto personDto, ShareRequestInfo requestInfo) {
+	public void pseudonymizePerson(PersonDto personDto, ShareRequestInfo requestInfo) {
 		if (requestInfo.isPseudonymizedPersonalData() || requestInfo.isPseudonymizedSensitiveData()) {
 			personDto.setFirstName(I18nProperties.getCaption(Captions.inaccessibleValue));
 			personDto.setLastName(I18nProperties.getCaption(Captions.inaccessibleValue));
 		}
-	}
-
-	public ContactDto getContactDto(Contact contact, Pseudonymizer pseudonymizer) {
-		ContactDto contactDto = contactFacade.convertToDto(contact, pseudonymizer);
-
-		// reporting user is not set to null here as it would not pass the validation
-		// the receiver appears to set it to SORMAS2SORMAS Client anyway
-		contactDto.setContactOfficer(null);
-		contactDto.setResultingCaseUser(null);
-		contactDto.setSormasToSormasOriginInfo(null);
-
-		clearIgnoredProperties(contactDto);
-
-		return contactDto;
 	}
 
 	public SormasToSormasOriginInfoDto createSormasToSormasOriginInfo(User user, ShareRequestInfo requestInfo) {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/share/ShareDataBuilderHelper.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/share/ShareDataBuilderHelper.java
@@ -99,7 +99,7 @@ public class ShareDataBuilderHelper {
 		ContactDto contactDto = contactFacade.convertToDto(contact, pseudonymizer);
 
 		// reporting user is not set to null here as it would not pass the validation
-		// the receiver appears to set it to SORMAS2SORMAS Client anyway in the UI
+		// the receiver appears to set it to SORMAS2SORMAS Client anyway
 		contactDto.setContactOfficer(null);
 		contactDto.setResultingCaseUser(null);
 		contactDto.setSormasToSormasOriginInfo(null);

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/AbstractBeanTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/AbstractBeanTest.java
@@ -807,6 +807,7 @@ public abstract class AbstractBeanTest extends BaseBeanTest {
 		return natUser;
 	}
 
+
 	protected UserDto useNationalAdminLogin() {
 		UserDto natUser = creator.createUser(
 			"",

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasTest.java
@@ -104,9 +104,11 @@ public abstract class SormasToSormasTest extends AbstractBeanTest {
 		rdcf = createRDCF(true).centralRdcf;
 
 		s2sClientUser = creator.createUser(
-				rdcf,
-				creator.getUserRoleReference(DefaultUserRole.NATIONAL_USER),
-				creator.getUserRoleReference(DefaultUserRole.SORMAS_TO_SORMAS_CLIENT));
+			rdcf,
+			"S2S",
+			"Client",
+			creator.getUserRoleReference(DefaultUserRole.NATIONAL_USER),
+			creator.getUserRoleReference(DefaultUserRole.SORMAS_TO_SORMAS_CLIENT));
 
 		getFacilityService().createConstantFacilities();
 		getPointOfEntryService().createConstantPointsOfEntry();

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/SormasToSormasTest.java
@@ -26,6 +26,8 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.function.Consumer;
 
+import de.symeda.sormas.api.user.DefaultUserRole;
+import org.junit.After;
 import org.mockito.Mockito;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
@@ -83,6 +85,7 @@ public abstract class SormasToSormasTest extends AbstractBeanTest {
 	public static final String SECOND_SERVER_ID = "2.sormas.id.sormas_b";
 	private ObjectMapper objectMapper;
 	protected TestDataCreator.RDCF rdcf;
+	protected UserDto s2sClientUser;
 
 	@Override
 	public void init() {
@@ -100,8 +103,20 @@ public abstract class SormasToSormasTest extends AbstractBeanTest {
 		// in S2S we use external IDs
 		rdcf = createRDCF(true).centralRdcf;
 
+		s2sClientUser = creator.createUser(
+				rdcf,
+				creator.getUserRoleReference(DefaultUserRole.NATIONAL_USER),
+				creator.getUserRoleReference(DefaultUserRole.SORMAS_TO_SORMAS_CLIENT));
+
 		getFacilityService().createConstantFacilities();
 		getPointOfEntryService().createConstantPointsOfEntry();
+	}
+
+	@After
+	public void teardown() {
+		FeatureConfigurationIndexDto featureConfiguration =
+			new FeatureConfigurationIndexDto(DataHelper.createUuid(), null, null, null, null, null, false, null);
+		getFeatureConfigurationFacade().saveFeatureConfiguration(featureConfiguration, FeatureType.SORMAS_TO_SORMAS_ACCEPT_REJECT);
 	}
 
 	protected boolean isAcceptRejectFeatureEnabled() {
@@ -280,6 +295,7 @@ public abstract class SormasToSormasTest extends AbstractBeanTest {
 		MockProducer.getProperties().setProperty(ConfigFacadeEjb.SORMAS2SORMAS_TRUSTSTORE_NAME, "sormas2sormas.truststore.p12");
 		MockProducer.getProperties().setProperty(ConfigFacadeEjb.SORMAS2SORMAS_TRUSTSTORE_PASS, "password");
 		MockProducer.getProperties().setProperty(ConfigFacadeEjb.SORMAS2SORMAS_ROOT_CA_ALIAS, "S2SCA");
+
 	}
 
 	protected MappableRdcf createRDCF(boolean withExternalId) {

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/entities/SormasToSormasCaseFacadeEjbTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/entities/SormasToSormasCaseFacadeEjbTest.java
@@ -130,7 +130,7 @@ public class SormasToSormasCaseFacadeEjbTest extends SormasToSormasTest {
 
 				assertThat(sharedCase.getEntity().getUuid(), is(caze.getUuid()));
 				// users should be cleaned up
-				assertThat(sharedCase.getEntity().getReportingUser(), is(nullValue()));
+				assertThat(sharedCase.getEntity().getReportingUser(), is(officer));
 				assertThat(sharedCase.getEntity().getSurveillanceOfficer(), is(nullValue()));
 				assertThat(sharedCase.getEntity().getClassificationUser(), is(nullValue()));
 

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/entities/SormasToSormasEventFacadeEjbTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/sormastosormas/entities/SormasToSormasEventFacadeEjbTest.java
@@ -791,7 +791,6 @@ public class SormasToSormasEventFacadeEjbTest extends SormasToSormasTest {
 
 		getEventParticipantFacade().save(eventParticipant);
 
-
 		SampleDto sample = createSample(eventParticipant.toReference(), officer.toReference(), rdcf.facility);
 		sample.setLabSampleID("Test lab sample id");
 		getSampleFacade().saveSample(sample);


### PR DESCRIPTION
Fixes #9701
The PR does the following:

- Do not set `reportingUser` to null where it is required while building the S2S share
- Add generic method to build the DTO while sharing