### PR TITLE
[#9708] move pseudonymization logic up to base

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/AbstractCoreFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/AbstractCoreFacadeEjb.java
@@ -72,13 +72,13 @@ public abstract class AbstractCoreFacadeEjb<ADO extends CoreAdo, DTO extends Ent
 	@Override
 	public DTO getByUuid(String uuid) {
 		Pseudonymizer pseudonymizer = Pseudonymizer.getDefault(userService::hasRight);
-		return convertToDto(service.getByUuid(uuid, true), pseudonymizer);
+		return toPseudonymizedDto(service.getByUuid(uuid, true), pseudonymizer);
 	}
 
 	@Override
 	public List<DTO> getByUuids(List<String> uuids) {
 		Pseudonymizer pseudonymizer = Pseudonymizer.getDefault(userService::hasRight);
-		return service.getByUuids(uuids).stream().map(c -> convertToDto(c, pseudonymizer)).collect(Collectors.toList());
+		return service.getByUuids(uuids).stream().map(c -> toPseudonymizedDto(c, pseudonymizer)).collect(Collectors.toList());
 	}
 
 	@Override
@@ -90,23 +90,14 @@ public abstract class AbstractCoreFacadeEjb<ADO extends CoreAdo, DTO extends Ent
 	public List<DTO> getAllAfter(Date date, Integer batchSize, String lastSynchronizedUuid) {
 
 		List<ADO> entities = service.getAllAfter(date, batchSize, lastSynchronizedUuid);
-		List<DTO> dtos = toPseudonymizedDtos(entities);
-
-		return dtos;
-	}
-
-	protected Pseudonymizer createPseudonymizer() {
-
-		return Pseudonymizer.getDefault(userService::hasRight);
+		return toPseudonymizedDtos(entities);
 	}
 
 	protected List<DTO> toPseudonymizedDtos(List<ADO> entities) {
 
 		List<Long> inJurisdictionIds = service.getInJurisdictionIds(entities);
 		Pseudonymizer pseudonymizer = createPseudonymizer();
-		List<DTO> dtos =
-			entities.stream().map(p -> convertToDto(p, pseudonymizer, inJurisdictionIds.contains(p.getId()))).collect(Collectors.toList());
-		return dtos;
+		return entities.stream().map(p -> toPseudonymizedDto(p, pseudonymizer, inJurisdictionIds.contains(p.getId()))).collect(Collectors.toList());
 	}
 
 	@DenyAll
@@ -127,7 +118,7 @@ public abstract class AbstractCoreFacadeEjb<ADO extends CoreAdo, DTO extends Ent
 		existingAdo = fillOrBuildEntity(dto, existingAdo, true);
 		service.ensurePersisted(existingAdo);
 
-		return convertToDto(existingAdo, pseudonymizer);
+		return toPseudonymizedDto(existingAdo, pseudonymizer);
 	}
 
 	public boolean exists(String uuid) {
@@ -155,23 +146,6 @@ public abstract class AbstractCoreFacadeEjb<ADO extends CoreAdo, DTO extends Ent
 
 	public boolean isDeleted(String uuid) {
 		return service.isDeleted(uuid);
-	}
-
-	public DTO convertToDto(ADO source, Pseudonymizer pseudonymizer) {
-
-		if (source == null) {
-			return null;
-		}
-
-		boolean inJurisdiction = service.inJurisdictionOrOwned(source);
-		return convertToDto(source, pseudonymizer, inJurisdiction);
-	}
-
-	protected DTO convertToDto(ADO source, Pseudonymizer pseudonymizer, boolean inJurisdiction) {
-
-		DTO dto = toDto(source);
-		pseudonymizeDto(source, dto, pseudonymizer, inJurisdiction);
-		return dto;
 	}
 
 	public List<String> getUuidsForAutomaticDeletion(DeletionConfiguration entityConfig) {
@@ -305,5 +279,11 @@ public abstract class AbstractCoreFacadeEjb<ADO extends CoreAdo, DTO extends Ent
 	@Override
 	public boolean isEditAllowed(String uuid) {
 		return service.isEditAllowed(service.getByUuid(uuid));
+	}
+
+	@Override
+
+	protected boolean isAdoInJurisdiction(ADO source) {
+		return service.inJurisdictionOrOwned(source);
 	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/contact/ContactFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/contact/ContactFacadeEjb.java
@@ -1576,29 +1576,29 @@ public class ContactFacadeEjb
 		Map<Long, ContactJurisdictionFlagsDto> jurisdictionsFlags = service.getJurisdictionsFlags(entities);
 		Pseudonymizer pseudonymizer = createPseudonymizer();
 		List<ContactDto> dtos =
-			entities.stream().map(p -> convertToDto(p, pseudonymizer, jurisdictionsFlags.get(p.getId()))).collect(Collectors.toList());
+			entities.stream().map(p -> toPseudonymizedDto(p, pseudonymizer, jurisdictionsFlags.get(p.getId()))).collect(Collectors.toList());
 		return dtos;
 	}
 
 	@Override
-	public ContactDto convertToDto(Contact source, Pseudonymizer pseudonymizer) {
+	public ContactDto toPseudonymizedDto(Contact source, Pseudonymizer pseudonymizer) {
 
 		if (source == null) {
 			return null;
 		}
 
 		ContactJurisdictionFlagsDto jurisdictionFlags = service.getJurisdictionFlags(source);
-		return convertToDto(source, pseudonymizer, jurisdictionFlags);
+		return toPseudonymizedDto(source, pseudonymizer, jurisdictionFlags);
 	}
 
 	@Deprecated
 	@Override
-	protected ContactDto convertToDto(Contact source, Pseudonymizer pseudonymizer, boolean inJurisdiction) {
+	public ContactDto toPseudonymizedDto(Contact source, Pseudonymizer pseudonymizer, boolean inJurisdiction) {
 
 		throw new UnsupportedOperationException("Use variant with jurisdictionFlags parameter");
 	}
 
-	protected ContactDto convertToDto(Contact source, Pseudonymizer pseudonymizer, ContactJurisdictionFlagsDto jurisdictionFlags) {
+	protected ContactDto toPseudonymizedDto(Contact source, Pseudonymizer pseudonymizer, ContactJurisdictionFlagsDto jurisdictionFlags) {
 
 		ContactDto dto = toDto(source);
 		pseudonymizeDto(source, dto, pseudonymizer, jurisdictionFlags);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/event/EventFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/event/EventFacadeEjb.java
@@ -1,20 +1,17 @@
-/*******************************************************************************
+/*
  * SORMAS® - Surveillance Outbreak Response Management & Analysis System
  * Copyright © 2016-2022 Helmholtz-Zentrum für Infektionsforschung GmbH (HZI)
- *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
- *******************************************************************************/
+ */
 package de.symeda.sormas.backend.event;
 
 import static java.util.Objects.isNull;
@@ -239,7 +236,7 @@ public class EventFacadeEjb extends AbstractCoreFacadeEjb<Event, EventDto, Event
 	public EventDto getEventByUuid(String uuid, boolean detailedReferences) {
 		return (detailedReferences)
 			? convertToDetailedReferenceDto(service.getByUuid(uuid), Pseudonymizer.getDefault(userService::hasRight))
-			: convertToDto(service.getByUuid(uuid), Pseudonymizer.getDefault(userService::hasRight));
+			: toPseudonymizedDto(service.getByUuid(uuid), Pseudonymizer.getDefault(userService::hasRight));
 	}
 
 	@Override
@@ -283,7 +280,7 @@ public class EventFacadeEjb extends AbstractCoreFacadeEjb<Event, EventDto, Event
 
 		onEventChange(toDto(event), internal);
 
-		return convertToDto(event, pseudonymizer);
+		return toPseudonymizedDto(event, pseudonymizer);
 	}
 
 	@PermitAll
@@ -1141,10 +1138,7 @@ public class EventFacadeEjb extends AbstractCoreFacadeEjb<Event, EventDto, Event
 
 		if (dto != null) {
 			pseudonymizer.pseudonymizeDto(EventDto.class, dto, inJurisdiction, e -> {
-				pseudonymizer.pseudonymizeUser(
-					event.getReportingUser(),
-					userService.getCurrentUser(),
-					dto::setReportingUser);
+				pseudonymizer.pseudonymizeUser(event.getReportingUser(), userService.getCurrentUser(), dto::setReportingUser);
 			});
 		}
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/event/EventParticipantFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/event/EventParticipantFacadeEjb.java
@@ -214,7 +214,7 @@ public class EventParticipantFacadeEjb
 		}
 
 		Pseudonymizer pseudonymizer = Pseudonymizer.getDefault(userService::hasRight);
-		return service.getAllByEventAfter(date, event).stream().map(e -> convertToDto(e, pseudonymizer)).collect(Collectors.toList());
+		return service.getAllByEventAfter(date, event).stream().map(e -> toPseudonymizedDto(e, pseudonymizer)).collect(Collectors.toList());
 	}
 
 	@Override
@@ -297,7 +297,7 @@ public class EventParticipantFacadeEjb
 
 	@Override
 	public EventParticipantDto getEventParticipantByUuid(String uuid) {
-		return convertToDto(service.getByUuid(uuid), Pseudonymizer.getDefault(userService::hasRight));
+		return toPseudonymizedDto(service.getByUuid(uuid), Pseudonymizer.getDefault(userService::hasRight));
 	}
 
 	@Override
@@ -362,7 +362,7 @@ public class EventParticipantFacadeEjb
 
 		onEventParticipantChanged(eventFacade.toDto(entity.getEvent()), existingDto, entity, internal);
 
-		return convertToDto(entity, pseudonymizer);
+		return toPseudonymizedDto(entity, pseudonymizer);
 	}
 
 	@PermitAll
@@ -950,7 +950,7 @@ public class EventParticipantFacadeEjb
 		}
 
 		return service.getFirst(criteria)
-			.map(e -> convertToDto(e, Pseudonymizer.getDefault(userService::hasRight, I18nProperties.getCaption(Captions.inaccessibleValue))))
+			.map(e -> toPseudonymizedDto(e, Pseudonymizer.getDefault(userService::hasRight, I18nProperties.getCaption(Captions.inaccessibleValue))))
 			.orElse(null);
 	}
 
@@ -1058,7 +1058,7 @@ public class EventParticipantFacadeEjb
 	@Override
 	public List<EventParticipantDto> getByEventUuids(List<String> eventUuids) {
 		Pseudonymizer pseudonymizer = Pseudonymizer.getDefault(userService::hasRight);
-		return service.getByEventUuids(eventUuids).stream().map(e -> convertToDto(e, pseudonymizer)).collect(Collectors.toList());
+		return service.getByEventUuids(eventUuids).stream().map(e -> toPseudonymizedDto(e, pseudonymizer)).collect(Collectors.toList());
 	}
 
 	@Override

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/immunization/ImmunizationFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/immunization/ImmunizationFacadeEjb.java
@@ -375,7 +375,7 @@ public class ImmunizationFacadeEjb
 
 		onImmunizationChanged(immunization, internal);
 
-		return convertToDto(immunization, pseudonymizer);
+		return toPseudonymizedDto(immunization, pseudonymizer);
 	}
 
 	@Override

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/AbstractInfrastructureFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/AbstractInfrastructureFacadeEjb.java
@@ -29,6 +29,7 @@ import de.symeda.sormas.backend.feature.FeatureConfigurationFacadeEjb;
 import de.symeda.sormas.backend.user.User;
 import de.symeda.sormas.backend.user.UserService;
 import de.symeda.sormas.backend.util.DtoHelper;
+import de.symeda.sormas.backend.util.Pseudonymizer;
 import de.symeda.sormas.backend.util.RightsAllowed;
 
 public abstract class AbstractInfrastructureFacadeEjb<ADO extends InfrastructureAdo, DTO extends InfrastructureDto, INDEX_DTO extends Serializable, REF_DTO extends InfrastructureDataReferenceDto, SRV extends AbstractInfrastructureAdoService<ADO, CRITERIA>, CRITERIA extends BaseCriteria>
@@ -243,5 +244,21 @@ public abstract class AbstractInfrastructureFacadeEjb<ADO extends Infrastructure
 		UserRight._INFRASTRUCTURE_VIEW })
 	public void validate(@Valid DTO dto) throws ValidationRuntimeException {
 		// todo we do not run any generic validation logic for infra yet
+	}
+
+	@Override
+	protected void pseudonymizeDto(ADO source, DTO dto, Pseudonymizer pseudonymizer, boolean inJurisdiction) {
+		// we do not pseudonymize infra data
+	}
+
+	@Override
+	protected void restorePseudonymizedDto(DTO dto, DTO existingDto, ADO entity, Pseudonymizer pseudonymizer) {
+		// we do not pseudonymize infra data
+	}
+
+	@Override
+	protected boolean isAdoInJurisdiction(ADO ado) {
+		// we do not pseudonymize infra data
+		return false;
 	}
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/caze/CaseShareDataBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/caze/CaseShareDataBuilder.java
@@ -85,7 +85,7 @@ public class CaseShareDataBuilder
 	@Override
 	protected CaseDataDto getDto(Case caze, Pseudonymizer pseudonymizer) {
 
-		CaseDataDto cazeDto = caseFacade.convertToDto(caze, pseudonymizer);
+		CaseDataDto cazeDto = caseFacade.toPseudonymizedDto(caze, pseudonymizer);
 		// reporting user is not set to null here as it would not pass the validation
 		// the receiver appears to set it to SORMAS2SORMAS Client anyway
 		cazeDto.setClassificationUser(null);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/contact/ContactShareDataBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/contact/ContactShareDataBuilder.java
@@ -72,7 +72,7 @@ public class ContactShareDataBuilder
 	@Override
 	protected ContactDto getDto(Contact contact, Pseudonymizer pseudonymizer) {
 
-		ContactDto contactDto = contactFacade.convertToDto(contact, pseudonymizer);
+		ContactDto contactDto = contactFacade.toPseudonymizedDto(contact, pseudonymizer);
 		// reporting user is not set to null here as it would not pass the validation
 		// the receiver appears to set it to SORMAS2SORMAS Client anyway
 		contactDto.setContactOfficer(null);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/event/EventShareDataBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/event/EventShareDataBuilder.java
@@ -71,7 +71,7 @@ public class EventShareDataBuilder
 	@Override
 	protected EventDto getDto(Event event, Pseudonymizer pseudonymizer) {
 
-		EventDto eventDto = eventFacade.convertToDto(event, pseudonymizer);
+		EventDto eventDto = eventFacade.toPseudonymizedDto(event, pseudonymizer);
 		// reporting user is not set to null here as it would not pass the validation
 		// the receiver appears to set it to SORMAS2SORMAS Client anyway
 		eventDto.setSormasToSormasOriginInfo(null);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/eventparticipant/EventParticipantShareDataBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/eventparticipant/EventParticipantShareDataBuilder.java
@@ -67,7 +67,7 @@ public class EventParticipantShareDataBuilder
 	@Override
 	protected EventParticipantDto getDto(EventParticipant eventParticipant, Pseudonymizer pseudonymizer) {
 
-		EventParticipantDto eventParticipantDto = eventParticipantFacade.convertToDto(eventParticipant, pseudonymizer);
+		EventParticipantDto eventParticipantDto = eventParticipantFacade.toPseudonymizedDto(eventParticipant, pseudonymizer);
 		// reporting user is not set to null here as it would not pass the validation
 		// the receiver appears to set it to SORMAS2SORMAS Client anyway
 		eventParticipantDto.setSormasToSormasOriginInfo(null);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/immunization/ImmunizationShareDataBuilder.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/entities/immunization/ImmunizationShareDataBuilder.java
@@ -60,7 +60,7 @@ public class ImmunizationShareDataBuilder
 	@Override
 	protected ImmunizationDto getDto(Immunization immunization, Pseudonymizer pseudonymizer) {
 
-		ImmunizationDto immunizationDto = immunizationFacade.convertToDto(immunization, pseudonymizer);
+		ImmunizationDto immunizationDto = immunizationFacade.toPseudonymizedDto(immunization, pseudonymizer);
 		// reporting user is not set to null here as it would not pass the validation
 		// the receiver appears to set it to SORMAS2SORMAS Client anyway
 		immunizationDto.setSormasToSormasOriginInfo(null);

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/share/ShareDataBuilderHelper.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/share/ShareDataBuilderHelper.java
@@ -73,7 +73,7 @@ public class ShareDataBuilderHelper {
 	}
 
 	public PersonDto getPersonDto(Person person, Pseudonymizer pseudonymizer, ShareRequestInfo requestInfo) {
-		PersonDto personDto = personFacade.convertToDto(person, pseudonymizer, true);
+		PersonDto personDto = personFacade.toPseudonymizedDto(person, pseudonymizer, true);
 
 		pseudonymizePerson(personDto, requestInfo);
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/travelentry/TravelEntryFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/travelentry/TravelEntryFacadeEjb.java
@@ -125,7 +125,7 @@ public class TravelEntryFacadeEjb
 
 		if (lastTravelEntry != null) {
 			Pseudonymizer aDefault = Pseudonymizer.getDefault(userService::hasRight);
-			TravelEntryDto travelEntryDto = convertToDto(lastTravelEntry, aDefault);
+			TravelEntryDto travelEntryDto = toPseudonymizedDto(lastTravelEntry, aDefault);
 			return travelEntryDto.getDeaContent();
 		}
 


### PR DESCRIPTION
Found opportunity to refactor this while working on #9708.
* convertToDto -> toPseudonymizedDto
* Moved abstract core methods up to base
* renamed/changed Person methods such that they override the new base methods