### PR TITLE
[#9091] explicitly remove client role from keycloak user

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/StartupShutdownService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/StartupShutdownService.java
@@ -20,7 +20,6 @@ import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.sql.Timestamp;
-import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -631,26 +630,9 @@ public class StartupShutdownService {
 
 		List<User> users = userService.getAllActive();
 		for (User user : users) {
-			syncUser(user);
+			userService.syncUserAsync(user);
 		}
 		logger.info("User synchronization finalized");
-	}
-
-	/**
-	 * Triggers the user sync asynchronously to not block the deployment step
-	 */
-	private void syncUser(User user) {
-		String shortUuid = DataHelper.getShortUuid(user.getUuid());
-		logger.debug("Synchronizing user {}", shortUuid);
-		try {
-
-			UserUpdateEvent event = new UserUpdateEvent(user);
-			event.setExceptionCallback(exceptionMessage -> logger.error("Could not synchronize user {} due to {}", shortUuid, exceptionMessage));
-
-			this.userUpdateEvent.fireAsync(event);
-		} catch (Throwable e) {
-			logger.error(MessageFormat.format("Unexpected exception when synchronizing user {0}", shortUuid), e);
-		}
 	}
 
 	/**

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/user/KeycloakService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/user/KeycloakService.java
@@ -325,6 +325,14 @@ public class KeycloakService {
 		UsersResource usersResource = keycloak.realm(REALM_NAME).users();
 		UserResource userResource = usersResource.get(userResourceId);
 
+		assignSormasStatsRole(keycloak, sormasUser, userResource);
+	}
+
+	private void assignSormasStatsRole(Keycloak keycloak, User sormasUser, UserResource userResource) {
+		if (StringUtils.isBlank(configFacade.getSormasStatsUrl())) {
+			return;
+		}
+
 		Optional<ClientRepresentation> clientRepresentation =
 			keycloak.realm(REALM_NAME).clients().findAll().stream().filter(client -> client.getClientId().equals(CLIENT_ID_SORMAS_STATS)).findFirst();
 		if (!clientRepresentation.isPresent()) {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/user/UserRoleFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/user/UserRoleFacadeEjb.java
@@ -143,6 +143,9 @@ public class UserRoleFacadeEjb implements UserRoleFacade {
 		UserRole entity = fromDto(dto, true);
 
 		userRoleService.ensurePersisted(entity);
+
+		userService.getAllWithRole(entity).forEach(user -> userService.syncUserAsync(user));
+
 		return toDto(entity);
 	}
 
@@ -167,7 +170,9 @@ public class UserRoleFacadeEjb implements UserRoleFacade {
 		}
 
 		UserRoleDto existingUserRole = getByUuid(source.getUuid());
-		if (existingUserRole != null && source.getJurisdictionLevel() != existingUserRole.getJurisdictionLevel() && userService.countWithRole(source.toReference()) > 0) {
+		if (existingUserRole != null
+			&& source.getJurisdictionLevel() != existingUserRole.getJurisdictionLevel()
+			&& userService.countWithRole(source.toReference()) > 0) {
 			throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.jurisdictionChangeUserAssignment));
 		}
 


### PR DESCRIPTION
Fixes #9091 

@MartinWahnschaffe Just like we cannot add a client role to a normal user representation in an update, we cannot remove it.