### PR TITLE
#10279 cases are not accessible

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/share/ExternalShareInfo.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/share/ExternalShareInfo.java
@@ -66,7 +66,7 @@ public class ExternalShareInfo extends AbstractDomainObject {
 	}
 
 	@ManyToOne
-	@JoinColumn(nullable = false)
+	@JoinColumn
 	public User getSender() {
 		return sender;
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/share/ExternalShareInfoFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/share/ExternalShareInfoFacadeEjb.java
@@ -34,6 +34,7 @@ import de.symeda.sormas.api.share.ExternalShareInfoCriteria;
 import de.symeda.sormas.api.share.ExternalShareInfoDto;
 import de.symeda.sormas.api.share.ExternalShareInfoFacade;
 import de.symeda.sormas.backend.common.CriteriaBuilderHelper;
+import de.symeda.sormas.backend.user.UserFacadeEjb;
 import de.symeda.sormas.backend.user.UserService;
 import de.symeda.sormas.backend.util.DtoHelper;
 import de.symeda.sormas.backend.util.ModelConstants;
@@ -93,7 +94,7 @@ public class ExternalShareInfoFacadeEjb implements ExternalShareInfoFacade {
 
 		DtoHelper.fillDto(target, source);
 
-		target.setSender(source.getSender().toReference());
+		target.setSender(UserFacadeEjb.toReferenceDto(source.getSender()));
 		target.setStatus(source.getStatus());
 
 		return target;

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/externalsurveillanceservice/ExternalShareInfoList.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/externalsurveillanceservice/ExternalShareInfoList.java
@@ -31,6 +31,7 @@ import de.symeda.sormas.api.i18n.Strings;
 import de.symeda.sormas.api.share.ExternalShareInfoCriteria;
 import de.symeda.sormas.api.share.ExternalShareInfoDto;
 import de.symeda.sormas.api.share.ExternalShareStatus;
+import de.symeda.sormas.api.user.UserReferenceDto;
 import de.symeda.sormas.api.utils.DateHelper;
 import de.symeda.sormas.ui.utils.CssStyles;
 import de.symeda.sormas.ui.utils.PaginationList;
@@ -93,8 +94,11 @@ public class ExternalShareInfoList extends PaginationList<ExternalShareInfoDto> 
 			infoLayout.setTemplateContents(buildLayout(shareInfo.getStatus()));
 			infoLayout.setWidth(100, Unit.PERCENTAGE);
 
+			UserReferenceDto sender = shareInfo.getSender();
 			Label senderLabel = new Label(
-				shareInfo.isPseudonymized() ? I18nProperties.getCaption(Captions.inaccessibleValue) : shareInfo.getSender().getShortCaption());
+				shareInfo.isPseudonymized()
+					? I18nProperties.getCaption(Captions.inaccessibleValue)
+					: sender != null ? sender.getShortCaption() : I18nProperties.getCaption(Captions.system));
 			senderLabel.addStyleName(CssStyles.LABEL_BOLD);
 			if (shareInfo.isPseudonymized()) {
 				senderLabel.addStyleName(CssStyles.INACCESSIBLE_LABEL);


### PR DESCRIPTION
<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #10279

The problem was that automatic archiving triggers a share with archived flag to survnet that creates an external share info with SHARED status.
As it's called as SYSTEM there is no user to set the sender user of the external share info. I don't see why the automatic archivation did not fail when creating the share info without user.

Maybe we can create a ticket for better handling the shares did by the system