### PR TITLE
[#10155] include apache commons codec dependency in keycloak serviec …

### DIFF
--- a/sormas-base/dependencies/serverlibs.pom
+++ b/sormas-base/dependencies/serverlibs.pom
@@ -63,10 +63,6 @@
 			<artifactId>commons-beanutils</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>commons-codec</groupId>
-			<artifactId>commons-codec</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>commons-collections</groupId>
 			<artifactId>commons-collections</artifactId>
 		</dependency>

--- a/sormas-base/pom.xml
+++ b/sormas-base/pom.xml
@@ -377,7 +377,6 @@
 				<groupId>commons-codec</groupId>
 				<artifactId>commons-codec</artifactId>
 				<version>1.15</version>
-				<scope>provided</scope>
 			</dependency>
 			<dependency>
 				<groupId>commons-collections</groupId>

--- a/sormas-keycloak-service-provider/pom.xml
+++ b/sormas-keycloak-service-provider/pom.xml
@@ -32,6 +32,10 @@
 			<artifactId>sormas-api</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
…provider package
Fixes #10155 
Before this fix, the missing dependency was not part of the resulting JAR, after this fix it is included. The classloader of Keycloak should therefore be able to find it in the provider package.