### PR TITLE
#10489 S2S_read only leads to active box 'send to reporting tool'

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/CaseDataView.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/CaseDataView.java
@@ -179,7 +179,7 @@ public class CaseDataView extends AbstractCaseView {
 			layout.addSidePanelComponent(sormasToSormasLocLayout, SORMAS_TO_SORMAS_LOC);
 		}
 
-		ExternalSurveillanceServiceGateway.addComponentToLayout(layout.getSidePanelComponent(), editComponent, caze);
+		ExternalSurveillanceServiceGateway.addComponentToLayout(layout, editComponent, caze);
 
 		if (FacadeProvider.getFeatureConfigurationFacade().isFeatureEnabled(FeatureType.SURVEILLANCE_REPORTS)) {
 			SurveillanceReportListComponent surveillanceReportList = new SurveillanceReportListComponent(caze.toReference());
@@ -198,7 +198,7 @@ public class CaseDataView extends AbstractCaseView {
 			layout.addSidePanelComponent(new SideComponentLayout(documentList), DOCUMENTS_LOC);
 		}
 
-		QuarantineOrderDocumentsComponent.addComponentToLayout(layout.getSidePanelComponent(), caze, documentList);
+		QuarantineOrderDocumentsComponent.addComponentToLayout(layout, caze, documentList);
 
 		EditPermissionType caseEditAllowed = FacadeProvider.getCaseFacade().getEditPermissionType(caze.getUuid());
 

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/contact/ContactDataView.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/contact/ContactDataView.java
@@ -270,7 +270,7 @@ public class ContactDataView extends AbstractContactView {
 			layout.addSidePanelComponent(new SideComponentLayout(documentList), DOCUMENTS_LOC);
 		}
 
-		QuarantineOrderDocumentsComponent.addComponentToLayout(layout.getSidePanelComponent(), contactDto, documentList);
+		QuarantineOrderDocumentsComponent.addComponentToLayout(layout, contactDto, documentList);
 
 		EditPermissionType contactEditAllowed = FacadeProvider.getContactFacade().getEditPermissionType(contactDto.getUuid());
 

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/docgeneration/QuarantineOrderDocumentsComponent.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/docgeneration/QuarantineOrderDocumentsComponent.java
@@ -17,8 +17,6 @@ package de.symeda.sormas.ui.docgeneration;
 
 import static de.symeda.sormas.ui.docgeneration.DocGenerationHelper.isDocGenerationAllowed;
 
-import com.vaadin.ui.CustomLayout;
-
 import de.symeda.sormas.api.ReferenceDto;
 import de.symeda.sormas.api.caze.CaseDataDto;
 import de.symeda.sormas.api.contact.ContactDto;
@@ -30,12 +28,25 @@ import de.symeda.sormas.api.vaccination.VaccinationListCriteria;
 import de.symeda.sormas.ui.ControllerProvider;
 import de.symeda.sormas.ui.document.DocumentListComponent;
 import de.symeda.sormas.ui.utils.CssStyles;
+import de.symeda.sormas.ui.utils.LayoutWithSidePanel;
 
 public class QuarantineOrderDocumentsComponent extends AbstractDocumentGenerationComponent {
 
 	public static final String QUARANTINE_LOC = "quarantine";
 
-	public static void addComponentToLayout(CustomLayout targetLayout, CaseDataDto caze, DocumentListComponent documentList) {
+	public QuarantineOrderDocumentsComponent(
+		ReferenceDto referenceDto,
+		DocumentWorkflow workflow,
+		SampleCriteria sampleCriteria,
+		VaccinationListCriteria vaccinationCriteria) {
+		super();
+		addDocumentBar(
+			() -> ControllerProvider.getDocGenerationController()
+				.showQuarantineOrderDocumentDialog(referenceDto, workflow, sampleCriteria, vaccinationCriteria, null),
+			Captions.DocumentTemplate_QuarantineOrder);
+	}
+
+	public static void addComponentToLayout(LayoutWithSidePanel targetLayout, CaseDataDto caze, DocumentListComponent documentList) {
 		SampleCriteria sampleCriteria = new SampleCriteria().caze(caze.toReference());
 		VaccinationListCriteria vaccinationCriteria = new VaccinationListCriteria.Builder(caze.getPerson()).withDisease(caze.getDisease()).build();
 		addComponentToLayout(
@@ -47,7 +58,7 @@ public class QuarantineOrderDocumentsComponent extends AbstractDocumentGeneratio
 			documentList);
 	}
 
-	public static void addComponentToLayout(CustomLayout targetLayout, ContactDto contact, DocumentListComponent documentList) {
+	public static void addComponentToLayout(LayoutWithSidePanel targetLayout, ContactDto contact, DocumentListComponent documentList) {
 		VaccinationListCriteria vaccinationCriteria =
 			new VaccinationListCriteria.Builder(contact.getPerson()).withDisease(contact.getDisease()).build();
 		SampleCriteria sampleCriteria = new SampleCriteria().contact(contact.toReference());
@@ -61,12 +72,15 @@ public class QuarantineOrderDocumentsComponent extends AbstractDocumentGeneratio
 			documentList);
 	}
 
-	public static void addComponentToLayout(CustomLayout targetLayout, TravelEntryReferenceDto travelEntry, DocumentListComponent documentList) {
+	public static void addComponentToLayout(
+		LayoutWithSidePanel targetLayout,
+		TravelEntryReferenceDto travelEntry,
+		DocumentListComponent documentList) {
 		addComponentToLayout(targetLayout, travelEntry, DocumentWorkflow.QUARANTINE_ORDER_TRAVEL_ENTRY, null, null, documentList);
 	}
 
 	public static void addComponentToLayout(
-		CustomLayout targetLayout,
+		LayoutWithSidePanel targetLayout,
 		ReferenceDto referenceDto,
 		DocumentWorkflow workflow,
 		SampleCriteria sampleCriteria,
@@ -75,12 +89,12 @@ public class QuarantineOrderDocumentsComponent extends AbstractDocumentGeneratio
 			QuarantineOrderDocumentsComponent docGenerationComponent =
 				new QuarantineOrderDocumentsComponent(referenceDto, workflow, sampleCriteria, vaccinationCriteria);
 			docGenerationComponent.addStyleName(CssStyles.SIDE_COMPONENT);
-			targetLayout.addComponent(docGenerationComponent, QUARANTINE_LOC);
+			targetLayout.addSidePanelComponent(docGenerationComponent, QUARANTINE_LOC);
 		}
 	}
 
 	public static void addComponentToLayout(
-		CustomLayout targetLayout,
+		LayoutWithSidePanel targetLayout,
 		ReferenceDto referenceDto,
 		DocumentWorkflow workflow,
 		SampleCriteria sampleCriteria,
@@ -90,19 +104,8 @@ public class QuarantineOrderDocumentsComponent extends AbstractDocumentGeneratio
 			QuarantineOrderDocumentsComponent docGenerationComponent =
 				new QuarantineOrderDocumentsComponent(referenceDto, workflow, sampleCriteria, vaccinationCriteria, documentListComponent);
 			docGenerationComponent.addStyleName(CssStyles.SIDE_COMPONENT);
-			targetLayout.addComponent(docGenerationComponent, QUARANTINE_LOC);
+			targetLayout.addSidePanelComponent(docGenerationComponent, QUARANTINE_LOC);
 		}
-	}
-
-	public QuarantineOrderDocumentsComponent(
-		ReferenceDto referenceDto,
-		DocumentWorkflow workflow,
-		SampleCriteria sampleCriteria,
-		VaccinationListCriteria vaccinationCriteria) {
-		super();
-		addDocumentBar(
-			() -> ControllerProvider.getDocGenerationController().showQuarantineOrderDocumentDialog(referenceDto, workflow, sampleCriteria, vaccinationCriteria, null),
-			Captions.DocumentTemplate_QuarantineOrder);
 	}
 
 	public QuarantineOrderDocumentsComponent(

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/events/EventDataView.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/events/EventDataView.java
@@ -107,7 +107,7 @@ public class EventDataView extends AbstractEventView {
 
 		container.addComponent(layout);
 
-		externalSurvToolLayout = ExternalSurveillanceServiceGateway.addComponentToLayout(layout.getSidePanelComponent(), editComponent, event);
+		externalSurvToolLayout = ExternalSurveillanceServiceGateway.addComponentToLayout(layout, editComponent, event);
 		setExternalSurvToolLayoutVisibility(event.getEventStatus());
 
 		if (FacadeProvider.getFeatureConfigurationFacade().isFeatureEnabled(FeatureType.TASK_MANAGEMENT)

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/events/EventParticipantDataView.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/events/EventParticipantDataView.java
@@ -175,7 +175,7 @@ public class EventParticipantDataView extends AbstractDetailView<EventParticipan
 		VaccinationListCriteria vaccinationCriteria =
 			new VaccinationListCriteria.Builder(eventParticipant.getPerson().toReference()).withDisease(event.getDisease()).build();
 		QuarantineOrderDocumentsComponent.addComponentToLayout(
-			layout.getSidePanelComponent(),
+			layout,
 			eventParticipantRef,
 			DocumentWorkflow.QUARANTINE_ORDER_EVENT_PARTICIPANT,
 			sampleCriteria,

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/externalsurveillanceservice/ExternalSurveillanceServiceGateway.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/externalsurveillanceservice/ExternalSurveillanceServiceGateway.java
@@ -7,7 +7,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.vaadin.ui.CustomLayout;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.Notification;
 
@@ -21,6 +20,7 @@ import de.symeda.sormas.api.i18n.Strings;
 import de.symeda.sormas.api.share.ExternalShareInfoCriteria;
 import de.symeda.sormas.ui.SormasUI;
 import de.symeda.sormas.ui.utils.DirtyStateComponent;
+import de.symeda.sormas.ui.utils.LayoutWithSidePanel;
 import de.symeda.sormas.ui.utils.VaadinUiUtil;
 
 /**
@@ -37,7 +37,7 @@ public class ExternalSurveillanceServiceGateway {
 	}
 
 	public static ExternalSurveillanceShareComponent addComponentToLayout(
-		CustomLayout targetLayout,
+		LayoutWithSidePanel targetLayout,
 		DirtyStateComponent editComponent,
 		CaseDataDto caze) {
 		return addComponentToLayout(
@@ -56,7 +56,7 @@ public class ExternalSurveillanceServiceGateway {
 	}
 
 	public static ExternalSurveillanceShareComponent addComponentToLayout(
-		CustomLayout targetLayout,
+		LayoutWithSidePanel targetLayout,
 		DirtyStateComponent editComponent,
 		EventDto event) {
 		return addComponentToLayout(
@@ -75,7 +75,7 @@ public class ExternalSurveillanceServiceGateway {
 	}
 
 	private static ExternalSurveillanceShareComponent addComponentToLayout(
-		CustomLayout targetLayout,
+		LayoutWithSidePanel targetLayout,
 		DirtyStateComponent editComponent,
 		String entityName,
 		String confirmationText,
@@ -97,7 +97,7 @@ public class ExternalSurveillanceServiceGateway {
 		} : null, () -> {
 			deleteInExternalSurveillanceTool(deletionText, gatewayDeleteCall, SormasUI::refreshView);
 		}, shareInfoCriteria, editComponent);
-		targetLayout.addComponent(shareComponent, EXTERANEL_SURVEILLANCE_TOOL_GATEWAY_LOC);
+		targetLayout.addSidePanelComponent(shareComponent, EXTERANEL_SURVEILLANCE_TOOL_GATEWAY_LOC);
 
 		return shareComponent;
 	}

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/travelentry/TravelEntryDataView.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/travelentry/TravelEntryDataView.java
@@ -87,7 +87,7 @@ public class TravelEntryDataView extends AbstractTravelEntryView {
 			layout.addSidePanelComponent(new SideComponentLayout(documentList), DOCUMENTS_LOC);
 		}
 
-		QuarantineOrderDocumentsComponent.addComponentToLayout(layout.getSidePanelComponent(), getTravelEntryRef(), documentList);
+		QuarantineOrderDocumentsComponent.addComponentToLayout(layout, getTravelEntryRef(), documentList);
 
 		if (FacadeProvider.getFeatureConfigurationFacade().isFeatureEnabled(FeatureType.TASK_MANAGEMENT)) {
 			TaskListComponent taskList = new TaskListComponent(TaskContext.TRAVEL_ENTRY, getTravelEntryRef(), travelEntryDto.getDisease());


### PR DESCRIPTION
<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #10489

Survnet and Document template boxes where not added correctly to the view, so they weren't disabled together with the other ones