### PR TITLE
#10346 Hide columns if missing right

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/caze/CaseIndexDetailedDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/caze/CaseIndexDetailedDto.java
@@ -113,6 +113,36 @@ public class CaseIndexDetailedDto extends CaseIndexDto {
 		this.responsibleCommunity = responsibleCommunity;
 	}
 
+	public CaseIndexDetailedDto(
+			long id, String uuid, String epidNumber, String externalID, String externalToken, String internalToken,
+			String personUuid, String personFirstName, String personLastName,
+			Disease disease, DiseaseVariant diseaseVariant, String diseaseDetails,
+			CaseClassification caseClassification, InvestigationStatus investigationStatus, PresentCondition presentCondition,
+			Date reportDate, Date creationDate,
+			String regionUuid, String districtUuid,
+			String healthFacilityUuid, String healthFacilityName, String healthFacilityDetails,
+			String pointOfEntryUuid, String pointOfEntryName, String pointOfEntryDetails, String surveillanceOfficerUuid,
+			CaseOutcome outcome, Integer age, ApproximateAgeType ageType, Integer birthdateDD, Integer birthdateMM, Integer birthdateYYYY,
+			Sex sex, Date quarantineTo, Float completeness, FollowUpStatus followUpStatus, Date followUpUntil,
+			SymptomJournalStatus symptomJournalStatus, VaccinationStatus vaccinationStatus, Date changeDate, Long facilityId,
+			String responsibleRegionUuid, String responsibleDistrictUuid, String responsibleDistrictName, boolean isInJurisdiction,
+			//detailed fields
+			YesNoUnknown reInfection, String city, String street, String houseNumber, String additionalInformation,
+			String postalCode, String phone, String reportingUserUuid, String reportingUserFirstName, String reportingUserLastName,
+			Date symptomOnsetDate, String responsibleRegion, String responsibleCommunity, int visitCount,
+			Date latestSampleDateTime, long sampleCount, Date latestChangedDate) {
+		this(id, uuid, epidNumber, externalID, externalToken, internalToken, personUuid, personFirstName, personLastName,
+				disease, diseaseVariant, diseaseDetails, caseClassification, investigationStatus, presentCondition,
+				reportDate, creationDate, regionUuid, districtUuid, healthFacilityUuid, healthFacilityName,
+				healthFacilityDetails, pointOfEntryUuid, pointOfEntryName, pointOfEntryDetails, surveillanceOfficerUuid,
+				outcome, age, ageType, birthdateDD, birthdateMM, birthdateYYYY, sex, quarantineTo, completeness,
+				followUpStatus, followUpUntil, symptomJournalStatus, vaccinationStatus, changeDate, facilityId,
+				responsibleRegionUuid, responsibleDistrictUuid, responsibleDistrictName, isInJurisdiction, reInfection,
+				city, street, houseNumber, additionalInformation, postalCode, phone, reportingUserUuid,
+				reportingUserFirstName, reportingUserLastName, symptomOnsetDate, responsibleRegion, responsibleCommunity,
+				visitCount, 0, latestSampleDateTime, sampleCount, latestChangedDate);
+	}
+
 	public YesNoUnknown getReInfection() {
 		return reInfection;
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseListCriteriaBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseListCriteriaBuilder.java
@@ -107,7 +107,7 @@ public class CaseListCriteriaBuilder {
 
 		if (detailed) {
 			// Events count subquery
-			if (!currentUserService.hasUserRight(UserRight.EVENT_VIEW)) {
+			if (currentUserService.hasUserRight(UserRight.EVENT_VIEW)) {
 				Subquery<Long> eventCountSq = cq.subquery(Long.class);
 				Root<EventParticipant> eventCountRoot = eventCountSq.from(EventParticipant.class);
 				Join<EventParticipant, Event> event = eventCountRoot.join(EventParticipant.EVENT, JoinType.INNER);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseListCriteriaBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseListCriteriaBuilder.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 import javax.ejb.EJB;
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
+import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.criteria.CriteriaBuilder;
@@ -27,6 +28,8 @@ import javax.persistence.criteria.Root;
 import javax.persistence.criteria.Selection;
 import javax.persistence.criteria.Subquery;
 
+import de.symeda.sormas.api.user.UserRight;
+import de.symeda.sormas.backend.user.CurrentUserService;
 import org.apache.commons.collections4.CollectionUtils;
 
 import de.symeda.sormas.api.caze.CaseCriteria;
@@ -61,6 +64,9 @@ public class CaseListCriteriaBuilder {
 	private EntityManager em;
 	@EJB
 	private CaseService caseService;
+
+	@Inject
+	private CurrentUserService currentUserService;
 
 	public CriteriaQuery<CaseIndexDto> buildIndexCriteria(CaseCriteria caseCriteria, List<SortProperty> sortProperties) {
 		return buildIndexCriteria(CaseIndexDto.class, this::getCaseIndexSelections, caseCriteria, this::getIndexOrders, sortProperties, false);
@@ -101,17 +107,19 @@ public class CaseListCriteriaBuilder {
 
 		if (detailed) {
 			// Events count subquery
-			Subquery<Long> eventCountSq = cq.subquery(Long.class);
-			Root<EventParticipant> eventCountRoot = eventCountSq.from(EventParticipant.class);
-			Join<EventParticipant, Event> event = eventCountRoot.join(EventParticipant.EVENT, JoinType.INNER);
-			Join<EventParticipant, Case> resultingCase = eventCountRoot.join(EventParticipant.RESULTING_CASE, JoinType.INNER);
-			eventCountSq.where(
-				cb.and(
-					cb.equal(resultingCase.get(Case.ID), caze.get(Case.ID)),
-					cb.isFalse(event.get(Event.DELETED)),
-					cb.isFalse(eventCountRoot.get(EventParticipant.DELETED))));
-			eventCountSq.select(cb.countDistinct(event.get(Event.ID)));
-			selectionList.add(eventCountSq);
+			if (!currentUserService.hasUserRight(UserRight.EVENT_VIEW)) {
+				Subquery<Long> eventCountSq = cq.subquery(Long.class);
+				Root<EventParticipant> eventCountRoot = eventCountSq.from(EventParticipant.class);
+				Join<EventParticipant, Event> event = eventCountRoot.join(EventParticipant.EVENT, JoinType.INNER);
+				Join<EventParticipant, Case> resultingCase = eventCountRoot.join(EventParticipant.RESULTING_CASE, JoinType.INNER);
+				eventCountSq.where(
+						cb.and(
+								cb.equal(resultingCase.get(Case.ID), caze.get(Case.ID)),
+								cb.isFalse(event.get(Event.DELETED)),
+								cb.isFalse(eventCountRoot.get(EventParticipant.DELETED))));
+				eventCountSq.select(cb.countDistinct(event.get(Event.ID)));
+				selectionList.add(eventCountSq);
+			}
 
 			// Latest sampleDateTime subquery
 			Subquery<Timestamp> latestSampleDateTimeSq = cq.subquery(Timestamp.class);

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/CaseGridDetailed.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/CaseGridDetailed.java
@@ -61,7 +61,7 @@ public class CaseGridDetailed extends AbstractCaseGrid<CaseIndexDetailedDto> {
 
 	@Override
 	public Stream<String> getEventColumns() {
-		if (UserProvider.getCurrent().hasUserRight(UserRight.EVENT_VIEW)) {
+		if (!UserProvider.getCurrent().hasUserRight(UserRight.EVENT_VIEW)) {
 			return Stream.empty();
 		}
 

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/CaseGridDetailed.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/CaseGridDetailed.java
@@ -16,8 +16,10 @@ import de.symeda.sormas.api.caze.CaseIndexDto;
 import de.symeda.sormas.api.i18n.I18nProperties;
 import de.symeda.sormas.api.person.PersonHelper;
 import de.symeda.sormas.api.symptoms.SymptomsDto;
+import de.symeda.sormas.api.user.UserRight;
 import de.symeda.sormas.api.utils.SortProperty;
 import de.symeda.sormas.ui.ControllerProvider;
+import de.symeda.sormas.ui.UserProvider;
 import de.symeda.sormas.ui.utils.DateFormatHelper;
 import de.symeda.sormas.ui.utils.ShowDetailsListener;
 import de.symeda.sormas.ui.utils.UuidRenderer;
@@ -59,11 +61,15 @@ public class CaseGridDetailed extends AbstractCaseGrid<CaseIndexDetailedDto> {
 
 	@Override
 	public Stream<String> getEventColumns() {
+		if (UserProvider.getCurrent().hasUserRight(UserRight.EVENT_VIEW)) {
+			return Stream.empty();
+		}
+
 		return Stream.of(
-			CaseIndexDetailedDto.EVENT_COUNT,
-			CaseIndexDetailedDto.LATEST_EVENT_ID,
-			CaseIndexDetailedDto.LATEST_EVENT_STATUS,
-			CaseIndexDetailedDto.LATEST_EVENT_TITLE);
+				CaseIndexDetailedDto.EVENT_COUNT,
+				CaseIndexDetailedDto.LATEST_EVENT_ID,
+				CaseIndexDetailedDto.LATEST_EVENT_STATUS,
+				CaseIndexDetailedDto.LATEST_EVENT_TITLE);
 	}
 
 	@Override
@@ -119,16 +125,18 @@ public class CaseGridDetailed extends AbstractCaseGrid<CaseIndexDetailedDto> {
 		getColumn(CaseIndexDetailedDto.HOUSE_NUMBER).setWidth(50);
 		getColumn(CaseIndexDetailedDto.ADDITIONAL_INFORMATION).setWidth(200);
 		getColumn(CaseIndexDetailedDto.PHONE).setWidth(100);
-		getColumn(CaseIndexDetailedDto.EVENT_COUNT).setWidth(80).setSortable(false);
-		getColumn(CaseIndexDetailedDto.LATEST_EVENT_ID).setWidth(80).setSortable(false);
-		getColumn(CaseIndexDetailedDto.LATEST_EVENT_STATUS).setWidth(80).setSortable(false);
-		getColumn(CaseIndexDetailedDto.LATEST_EVENT_TITLE).setWidth(150).setSortable(false);
 
-		((Column<CaseIndexDetailedDto, String>) getColumn(CaseIndexDetailedDto.LATEST_EVENT_ID)).setRenderer(new UuidRenderer());
-		addItemClickListener(
-			new ShowDetailsListener<>(
-				CaseIndexDetailedDto.LATEST_EVENT_ID,
-				c -> ControllerProvider.getEventController().navigateToData(c.getLatestEventId())));
+		if (this.getEventColumns().findAny().isPresent()) {
+			getColumn(CaseIndexDetailedDto.EVENT_COUNT).setWidth(80).setSortable(false);
+			getColumn(CaseIndexDetailedDto.LATEST_EVENT_ID).setWidth(80).setSortable(false);
+			getColumn(CaseIndexDetailedDto.LATEST_EVENT_STATUS).setWidth(80).setSortable(false);
+			getColumn(CaseIndexDetailedDto.LATEST_EVENT_TITLE).setWidth(150).setSortable(false);
+			((Column<CaseIndexDetailedDto, String>) getColumn(CaseIndexDetailedDto.LATEST_EVENT_ID)).setRenderer(new UuidRenderer());
+			addItemClickListener(
+					new ShowDetailsListener<>(
+							CaseIndexDetailedDto.LATEST_EVENT_ID,
+							c -> ControllerProvider.getEventController().navigateToData(c.getLatestEventId())));
+		}
 
 		((Column<CaseIndexDetailedDto, AgeAndBirthDateDto>) getColumn(CaseIndexDetailedDto.AGE_AND_BIRTH_DATE)).setRenderer(
 			value -> value == null


### PR DESCRIPTION
 Hide Event columns from Case Detailed View if the user doesn't have rights
 - if the user is missing "EVENT_VIEW" rights than hide the event related collumns
 - do not load Event fields for CaseIndexDetailedDto