### PR TITLE
qu-auto/SORQA-467 Automatize "Test Vaccinations without a "vaccination date" should also be marked as relevant and included in the status calculation (Contact)"

### DIFF
--- a/sormas-e2e-tests/src/main/java/org/sormas/e2etests/pages/application/contacts/EditContactPage.java
+++ b/sormas-e2e-tests/src/main/java/org/sormas/e2etests/pages/application/contacts/EditContactPage.java
@@ -186,4 +186,7 @@ public class EditContactPage {
   }
 
   public static final By NOTIFICATION_MESSAGE_POPUP = By.cssSelector(".v-Notification-description");
+  public static final By EDIT_VACCINATION_BUTTON =
+      By.xpath(
+          "//div[@location='vaccinations']//div[@class='v-button v-widget link v-button-link compact v-button-compact']");
 }

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/cases/EditContactsSteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/cases/EditContactsSteps.java
@@ -484,6 +484,14 @@ public class EditContactsSteps implements En {
     When(
         "I click on the contacts list button",
         () -> webDriverHelpers.clickOnWebElementBySelector(CONTACTS_LIST));
+
+    And(
+        "^I set the last contact date for minus (\\d+) days from today for DE version$",
+        (Integer days) -> {
+          webDriverHelpers.scrollToElement(LAST_CONTACT_DATE);
+          webDriverHelpers.fillAndSubmitInWebElement(
+              LAST_CONTACT_DATE, formatterDE.format(LocalDate.now().minusDays(days)));
+        });
   }
 
   private void fillFirstName(String firstName) {

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/contacts/CreateNewContactSteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/contacts/CreateNewContactSteps.java
@@ -532,6 +532,19 @@ public class CreateNewContactSteps implements En {
         () -> {
           webDriverHelpers.clickOnWebElementBySelector(DISCARD_TASK_BUTTON);
         });
+
+    And(
+        "^I fill a new Contact form with specific data for DE version with date (\\d+) days ago$",
+        (Integer daysAgo) -> {
+          contact = contactService.buildGeneratedContactDE();
+          fillFirstName(contact.getFirstName());
+          fillLastName(contact.getLastName());
+          selectSex(contact.getSex());
+          fillDateOfReport(LocalDate.now().minusDays(daysAgo), Locale.GERMAN);
+          fillDiseaseOfSourceCase(contact.getDiseaseOfSourceCase());
+          selectResponsibleRegion(contact.getResponsibleRegion());
+          selectResponsibleDistrict(contact.getResponsibleDistrict());
+        });
   }
 
   private void fillFirstName(String firstName) {

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/contacts/EditContactSteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/contacts/EditContactSteps.java
@@ -49,6 +49,7 @@ import static org.sormas.e2etests.pages.application.cases.EditCasePage.USER_INFO
 import static org.sormas.e2etests.pages.application.cases.EditCasePage.UUID_INPUT;
 import static org.sormas.e2etests.pages.application.cases.EditCasePage.VACCINATION_CARD_INFO_ICON;
 import static org.sormas.e2etests.pages.application.cases.EditCasePage.VACCINATION_CARD_INFO_POPUP_TEXT;
+import static org.sormas.e2etests.pages.application.cases.EditCasePage.VACCINATION_CARD_VACCINATION_NAME;
 import static org.sormas.e2etests.pages.application.cases.EditCasePage.VACCINATION_STATUS_FOR_THIS_DISEASE_COMBOBOX;
 import static org.sormas.e2etests.pages.application.cases.EditCasePage.VACCINATION_STATUS_INPUT;
 import static org.sormas.e2etests.pages.application.cases.EditContactsPage.CASE_OR_EVENT_INFORMATION_CONTACT_TEXT_AREA;
@@ -1240,6 +1241,33 @@ public class EditContactSteps implements En {
               "Diese Impfung ist f\u00FCr diesen Kontakt nicht relevant, weil das Datum der Impfung nach dem Datum des letzten Kontaktes oder dem Kontakt-Meldedatum liegt.",
               "Message is incorrect");
           softly.assertAll();
+        });
+
+    And(
+        "^I check that displayed vaccination name is equal to \"([^\"]*)\" on Edit contact page$",
+        (String expectedName) -> {
+          webDriverHelpers.waitUntilIdentifiedElementIsPresent(VACCINATION_CARD_VACCINATION_NAME);
+          String name = webDriverHelpers.getTextFromWebElement(VACCINATION_CARD_VACCINATION_NAME);
+          softly.assertEquals(
+              name,
+              "Impfstoffname: " + expectedName,
+              "Vaccination name is different than expected!");
+          softly.assertAll();
+        });
+
+    And(
+        "^I check that displayed vaccination name is \"([^\"]*)\" on Edit contact page$",
+        (String activationState) -> {
+          switch (activationState) {
+            case "enabled":
+              Assert.assertTrue(
+                  webDriverHelpers.isElementEnabled(VACCINATION_CARD_VACCINATION_NAME),
+                  "Vaccination name is not enabled!");
+              break;
+            case "greyed out":
+              webDriverHelpers.isElementGreyedOut(VACCINATION_CARD_VACCINATION_NAME);
+              break;
+          }
         });
   }
 

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/contacts/EditContactSteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/contacts/EditContactSteps.java
@@ -1269,6 +1269,10 @@ public class EditContactSteps implements En {
               break;
           }
         });
+
+    And(
+        "^I click on the Edit Vaccination icon on vaccination card on Edit contact page$",
+        () -> webDriverHelpers.clickOnWebElementBySelector(EDIT_VACCINATION_BUTTON));
   }
 
   private void selectContactClassification(String classification) {

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/vaccination/CreateNewVaccinationSteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/vaccination/CreateNewVaccinationSteps.java
@@ -199,7 +199,10 @@ public class CreateNewVaccinationSteps implements En {
 
     When(
         "I click NEW VACCINATION button for DE",
-        () -> webDriverHelpers.clickOnWebElementBySelector(NEW_VACCINATION_DE_BUTTON));
+        () -> {
+          webDriverHelpers.clickOnWebElementBySelector(NEW_VACCINATION_DE_BUTTON);
+          webDriverHelpers.waitUntilIdentifiedElementIsVisibleAndClickable(VACCINATION_DATE_INPUT);
+        });
 
     And(
         "^I fill new vaccination data in new Vaccination form with vaccination date (\\d+) days before the current day for DE$",
@@ -257,6 +260,14 @@ public class CreateNewVaccinationSteps implements En {
               vaccinationService.buildGeneratedVaccinationWithSpecificVaccinationDateDE(
                   vaccinationDate);
           fillVaccinationDate(vaccination.getVaccinationDate(), Locale.GERMAN);
+        });
+
+    And(
+        "^I change the report vaccination date for minus (\\d+) days from today on new Vaccination form$",
+        (Integer days) -> {
+          webDriverHelpers.scrollToElement(REPORT_DATE_INPUT);
+          webDriverHelpers.fillAndSubmitInWebElement(
+              REPORT_DATE_INPUT, formatterDE.format(LocalDate.now().minusDays(days)));
         });
   }
 

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/vaccination/CreateNewVaccinationSteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/vaccination/CreateNewVaccinationSteps.java
@@ -272,14 +272,6 @@ public class CreateNewVaccinationSteps implements En {
           webDriverHelpers.fillAndSubmitInWebElement(
               REPORT_DATE_INPUT, formatterDE.format(LocalDate.now().minusDays(day)));
         });
-
-    And(
-        "^I change the report vaccination date for minus (\\d+) days from today on new Vaccination form$",
-        (Integer days) -> {
-          webDriverHelpers.scrollToElement(REPORT_DATE_INPUT);
-          webDriverHelpers.fillAndSubmitInWebElement(
-              REPORT_DATE_INPUT, formatterDE.format(LocalDate.now().minusDays(days)));
-        });
   }
 
   private void fillVaccinationDate(LocalDate date, Locale locale) {

--- a/sormas-e2e-tests/src/test/resources/features/sanity/web/Vaccination.feature
+++ b/sormas-e2e-tests/src/test/resources/features/sanity/web/Vaccination.feature
@@ -657,10 +657,31 @@ Feature: Vaccination tests
     And I fill a new Contact form with specific data for DE version with date 16 days ago
     And I click on SAVE new contact button
     And I click NEW VACCINATION button for DE
-#    change step below
-    And I change the report vaccination date for minus 17 days from today on new Vaccination form
+    And I change the report vaccination date for minus 17 day from today
     And I fill new vaccination data in new Vaccination form for DE
     And I remove the vaccination date in displayed vaccination form
     And I click SAVE button in new Vaccination form
     And I check that displayed vaccination name is equal to "COVID-19 Impfstoff Moderna (mRNA-Impfstoff)" on Edit contact page
     And I check that displayed vaccination name is "enabled" on Edit contact page
+    And I click on the Edit Vaccination icon on vaccination card on Edit Case page
+    And I change the report vaccination date for minus 9 day from today
+    And I click SAVE button in new Vaccination form
+    And I check that displayed vaccination name is equal to "COVID-19 Impfstoff Moderna (mRNA-Impfstoff)" on Edit case page
+    And I check that displayed vaccination name is "enabled" on Edit case page
+    And I check if Vaccination Status is set to "Geimpft" on Edit Case page
+    And I click on the Edit Vaccination icon on vaccination card on Edit Case page
+    And I change the report vaccination date for minus 1 day from today
+    And I click SAVE button in new Vaccination form
+    And I check that displayed vaccination name is equal to "COVID-19 Impfstoff Moderna (mRNA-Impfstoff)" on Edit case page
+    And I check that displayed vaccination name is "greyed out" on Edit case page
+    And I set the last contact date for minus 5 days from today for DE version
+    And I click SAVE button on Edit Contact Page
+    And I check that displayed vaccination name is equal to "COVID-19 Impfstoff Moderna (mRNA-Impfstoff)" on Edit contact page
+    And I check that displayed vaccination name is "enabled" on Edit contact page
+    And I set the last contact date for minus 16 days from today for DE version
+    And I click SAVE button on Edit Contact Page
+    And I click on the Edit Vaccination icon on vaccination card on Edit Case page
+    And I change the report vaccination date for minus 1 day from today
+    And I click SAVE button in new Vaccination form
+    And I check that displayed vaccination name is equal to "COVID-19 Impfstoff Moderna (mRNA-Impfstoff)" on Edit case page
+    And I check that displayed vaccination name is "greyed out" on Edit case page

--- a/sormas-e2e-tests/src/test/resources/features/sanity/web/Vaccination.feature
+++ b/sormas-e2e-tests/src/test/resources/features/sanity/web/Vaccination.feature
@@ -663,25 +663,28 @@ Feature: Vaccination tests
     And I click SAVE button in new Vaccination form
     And I check that displayed vaccination name is equal to "COVID-19 Impfstoff Moderna (mRNA-Impfstoff)" on Edit contact page
     And I check that displayed vaccination name is "enabled" on Edit contact page
-    And I click on the Edit Vaccination icon on vaccination card on Edit Case page
+    And I click on the Edit Vaccination icon on vaccination card on Edit contact page
     And I change the report vaccination date for minus 9 day from today
     And I click SAVE button in new Vaccination form
-    And I check that displayed vaccination name is equal to "COVID-19 Impfstoff Moderna (mRNA-Impfstoff)" on Edit case page
-    And I check that displayed vaccination name is "enabled" on Edit case page
-    And I check if Vaccination Status is set to "Geimpft" on Edit Case page
-    And I click on the Edit Vaccination icon on vaccination card on Edit Case page
-    And I change the report vaccination date for minus 1 day from today
-    And I click SAVE button in new Vaccination form
-    And I check that displayed vaccination name is equal to "COVID-19 Impfstoff Moderna (mRNA-Impfstoff)" on Edit case page
-    And I check that displayed vaccination name is "greyed out" on Edit case page
-    And I set the last contact date for minus 5 days from today for DE version
-    And I click SAVE button on Edit Contact Page
     And I check that displayed vaccination name is equal to "COVID-19 Impfstoff Moderna (mRNA-Impfstoff)" on Edit contact page
     And I check that displayed vaccination name is "enabled" on Edit contact page
-    And I set the last contact date for minus 16 days from today for DE version
-    And I click SAVE button on Edit Contact Page
-    And I click on the Edit Vaccination icon on vaccination card on Edit Case page
+    And I check if Vaccination Status is set to "Geimpft" on Edit Contact page
+    And I click on the Edit Vaccination icon on vaccination card on Edit contact page
     And I change the report vaccination date for minus 1 day from today
     And I click SAVE button in new Vaccination form
-    And I check that displayed vaccination name is equal to "COVID-19 Impfstoff Moderna (mRNA-Impfstoff)" on Edit case page
-    And I check that displayed vaccination name is "greyed out" on Edit case page
+    And I check that displayed vaccination name is equal to "COVID-19 Impfstoff Moderna (mRNA-Impfstoff)" on Edit contact page
+    And I check that displayed vaccination name is "greyed out" on Edit contact page
+    And I set the last contact date for minus 17 days from today for DE version
+    And I click SAVE button on Edit Contact Page
+    And I click on the Edit Vaccination icon on vaccination card on Edit contact page
+    And I change the report vaccination date for minus 9 day from today
+    And I click SAVE button in new Vaccination form
+    And I check that displayed vaccination name is equal to "COVID-19 Impfstoff Moderna (mRNA-Impfstoff)" on Edit contact page
+    And I check that displayed vaccination name is "enabled" on Edit contact page
+    And I set the last contact date for minus 17 days from today for DE version
+    And I click SAVE button on Edit Contact Page
+    And I click on the Edit Vaccination icon on vaccination card on Edit contact page
+    And I change the report vaccination date for minus 1 day from today
+    And I click SAVE button in new Vaccination form
+    And I check that displayed vaccination name is equal to "COVID-19 Impfstoff Moderna (mRNA-Impfstoff)" on Edit contact page
+    And I check that displayed vaccination name is "greyed out" on Edit contact page

--- a/sormas-e2e-tests/src/test/resources/features/sanity/web/Vaccination.feature
+++ b/sormas-e2e-tests/src/test/resources/features/sanity/web/Vaccination.feature
@@ -611,3 +611,19 @@ Feature: Vaccination tests
     And I close import popup in Edit Contact directory
     And I click to edit 2 vaccination on Edit Contact page
     And I check that displayed vaccination form has empty vaccination date and name
+
+  @tmsLink=SORDEV-12286 @env_de
+  Scenario: Test Vaccinations without a "vaccination date" should also be marked as relevant and included in the status calculation (Contact)
+    Given I log in as a Admin User
+    When I click on the Contacts button from navbar
+    And I click on the NEW CONTACT button
+    And I fill a new Contact form with specific data for DE version with date 16 days ago
+    And I click on SAVE new contact button
+    And I click NEW VACCINATION button for DE
+#    change step below
+    And I change the report vaccination date for minus 17 days from today on new Vaccination form
+    And I fill new vaccination data in new Vaccination form for DE
+    And I remove the vaccination date in displayed vaccination form
+    And I click SAVE button in new Vaccination form
+    And I check that displayed vaccination name is equal to "COVID-19 Impfstoff Moderna (mRNA-Impfstoff)" on Edit contact page
+    And I check that displayed vaccination name is "enabled" on Edit contact page


### PR DESCRIPTION
<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #