### PR TITLE
#10414 limit persons by config and user rights

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/person/PersonAssociation.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/person/PersonAssociation.java
@@ -4,6 +4,11 @@ import de.symeda.sormas.api.i18n.I18nProperties;
 
 public enum PersonAssociation {
 
+	/**
+	 * Persons that are associated to <strong>all permitted</strong> association types.
+	 * 
+	 * @see #getSingleAssociations()
+	 */
 	ALL,
 	CASE,
 	CONTACT,

--- a/sormas-api/src/main/java/de/symeda/sormas/api/person/PersonFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/person/PersonFacade.java
@@ -35,6 +35,8 @@ import de.symeda.sormas.api.utils.SortProperty;
 @Remote
 public interface PersonFacade extends BaseFacade<PersonDto, PersonIndexDto, PersonReferenceDto, PersonCriteria> {
 
+	List<PersonAssociation> getPermittedAssociations();
+
 	List<PersonDto> getDeathsBetween(Date fromDate, Date toDate, DistrictReferenceDto districtRef, Disease disease);
 
 	JournalPersonDto getPersonForJournal(String uuid);

--- a/sormas-api/src/main/java/de/symeda/sormas/api/person/PersonFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/person/PersonFacade.java
@@ -16,6 +16,7 @@ package de.symeda.sormas.api.person;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 
 import javax.ejb.Remote;
 import javax.validation.Valid;
@@ -35,7 +36,7 @@ import de.symeda.sormas.api.utils.SortProperty;
 @Remote
 public interface PersonFacade extends BaseFacade<PersonDto, PersonIndexDto, PersonReferenceDto, PersonCriteria> {
 
-	List<PersonAssociation> getPermittedAssociations();
+	Set<PersonAssociation> getPermittedAssociations();
 
 	List<PersonDto> getDeathsBetween(Date fromDate, Date toDate, DistrictReferenceDto districtRef, Disease disease);
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/immunization/DirectoryImmunizationService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/immunization/DirectoryImmunizationService.java
@@ -44,6 +44,7 @@ import de.symeda.sormas.backend.person.Person;
 import de.symeda.sormas.backend.person.PersonJoins;
 import de.symeda.sormas.backend.person.PersonJurisdictionPredicateValidator;
 import de.symeda.sormas.backend.person.PersonQueryContext;
+import de.symeda.sormas.backend.person.PersonService;
 import de.symeda.sormas.backend.user.User;
 import de.symeda.sormas.backend.user.UserService;
 import de.symeda.sormas.backend.util.JurisdictionHelper;
@@ -55,6 +56,8 @@ import de.symeda.sormas.backend.vaccination.LastVaccineType;
 @LocalBean
 public class DirectoryImmunizationService extends AbstractDeletableAdoService<DirectoryImmunization> {
 
+	@EJB
+	private PersonService personService;
 	@EJB
 	private UserService userService;
 	@EJB
@@ -329,6 +332,7 @@ public class DirectoryImmunizationService extends AbstractDeletableAdoService<Di
 	}
 
 	private Predicate isInJurisdictionOrOwned(DirectoryImmunizationQueryContext qc) {
+
 		final User currentUser = userService.getCurrentUser();
 		CriteriaBuilder cb = qc.getCriteriaBuilder();
 		Predicate filter;
@@ -338,7 +342,8 @@ public class DirectoryImmunizationService extends AbstractDeletableAdoService<Di
 			filter = CriteriaBuilderHelper.or(
 				cb,
 				cb.equal(qc.getRoot().get(Immunization.REPORTING_USER), currentUser),
-				PersonJurisdictionPredicateValidator.of(qc.getQuery(), cb, new PersonJoins(qc.getJoins().getPerson()), currentUser, false)
+				PersonJurisdictionPredicateValidator
+					.of(qc.getQuery(), cb, new PersonJoins(qc.getJoins().getPerson()), currentUser, personService.getPermittedAssociations())
 					.inJurisdictionOrOwned());
 		}
 		return filter;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/immunization/ImmunizationService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/immunization/ImmunizationService.java
@@ -59,6 +59,7 @@ import de.symeda.sormas.backend.immunization.transformers.ImmunizationListEntryD
 import de.symeda.sormas.backend.person.Person;
 import de.symeda.sormas.backend.person.PersonJoins;
 import de.symeda.sormas.backend.person.PersonJurisdictionPredicateValidator;
+import de.symeda.sormas.backend.person.PersonService;
 import de.symeda.sormas.backend.sormastosormas.share.outgoing.SormasToSormasShareInfo;
 import de.symeda.sormas.backend.sormastosormas.share.outgoing.SormasToSormasShareInfoFacadeEjb.SormasToSormasShareInfoFacadeEjbLocal;
 import de.symeda.sormas.backend.sormastosormas.share.outgoing.SormasToSormasShareInfoService;
@@ -75,6 +76,8 @@ import de.symeda.sormas.backend.vaccination.Vaccination;
 @LocalBean
 public class ImmunizationService extends AbstractCoreAdoService<Immunization> {
 
+	@EJB
+	private PersonService personService;
 	@EJB
 	private UserService userService;
 	@EJB
@@ -159,7 +162,8 @@ public class ImmunizationService extends AbstractCoreAdoService<Immunization> {
 			filter = CriteriaBuilderHelper.or(
 				cb,
 				cb.equal(qc.getRoot().get(Immunization.REPORTING_USER), currentUser),
-				PersonJurisdictionPredicateValidator.of(qc.getQuery(), cb, new PersonJoins(qc.getJoins().getPerson()), currentUser, false)
+				PersonJurisdictionPredicateValidator
+					.of(qc.getQuery(), cb, new PersonJoins(qc.getJoins().getPerson()), currentUser, personService.getPermittedAssociations())
 					.inJurisdictionOrOwned());
 		}
 		return filter;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonFacadeEjb.java
@@ -244,6 +244,11 @@ public class PersonFacadeEjb extends AbstractBaseEjb<Person, PersonDto, PersonIn
 	}
 
 	@Override
+	public List<PersonAssociation> getPermittedAssociations() {
+		return service.getPermittedAssociations();
+	}
+
+	@Override
 	public List<SimilarPersonDto> getSimilarPersonDtos(PersonSimilarityCriteria criteria) {
 
 		return service.getSimilarPersonDtos(criteria, null);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonFacadeEjb.java
@@ -81,7 +81,6 @@ import de.symeda.sormas.api.event.EventParticipantCriteria;
 import de.symeda.sormas.api.externaldata.ExternalDataDto;
 import de.symeda.sormas.api.externaldata.ExternalDataUpdateException;
 import de.symeda.sormas.api.feature.FeatureType;
-import de.symeda.sormas.api.feature.FeatureTypeProperty;
 import de.symeda.sormas.api.i18n.Captions;
 import de.symeda.sormas.api.i18n.I18nProperties;
 import de.symeda.sormas.api.i18n.Strings;
@@ -1020,10 +1019,8 @@ public class PersonFacadeEjb extends AbstractBaseEjb<Person, PersonDto, PersonIn
 		if (nullSafeCriteria.getPersonAssociation() == PersonAssociation.ALL) {
 			// Fetch Person.id per association and find the distinct count.
 			Set<Long> distinctPersonIds = new HashSet<>();
-			boolean immunizationModuleReduced =
-				featureConfigurationFacade.isPropertyValueTrue(FeatureType.IMMUNIZATION_MANAGEMENT, FeatureTypeProperty.REDUCED);
 			Arrays.stream(PersonAssociation.getSingleAssociations())
-				.filter(e -> !(immunizationModuleReduced && e == PersonAssociation.IMMUNIZATION))
+				.filter(e -> service.isPermittedAssociation(e))
 				.map(e -> getPersonIds(SerializationUtils.clone(nullSafeCriteria).personAssociation(e)))
 				.forEach(distinctPersonIds::addAll);
 			count = distinctPersonIds.size();

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonFacadeEjb.java
@@ -244,7 +244,7 @@ public class PersonFacadeEjb extends AbstractBaseEjb<Person, PersonDto, PersonIn
 	}
 
 	@Override
-	public List<PersonAssociation> getPermittedAssociations() {
+	public Set<PersonAssociation> getPermittedAssociations() {
 		return service.getPermittedAssociations();
 	}
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonJurisdictionPredicateValidator.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonJurisdictionPredicateValidator.java
@@ -86,10 +86,6 @@ public class PersonJurisdictionPredicateValidator extends PredicateJurisdictionV
 			}
 		}
 
-		if (associatedJurisdictionValidators.isEmpty()) {
-			throw new IllegalArgumentException("No filter compiled for persons by associations: " + permittedAssociations);
-		}
-
 		return new PersonJurisdictionPredicateValidator(cb, joins, user, associatedJurisdictionValidators);
 	}
 
@@ -100,7 +96,9 @@ public class PersonJurisdictionPredicateValidator extends PredicateJurisdictionV
 
 	@Override
 	protected Predicate isInJurisdiction() {
-		return isInJurisdictionByJurisdictionLevel(user.getJurisdictionLevel());
+
+		// Fallback if no associatedJurisdictionValidator was linked: No persons can to be identified by permitted explicit associations
+		return cb.disjunction();
 	}
 
 	@Override
@@ -110,7 +108,7 @@ public class PersonJurisdictionPredicateValidator extends PredicateJurisdictionV
 
 	@Override
 	protected Predicate whenNationalLevel() {
-		return cb.conjunction();
+		return cb.disjunction();
 	}
 
 	@Override

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonJurisdictionPredicateValidator.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonJurisdictionPredicateValidator.java
@@ -17,6 +17,7 @@ package de.symeda.sormas.backend.person;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
@@ -52,7 +53,7 @@ public class PersonJurisdictionPredicateValidator extends PredicateJurisdictionV
 		CriteriaBuilder cb,
 		PersonJoins joins,
 		User user,
-		List<PersonAssociation> permittedAssociations) {
+		Set<PersonAssociation> permittedAssociations) {
 
 		final List<PredicateJurisdictionValidator> associatedJurisdictionValidators = new ArrayList<>();
 		for (PersonAssociation personAssociation : permittedAssociations) {
@@ -78,7 +79,7 @@ public class PersonJurisdictionPredicateValidator extends PredicateJurisdictionV
 					.add(TravelEntryJurisdictionPredicateValidator.of(new TravelEntryQueryContext(cb, cq, joins.getTravelEntryJoins()), user));
 				break;
 			case ALL:
-				// NOOP: Persons need to be identified by explicit associations
+				// NOOP: Persons need to be identified by permitted explicit associations
 				break;
 			default:
 				throw new IllegalArgumentException(personAssociation.toString());

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonService.java
@@ -303,7 +303,8 @@ public class PersonService extends AdoServiceWithUserFilter<Person> implements J
 		}
 
 		if (userFilter == null) {
-			throw new IllegalArgumentException("No filter compiled for persons by association " + personAssociation.name());
+			logger.debug("No userFilter compiled for persons by association {}, fallback to empty collection", personAssociation.name());
+			return queryContext.getCriteriaBuilder().disjunction();
 		}
 
 		return userFilter;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonService.java
@@ -883,18 +883,6 @@ public class PersonService extends AdoServiceWithUserFilter<Person> implements J
 		return changeDateFilterBuilder.add(persons).add(address).build();
 	}
 
-	private Predicate createChangeDateFilter(PersonQueryContext personQueryContext, Timestamp date, String lastSynchronizedUuid) {
-		final From<?, Person> persons = personQueryContext.getRoot();
-		final CriteriaBuilder cb = personQueryContext.getCriteriaBuilder();
-		final PersonJoins joins = personQueryContext.getJoins();
-		final Join<Person, Location> address = joins.getAddress();
-
-		ChangeDateFilterBuilder changeDateFilterBuilder = lastSynchronizedUuid == null
-			? new ChangeDateFilterBuilder(cb, date)
-			: new ChangeDateFilterBuilder(cb, date, persons, lastSynchronizedUuid);
-		return changeDateFilterBuilder.add(persons).add(address).build();
-	}
-
 	@TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
 	public long updateGeoLocation(List<String> personUuids, boolean overwriteExistingCoordinates) {
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonService.java
@@ -152,9 +152,9 @@ public class PersonService extends AdoServiceWithUserFilter<Person> implements J
 		return new Person();
 	}
 
-	public List<PersonAssociation> getPermittedAssociations() {
+	public Set<PersonAssociation> getPermittedAssociations() {
 
-		return Arrays.stream(PersonAssociation.values()).filter(e -> isPermittedAssociation(e)).collect(Collectors.toList());
+		return new LinkedHashSet<>(Arrays.stream(PersonAssociation.values()).filter(e -> isPermittedAssociation(e)).collect(Collectors.toList()));
 	}
 
 	public boolean isPermittedAssociation(@NotNull PersonAssociation association) {
@@ -235,7 +235,7 @@ public class PersonService extends AdoServiceWithUserFilter<Person> implements J
 				}
 				break;
 			case ALL:
-				// NOOP: check the explicit associations
+				// NOOP: Persons need to be identified by permitted explicit associations
 				break;
 			default:
 				throw new IllegalArgumentException(personAssociation.toString());
@@ -491,7 +491,7 @@ public class PersonService extends AdoServiceWithUserFilter<Person> implements J
 				}
 				break;
 			case ALL:
-				// NOOP: check the explicit associations
+				// NOOP: Persons need to be identified by permitted explicit associations
 				break;
 			default:
 				throw new IllegalArgumentException(personAssociation.toString());
@@ -635,7 +635,7 @@ public class PersonService extends AdoServiceWithUserFilter<Person> implements J
 		CriteriaQuery<?> personQuery = queryContext.getQuery();
 		PersonJoins joins = queryContext.getJoins();
 
-		List<PersonAssociation> permittedAssociations = getPermittedAssociations();
+		Set<PersonAssociation> permittedAssociations = getPermittedAssociations();
 		List<Predicate> associationPredicates = new ArrayList<>();
 		for (PersonAssociation personAssociation : permittedAssociations) {
 			switch (personAssociation) {
@@ -691,7 +691,7 @@ public class PersonService extends AdoServiceWithUserFilter<Person> implements J
 					.add(and(cb, personTravelEntryJoin.get(TravelEntry.ID).isNotNull(), travelEntryUserFilter, activeTravelEntriesFilter));
 				break;
 			case ALL:
-				// NOOP: check the explicit associations
+				// NOOP: Persons need to be identified by permitted explicit associations
 				break;
 			default:
 				throw new IllegalArgumentException(personAssociation.toString());

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/person/PersonFacadeEjbTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/person/PersonFacadeEjbTest.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -714,6 +713,7 @@ public class PersonFacadeEjbTest extends AbstractBeanTest {
 			.createTravelEntry(person3.toReference(), nationalUser.toReference(), Disease.CORONAVIRUS, rdcf.region, rdcf.district, rdcf.pointOfEntry);
 
 		// 3a. Found by TravelEntry
+		MockProducer.mockProperty(ConfigFacadeEjb.COUNTRY_LOCALE, CountryHelper.COUNTRY_CODE_GERMANY);
 		assertThat(getPersonFacade().getAllAfter(t1), contains(person1, person2, person3));
 		assertThat(getPersonFacade().getAllAfter(t1, batchSize, EntityDto.NO_LAST_SYNCED_UUID), contains(person1, person2, person3));
 		assertThat(getPersonFacade().getAllAfter(t3, batchSize, EntityDto.NO_LAST_SYNCED_UUID), contains(person3));

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/person/PersonFacadeEjbTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/person/PersonFacadeEjbTest.java
@@ -22,9 +22,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
+import de.symeda.sormas.api.CountryHelper;
 import de.symeda.sormas.api.Disease;
 import de.symeda.sormas.api.EntityDto;
 import de.symeda.sormas.api.caze.CaseClassification;
@@ -73,6 +75,7 @@ import de.symeda.sormas.backend.AbstractBeanTest;
 import de.symeda.sormas.backend.MockProducer;
 import de.symeda.sormas.backend.TestDataCreator;
 import de.symeda.sormas.backend.TestDataCreator.RDCF;
+import de.symeda.sormas.backend.common.ConfigFacadeEjb;
 
 public class PersonFacadeEjbTest extends AbstractBeanTest {
 
@@ -121,6 +124,9 @@ public class PersonFacadeEjbTest extends AbstractBeanTest {
 			"Sup",
 			creator.getUserRoleReference(DefaultUserRole.SURVEILLANCE_SUPERVISOR));
 		loginWith(user);
+
+		// TravelEntry only active for Germany
+		MockProducer.mockProperty(ConfigFacadeEjb.COUNTRY_LOCALE, CountryHelper.COUNTRY_CODE_GERMANY);
 
 		// 1a. Test for all available PersonAssociations
 		for (PersonAssociation pa : PersonAssociation.values()) {
@@ -1029,6 +1035,7 @@ public class PersonFacadeEjbTest extends AbstractBeanTest {
 
 	@Test
 	public void testUserWithLimitedDiseaseSeeOnlyLimitedTravelEntry() {
+
 		PersonCriteria criteria = new PersonCriteria();
 		criteria.setPersonAssociation(PersonAssociation.TRAVEL_ENTRY);
 
@@ -1051,6 +1058,8 @@ public class PersonFacadeEjbTest extends AbstractBeanTest {
 			rdcf.region,
 			rdcf.district,
 			rdcf.pointOfEntry);
+
+		MockProducer.mockProperty(ConfigFacadeEjb.COUNTRY_LOCALE, CountryHelper.COUNTRY_CODE_GERMANY);
 
 		//National User with no restrictions can see all the travel entries
 		List<PersonIndexDto> personIndexDtos = getPersonFacade().getIndexList(criteria, 0, 100, null);

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/person/PersonFacadeEjbUserFilterTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/person/PersonFacadeEjbUserFilterTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import de.symeda.sormas.api.CountryHelper;
 import de.symeda.sormas.api.Disease;
 import de.symeda.sormas.api.caze.CaseClassification;
 import de.symeda.sormas.api.caze.CaseDataDto;
@@ -36,7 +37,9 @@ import de.symeda.sormas.api.travelentry.TravelEntryDto;
 import de.symeda.sormas.api.user.DefaultUserRole;
 import de.symeda.sormas.api.user.UserDto;
 import de.symeda.sormas.backend.AbstractBeanTest;
+import de.symeda.sormas.backend.MockProducer;
 import de.symeda.sormas.backend.TestDataCreator;
+import de.symeda.sormas.backend.common.ConfigFacadeEjb;
 
 public class PersonFacadeEjbUserFilterTest extends AbstractBeanTest {
 
@@ -128,6 +131,7 @@ public class PersonFacadeEjbUserFilterTest extends AbstractBeanTest {
 
 		PersonCriteria criteria = new PersonCriteria();
 		criteria.setPersonAssociation(PersonAssociation.TRAVEL_ENTRY);
+		MockProducer.mockProperty(ConfigFacadeEjb.COUNTRY_LOCALE, CountryHelper.COUNTRY_CODE_GERMANY);
 		List<PersonIndexDto> travelEntryPersonsFornationalUser = getPersonFacade().getIndexList(criteria, null, null, null);
 		assertEquals(1, travelEntryPersonsFornationalUser.size());
 		assertEquals(person1.getUuid(), travelEntryPersonsFornationalUser.get(0).getUuid());

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/person/PersonServiceTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/person/PersonServiceTest.java
@@ -1,0 +1,47 @@
+package de.symeda.sormas.backend.person;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import de.symeda.sormas.api.CountryHelper;
+import de.symeda.sormas.api.person.PersonAssociation;
+import de.symeda.sormas.backend.AbstractBeanTest;
+import de.symeda.sormas.backend.MockProducer;
+import de.symeda.sormas.backend.common.ConfigFacadeEjb;
+
+public class PersonServiceTest extends AbstractBeanTest {
+
+	@Test
+	public void testIsPermittedAssociation() {
+
+		assertTrue(getPersonService().isPermittedAssociation(PersonAssociation.ALL));
+		assertTrue(getPersonService().isPermittedAssociation(PersonAssociation.CASE));
+		assertTrue(getPersonService().isPermittedAssociation(PersonAssociation.CONTACT));
+		assertTrue(getPersonService().isPermittedAssociation(PersonAssociation.EVENT_PARTICIPANT));
+		assertTrue(getPersonService().isPermittedAssociation(PersonAssociation.IMMUNIZATION));
+		assertThat(
+			getPersonService().getPermittedAssociations(),
+			contains(
+				PersonAssociation.ALL,
+				PersonAssociation.CASE,
+				PersonAssociation.CONTACT,
+				PersonAssociation.EVENT_PARTICIPANT,
+				PersonAssociation.IMMUNIZATION));
+
+		// TravelEntry only active for Germany
+		MockProducer.mockProperty(ConfigFacadeEjb.COUNTRY_LOCALE, CountryHelper.COUNTRY_CODE_GERMANY);
+		assertTrue(getPersonService().isPermittedAssociation(PersonAssociation.TRAVEL_ENTRY));
+		assertThat(
+			getPersonService().getPermittedAssociations(),
+			contains(
+				PersonAssociation.ALL,
+				PersonAssociation.CASE,
+				PersonAssociation.CONTACT,
+				PersonAssociation.EVENT_PARTICIPANT,
+				PersonAssociation.IMMUNIZATION,
+				PersonAssociation.TRAVEL_ENTRY));
+	}
+}


### PR DESCRIPTION
<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #10414

Progress:
- [x] Backend logic to calculate which `PersonAssociation`s are allowed.
- [x] `PersonService.createUserFilter`, `PersonFacadeEjb.count` and `PersonService.inJurisdictionOrOwned` changed.
- [x] `PersonService.getAllAfter` changed.
- [x] `PersonService.getAllUuids` changed.
- [x] `PersonService.getSimilarPersonDtos` changed.
- [x] Replaced redundant logic in `PersonsView` by backend logic.

Challenges to solve:
- [x] 1. Two `ExternalVisitTest` cases fail now because `PersonService.inJurisdictionOrOwned` cannot find any allowed association to join.