### PR TITLE
National User can no longer edit multiple sections from cases #10547

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/utils/fieldaccess/FieldAccessCheckers.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/utils/fieldaccess/FieldAccessCheckers.java
@@ -17,7 +17,9 @@ package de.symeda.sormas.api.utils.fieldaccess;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class FieldAccessCheckers {
 
@@ -39,6 +41,20 @@ public class FieldAccessCheckers {
 	public boolean isAccessible(Field field, boolean withMandatoryFields) {
 
 		for (FieldAccessChecker checker : checkers) {
+			if (checker.isConfiguredForCheck(field, withMandatoryFields) && !checker.hasRight()) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	@SafeVarargs
+	public final boolean isAccessibleBy(Field field, boolean withMandatoryFields, Class<? extends FieldAccessChecker>... checkerTypes) {
+
+		List<FieldAccessChecker> filteredCheckers =
+			checkers.stream().filter(c -> Arrays.stream(checkerTypes).anyMatch(t -> c.getClass().isAssignableFrom(t))).collect(Collectors.toList());
+		for (FieldAccessChecker checker : filteredCheckers) {
 			if (checker.isConfiguredForCheck(field, withMandatoryFields) && !checker.hasRight()) {
 				return false;
 			}

--- a/sormas-api/src/main/java/de/symeda/sormas/api/utils/pseudonymization/DtoPseudonymizer.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/utils/pseudonymization/DtoPseudonymizer.java
@@ -199,8 +199,13 @@ public class DtoPseudonymizer {
 				pseudonymizeField(dto, field, defaultPseudonymizerClass);
 				// only personal and sensitive data pseudonymization needs special handling on the client side
 				// other not accessible data is hidden on the client side, so just cleanup and don't mark the DTO as pseudonymized
-				didPersonalOrSensitiveDataPseudonymization = !fieldAccessCheckers
-					.isAccessibleBy(field, pseudonymizeMandatoryFields, PersonalDataFieldAccessChecker.class, SensitiveDataFieldAccessChecker.class);
+				if (!didPersonalOrSensitiveDataPseudonymization) {
+					didPersonalOrSensitiveDataPseudonymization = !fieldAccessCheckers.isAccessibleBy(
+						field,
+						pseudonymizeMandatoryFields,
+						PersonalDataFieldAccessChecker.class,
+						SensitiveDataFieldAccessChecker.class);
+				}
 			}
 		}
 
@@ -214,14 +219,15 @@ public class DtoPseudonymizer {
 					Class<? extends ValuePseudonymizer> psudonomyzerClass =
 						pseudonymizerAnnotation != null ? pseudonymizerAnnotation.value() : defaultPseudonymizerClass;
 
-                    if (pseudonymizeDto((Class<Object>) embeddedField.getType(),
-                            embeddedField.get(dto),
-                            inJurisdiction,
-                            psudonomyzerClass,
-                            null,
-                            skipEmbeddedFields)) {
+					if (pseudonymizeDto(
+						(Class<Object>) embeddedField.getType(),
+						embeddedField.get(dto),
+						inJurisdiction,
+						psudonomyzerClass,
+						null,
+						skipEmbeddedFields)) {
 						didPersonalOrSensitiveDataPseudonymization = true;
-                    }
+					}
 				} catch (IllegalAccessException e) {
 					throw new RuntimeException(
 						"Failed to pseudonymize embedded field " + dto.getClass().getName() + "." + embeddedField.getName(),
@@ -250,7 +256,7 @@ public class DtoPseudonymizer {
 
 			ValuePseudonymizer<?> pseudonymizer = getPseudonymizer(field, pseudonymizerClass);
 			Object emptyValue = pseudonymizer.pseudonymize(field.get(dto));
-            field.set(dto, emptyValue);
+			field.set(dto, emptyValue);
 		} catch (IllegalAccessException | InstantiationException e) {
 			throw new RuntimeException(e);
 		} finally {

--- a/sormas-api/src/main/java/de/symeda/sormas/api/utils/pseudonymization/Pseudonymizable.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/utils/pseudonymization/Pseudonymizable.java
@@ -15,9 +15,20 @@
 
 package de.symeda.sormas.api.utils.pseudonymization;
 
+/**
+ * Interface used to be able to mark objects that has pseudonymized personal and sensitive data
+ */
 public interface Pseudonymizable {
 
+	/**
+	 * @return true if the object has pseudonymized personal and sensitive data
+	 */
 	boolean isPseudonymized();
 
+	/**
+	 * Marks the object that it has pseudonymized personal and sensitive data
+	 * 
+	 * @param pseudonymized
+	 */
 	void setPseudonymized(boolean pseudonymized);
 }

--- a/sormas-api/src/main/java/de/symeda/sormas/api/utils/pseudonymization/PseudonymizableDto.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/utils/pseudonymization/PseudonymizableDto.java
@@ -22,6 +22,9 @@ public abstract class PseudonymizableDto extends EntityDto implements Pseudonymi
 
 	public static final String PSEUDONYMIZED = "pseudonymized";
 
+	/**
+	 * Flag that marks the object that is has pseudonymized personal and sensitive data
+	 */
 	private boolean pseudonymized;
 
 	public boolean isPseudonymized() {


### PR DESCRIPTION
<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #10547

Pseudonymization of not personal and/or sensitive data will not mark the DTO as pseudonymized.
The pseudonymized flag is used to mark sensitive and/or personal fields on the UI. The other inaccessible fields are not shown on the UI

The solution was discussed with @MateStrysewske