### PR TITLE
#10520 Fix Synchronization Dialog callbacks for Additional Test

### DIFF
--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/backend/common/DtoFeatureConfigHelper.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/backend/common/DtoFeatureConfigHelper.java
@@ -1,0 +1,82 @@
+/*
+ * SORMAS® - Surveillance Outbreak Response Management & Analysis System
+ * Copyright © 2016-2022 Helmholtz-Zentrum für Infektionsforschung GmbH (HZI)
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package de.symeda.sormas.app.backend.common;
+
+import de.symeda.sormas.api.feature.FeatureType;
+
+public class DtoFeatureConfigHelper {
+
+	public static boolean isFeatureConfigForCaseEnabled() {
+		return DatabaseHelper.getFeatureConfigurationDao().isFeatureEnabled(FeatureType.CASE_SURVEILANCE);
+	}
+
+	public static boolean isFeatureConfigForImmunizationEnabled() {
+		return DatabaseHelper.getFeatureConfigurationDao().isFeatureEnabled(FeatureType.IMMUNIZATION_MANAGEMENT);
+	}
+
+	public static boolean isFeatureConfigForEventsEnabled() {
+		return DatabaseHelper.getFeatureConfigurationDao().isFeatureEnabled(FeatureType.EVENT_SURVEILLANCE);
+	}
+
+	public static boolean isFeatureConfigForEventParticipantsEnabled() {
+		return DatabaseHelper.getFeatureConfigurationDao().isFeatureEnabled(FeatureType.EVENT_SURVEILLANCE);
+	}
+
+	public static boolean isFeatureConfigForSampleEnabled() {
+		return DatabaseHelper.getFeatureConfigurationDao().isFeatureEnabled(FeatureType.SAMPLES_LAB);
+	}
+
+	public static boolean isFeatureConfigForSampleTestsEnabled() {
+		return DatabaseHelper.getFeatureConfigurationDao().isFeatureEnabled(FeatureType.SAMPLES_LAB);
+	}
+
+	public static boolean isFeatureConfigForAdditionalTestsEnabled() {
+		return DatabaseHelper.getFeatureConfigurationDao().isFeatureEnabled(FeatureType.ADDITIONAL_TESTS);
+	}
+
+	public static boolean isFeatureConfigForContactsEnabled() {
+		return DatabaseHelper.getFeatureConfigurationDao().isFeatureEnabled(FeatureType.CONTACT_TRACING);
+	}
+
+	public static boolean isFeatureConfigForVisitsEnabled() {
+		return DatabaseHelper.getFeatureConfigurationDao().isFeatureEnabled(FeatureType.CASE_FOLLOWUP)
+			|| DatabaseHelper.getFeatureConfigurationDao().isFeatureEnabled(FeatureType.CONTACT_TRACING);
+	}
+
+	public static boolean isFeatureConfigForTasksEnabled() {
+		return DatabaseHelper.getFeatureConfigurationDao().isFeatureEnabled(FeatureType.TASK_MANAGEMENT);
+	}
+
+	public static boolean isFeatureConfigForWeeklyReportsEnabled() {
+		return DatabaseHelper.getFeatureConfigurationDao().isFeatureEnabled(FeatureType.WEEKLY_REPORTING);
+	}
+
+	public static boolean isFeatureConfigForAggregateReportsEnabled() {
+		return DatabaseHelper.getFeatureConfigurationDao().isFeatureEnabled(FeatureType.AGGREGATE_REPORTING);
+	}
+
+	public static boolean isFeatureConfigForPrescriptionsEnabled() {
+		return DatabaseHelper.getFeatureConfigurationDao().isFeatureEnabled(FeatureType.CASE_SURVEILANCE);
+	}
+
+	public static boolean isFeatureConfigForTreatmentsEnabled() {
+		return DatabaseHelper.getFeatureConfigurationDao().isFeatureEnabled(FeatureType.CASE_SURVEILANCE);
+	}
+
+	public static boolean isFeatureConfigForClinicalVisitsEnabled() {
+		return DatabaseHelper.getFeatureConfigurationDao().isFeatureEnabled(FeatureType.CLINICAL_MANAGEMENT);
+	}
+}

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/backend/feature/FeatureConfigurationDao.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/backend/feature/FeatureConfigurationDao.java
@@ -76,6 +76,19 @@ public class FeatureConfigurationDao extends AbstractAdoDao<FeatureConfiguration
 		}
 	}
 
+	public boolean isFeatureEnabled(FeatureType featureType) {
+		try {
+			QueryBuilder builder = queryBuilder();
+			Where where = builder.where();
+			where.eq(FeatureConfiguration.FEATURE_TYPE, featureType);
+			where.and().eq(FeatureConfiguration.ENABLED, true);
+			return builder.countOf() > 0;
+		} catch (SQLException e) {
+			Log.e(getTableName(), "Could not perform isFeatureEnabled");
+			throw new RuntimeException(e);
+		}
+	}
+
 	public boolean isPropertyValueTrue(FeatureType featureType, FeatureTypeProperty property) {
 		if (!featureType.getSupportedProperties().contains(property)) {
 			throw new IllegalArgumentException("Feature type " + featureType + " does not support property " + property + ".");

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/component/dialog/SynchronizationDialog.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/component/dialog/SynchronizationDialog.java
@@ -414,7 +414,9 @@ public class SynchronizationDialog extends AbstractDialog {
 		addEntityIfViewAllowed(EventParticipantDto.class, Strings.entityEventParticipants, allowedEntities);
 		addEntityIfViewAllowed(SampleDto.class, Strings.entitySamples, allowedEntities);
 		addEntityIfViewAllowed(PathogenTestDto.class, Strings.entityPathogenTests, allowedEntities);
-		addEntityIfViewAllowed(AdditionalTestDto.class, Strings.entityAdditionalTests, allowedEntities);
+		if (!DatabaseHelper.getFeatureConfigurationDao().isFeatureDisabled(FeatureType.ADDITIONAL_TESTS)) {
+			addEntityIfViewAllowed(AdditionalTestDto.class, Strings.entityAdditionalTests, allowedEntities);
+		}
 		addEntityIfViewAllowed(ContactDto.class, Strings.entityContacts, allowedEntities);
 		addEntityIfViewAllowed(VisitDto.class, Strings.entityVisits, allowedEntities);
 		addEntityIfViewAllowed(TaskDto.class, Strings.entityTasks, allowedEntities);

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/component/dialog/SynchronizationDialog.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/component/dialog/SynchronizationDialog.java
@@ -47,6 +47,7 @@ import de.symeda.sormas.api.user.UserDto;
 import de.symeda.sormas.api.user.UserRoleDto;
 import de.symeda.sormas.api.visit.VisitDto;
 import de.symeda.sormas.app.R;
+import de.symeda.sormas.app.backend.common.DtoFeatureConfigHelper;
 import de.symeda.sormas.app.backend.common.DatabaseHelper;
 import de.symeda.sormas.app.backend.common.DtoUserRightsHelper;
 import de.symeda.sormas.app.databinding.DialogSynchronizationProgressItemLayoutBinding;
@@ -408,23 +409,36 @@ public class SynchronizationDialog extends AbstractDialog {
 
 		List<String> allowedEntities = new ArrayList<>();
 		addEntityIfViewAllowed(PersonDto.class, Strings.entityPersons, allowedEntities);
-		addEntityIfViewAllowed(CaseDataDto.class, Strings.entityCases, allowedEntities);
-		addEntityIfViewAllowed(ImmunizationDto.class, Strings.entityImmunizations, allowedEntities);
-		addEntityIfViewAllowed(EventDto.class, Strings.entityEvents, allowedEntities);
-		addEntityIfViewAllowed(EventParticipantDto.class, Strings.entityEventParticipants, allowedEntities);
-		addEntityIfViewAllowed(SampleDto.class, Strings.entitySamples, allowedEntities);
-		addEntityIfViewAllowed(PathogenTestDto.class, Strings.entityPathogenTests, allowedEntities);
-		if (!DatabaseHelper.getFeatureConfigurationDao().isFeatureDisabled(FeatureType.ADDITIONAL_TESTS)) {
+		if (DtoFeatureConfigHelper.isFeatureConfigForCaseEnabled())
+			addEntityIfViewAllowed(CaseDataDto.class, Strings.entityCases, allowedEntities);
+		if (DtoFeatureConfigHelper.isFeatureConfigForImmunizationEnabled())
+			addEntityIfViewAllowed(ImmunizationDto.class, Strings.entityImmunizations, allowedEntities);
+		if (DtoFeatureConfigHelper.isFeatureConfigForEventsEnabled())
+			addEntityIfViewAllowed(EventDto.class, Strings.entityEvents, allowedEntities);
+		if (DtoFeatureConfigHelper.isFeatureConfigForEventParticipantsEnabled())
+			addEntityIfViewAllowed(EventParticipantDto.class, Strings.entityEventParticipants, allowedEntities);
+		if (DtoFeatureConfigHelper.isFeatureConfigForSampleEnabled())
+			addEntityIfViewAllowed(SampleDto.class, Strings.entitySamples, allowedEntities);
+		if (DtoFeatureConfigHelper.isFeatureConfigForSampleTestsEnabled())
+			addEntityIfViewAllowed(PathogenTestDto.class, Strings.entityPathogenTests, allowedEntities);
+		if (DtoFeatureConfigHelper.isFeatureConfigForAdditionalTestsEnabled())
 			addEntityIfViewAllowed(AdditionalTestDto.class, Strings.entityAdditionalTests, allowedEntities);
-		}
-		addEntityIfViewAllowed(ContactDto.class, Strings.entityContacts, allowedEntities);
-		addEntityIfViewAllowed(VisitDto.class, Strings.entityVisits, allowedEntities);
-		addEntityIfViewAllowed(TaskDto.class, Strings.entityTasks, allowedEntities);
-		addEntityIfViewAllowed(WeeklyReportDto.class, Strings.entityWeeklyReports, allowedEntities);
-		addEntityIfViewAllowed(AggregateReportDto.class, Strings.entityAggregateReports, allowedEntities);
-		addEntityIfViewAllowed(PrescriptionDto.class, Strings.entityPrescriptions, allowedEntities);
-		addEntityIfViewAllowed(TreatmentDto.class, Strings.entityTreatments, allowedEntities);
-		addEntityIfViewAllowed(ClinicalVisitDto.class, Strings.entityClinicalVisits, allowedEntities);
+		if (DtoFeatureConfigHelper.isFeatureConfigForContactsEnabled())
+			addEntityIfViewAllowed(ContactDto.class, Strings.entityContacts, allowedEntities);
+		if (DtoFeatureConfigHelper.isFeatureConfigForVisitsEnabled())
+			addEntityIfViewAllowed(VisitDto.class, Strings.entityVisits, allowedEntities);
+		if (DtoFeatureConfigHelper.isFeatureConfigForTasksEnabled())
+			addEntityIfViewAllowed(TaskDto.class, Strings.entityTasks, allowedEntities);
+		if (DtoFeatureConfigHelper.isFeatureConfigForWeeklyReportsEnabled())
+			addEntityIfViewAllowed(WeeklyReportDto.class, Strings.entityWeeklyReports, allowedEntities);
+		if (DtoFeatureConfigHelper.isFeatureConfigForAggregateReportsEnabled())
+			addEntityIfViewAllowed(AggregateReportDto.class, Strings.entityAggregateReports, allowedEntities);
+		if (DtoFeatureConfigHelper.isFeatureConfigForPrescriptionsEnabled())
+			addEntityIfViewAllowed(PrescriptionDto.class, Strings.entityPrescriptions, allowedEntities);
+		if (DtoFeatureConfigHelper.isFeatureConfigForTreatmentsEnabled())
+			addEntityIfViewAllowed(TreatmentDto.class, Strings.entityTreatments, allowedEntities);
+		if (DtoFeatureConfigHelper.isFeatureConfigForClinicalVisitsEnabled())
+			addEntityIfViewAllowed(ClinicalVisitDto.class, Strings.entityClinicalVisits, allowedEntities);
 		if (!DatabaseHelper.getFeatureConfigurationDao().isFeatureDisabled(FeatureType.CAMPAIGNS)) {
 			addEntityIfViewAllowed(CampaignFormMetaDto.class, Strings.entityCampaignFormMeta, allowedEntities);
 			addEntityIfViewAllowed(CampaignDto.class, Strings.entityCampaigns, allowedEntities);

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/rest/SynchronizeDataAsync.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/rest/SynchronizeDataAsync.java
@@ -65,6 +65,7 @@ import de.symeda.sormas.app.backend.classification.DiseaseClassificationDtoHelpe
 import de.symeda.sormas.app.backend.clinicalcourse.ClinicalVisitDtoHelper;
 import de.symeda.sormas.app.backend.common.DaoException;
 import de.symeda.sormas.app.backend.common.DatabaseHelper;
+import de.symeda.sormas.app.backend.common.DtoFeatureConfigHelper;
 import de.symeda.sormas.app.backend.common.DtoUserRightsHelper;
 import de.symeda.sormas.app.backend.config.ConfigProvider;
 import de.symeda.sormas.app.backend.contact.ContactDtoHelper;
@@ -363,6 +364,37 @@ public class SynchronizeDataAsync extends AsyncTask<Void, Void, Void> {
 		boolean treatmentsNeedPull = treatmentDtoHelper.pullAndPushEntities(context, syncCallbacks);
 		boolean clinicalVisitsNeedPull = clinicalVisitDtoHelper.pullAndPushEntities(context, syncCallbacks);
 
+		boolean casesVisible = DtoUserRightsHelper.isViewAllowed(CaseDataDto.class)
+			&& DtoFeatureConfigHelper.isFeatureConfigForCaseEnabled();
+		boolean immunizationsVisible = DtoUserRightsHelper.isViewAllowed(ImmunizationDto.class)
+			&& DtoFeatureConfigHelper.isFeatureConfigForImmunizationEnabled();
+		boolean eventsVisible = DtoUserRightsHelper.isViewAllowed(EventDto.class)
+			&& DtoFeatureConfigHelper.isFeatureConfigForEventsEnabled();
+		boolean eventParticipantsVisible = DtoUserRightsHelper.isViewAllowed(EventParticipantDto.class)
+			&& DtoFeatureConfigHelper.isFeatureConfigForEventParticipantsEnabled();
+		boolean samplesVisible = DtoUserRightsHelper.isViewAllowed(SampleDto.class)
+			&& DtoFeatureConfigHelper.isFeatureConfigForSampleEnabled();
+		boolean sampleTestsVisible = DtoUserRightsHelper.isViewAllowed(PathogenTestDto.class)
+			&& DtoFeatureConfigHelper.isFeatureConfigForSampleTestsEnabled();
+		boolean additionalTestsVisible = DtoUserRightsHelper.isViewAllowed(AdditionalTestDto.class)
+			&& DtoFeatureConfigHelper.isFeatureConfigForAdditionalTestsEnabled();
+		boolean contactsVisible = DtoUserRightsHelper.isViewAllowed(ContactDto.class)
+			&& DtoFeatureConfigHelper.isFeatureConfigForContactsEnabled();
+		boolean visitsVisible = DtoUserRightsHelper.isViewAllowed(VisitDto.class)
+			&& DtoFeatureConfigHelper.isFeatureConfigForVisitsEnabled();
+		boolean tasksVisible = DtoUserRightsHelper.isViewAllowed(TaskDto.class)
+			&& DtoFeatureConfigHelper.isFeatureConfigForTasksEnabled();
+		boolean weeklyReportsVisible = DtoUserRightsHelper.isViewAllowed(WeeklyReportDto.class)
+			&& DtoFeatureConfigHelper.isFeatureConfigForWeeklyReportsEnabled();
+		boolean aggregateReportsVisible = DtoUserRightsHelper.isViewAllowed(AggregateReportDto.class)
+			&& DtoFeatureConfigHelper.isFeatureConfigForAggregateReportsEnabled();
+		boolean prescriptionsVisible = DtoUserRightsHelper.isViewAllowed(PrescriptionDto.class)
+			&& DtoFeatureConfigHelper.isFeatureConfigForPrescriptionsEnabled();
+		boolean treatmentsVisible = DtoUserRightsHelper.isViewAllowed(TreatmentDto.class)
+			&& DtoFeatureConfigHelper.isFeatureConfigForTreatmentsEnabled();
+		boolean clinicalVisitsVisible = DtoUserRightsHelper.isViewAllowed(ClinicalVisitDto.class)
+			&& DtoFeatureConfigHelper.isFeatureConfigForClinicalVisitsEnabled();
+
 		syncCallbacks.ifPresent(c -> c.getUpdateSynchronizationStepCallback().accept(SynchronizationDialog.SynchronizationStep.PULL_MODIFIED));
 
 		casesNeedPull |= clinicalVisitsNeedPull;
@@ -370,68 +402,95 @@ public class SynchronizeDataAsync extends AsyncTask<Void, Void, Void> {
 		if (personsNeedPull) {
 			personDtoHelper.pullEntities(true, context, syncCallbacks, false);
 		}
-		syncCallbacks.ifPresent(c -> c.getLoadNextCallback().run());
-		if (casesNeedPull) {
-			caseDtoHelper.pullEntities(true, context, syncCallbacks, false);
+		if (casesVisible) {
+			syncCallbacks.ifPresent(c -> c.getLoadNextCallback().run());
+			if (casesNeedPull) {
+				caseDtoHelper.pullEntities(true, context, syncCallbacks, false);
+			}
 		}
-		syncCallbacks.ifPresent(c -> c.getLoadNextCallback().run());
-		if (immunizationsNeedPull) {
-			immunizationDtoHelper.pullEntities(true, context, syncCallbacks, false);
+		if (immunizationsVisible) {
+			syncCallbacks.ifPresent(c -> c.getLoadNextCallback().run());
+			if (immunizationsNeedPull) {
+				immunizationDtoHelper.pullEntities(true, context, syncCallbacks, false);
+			}
 		}
-		syncCallbacks.ifPresent(c -> c.getLoadNextCallback().run());
-		if (eventsNeedPull) {
-			eventDtoHelper.pullEntities(true, context, syncCallbacks, false);
+		if (eventsVisible) {
+			syncCallbacks.ifPresent(c -> c.getLoadNextCallback().run());
+			if (eventsNeedPull) {
+				eventDtoHelper.pullEntities(true, context, syncCallbacks, false);
+			}
 		}
-		syncCallbacks.ifPresent(c -> c.getLoadNextCallback().run());
-		if (eventParticipantsNeedPull) {
-			eventParticipantDtoHelper.pullEntities(true, context, syncCallbacks, false);
+		if (eventParticipantsVisible) {
+			syncCallbacks.ifPresent(c -> c.getLoadNextCallback().run());
+			if (eventParticipantsNeedPull) {
+				eventParticipantDtoHelper.pullEntities(true, context, syncCallbacks, false);
+			}
 		}
-		syncCallbacks.ifPresent(c -> c.getLoadNextCallback().run());
-		if (samplesNeedPull) {
-			sampleDtoHelper.pullEntities(true, context, syncCallbacks, false);
+		if (samplesVisible) {
+			syncCallbacks.ifPresent(c -> c.getLoadNextCallback().run());
+			if (samplesNeedPull) {
+				sampleDtoHelper.pullEntities(true, context, syncCallbacks, false);
+			}
 		}
-		syncCallbacks.ifPresent(c -> c.getLoadNextCallback().run());
-		if (sampleTestsNeedPull) {
-			pathogenTestDtoHelper.pullEntities(true, context, syncCallbacks, false);
+		if (sampleTestsVisible) {
+			syncCallbacks.ifPresent(c -> c.getLoadNextCallback().run());
+			if (sampleTestsNeedPull) {
+				pathogenTestDtoHelper.pullEntities(true, context, syncCallbacks, false);
+			}
 		}
-		if (DtoUserRightsHelper.isViewAllowed(AdditionalTestDto.class)
-			&& !DatabaseHelper.getFeatureConfigurationDao().isFeatureDisabled(FeatureType.ADDITIONAL_TESTS)) {
+		if (additionalTestsVisible) {
 			syncCallbacks.ifPresent(c -> c.getLoadNextCallback().run());
 			if (additionalTestsNeedPull) {
 				additionalTestDtoHelper.pullEntities(true, context, syncCallbacks, false);
 			}
 		}
-		syncCallbacks.ifPresent(c -> c.getLoadNextCallback().run());
-		if (contactsNeedPull) {
-			contactDtoHelper.pullEntities(true, context, syncCallbacks, false);
+		if (contactsVisible) {
+			syncCallbacks.ifPresent(c -> c.getLoadNextCallback().run());
+			if (contactsNeedPull) {
+				contactDtoHelper.pullEntities(true, context, syncCallbacks, false);
+			}
 		}
-		syncCallbacks.ifPresent(c -> c.getLoadNextCallback().run());
-		if (visitsNeedPull) {
-			visitDtoHelper.pullEntities(true, context, syncCallbacks, false);
+		if (visitsVisible) {
+			syncCallbacks.ifPresent(c -> c.getLoadNextCallback().run());
+			if (visitsNeedPull) {
+				visitDtoHelper.pullEntities(true, context, syncCallbacks, false);
+			}
 		}
-		syncCallbacks.ifPresent(c -> c.getLoadNextCallback().run());
-		if (tasksNeedPull) {
-			taskDtoHelper.pullEntities(true, context, syncCallbacks, false);
+		if (tasksVisible) {
+			syncCallbacks.ifPresent(c -> c.getLoadNextCallback().run());
+			if (tasksNeedPull) {
+				taskDtoHelper.pullEntities(true, context, syncCallbacks, false);
+			}
 		}
-		syncCallbacks.ifPresent(c -> c.getLoadNextCallback().run());
-		if (weeklyReportsNeedPull) {
-			weeklyReportDtoHelper.pullEntities(true, context, syncCallbacks, false);
+		if (weeklyReportsVisible) {
+			syncCallbacks.ifPresent(c -> c.getLoadNextCallback().run());
+			if (weeklyReportsNeedPull) {
+				weeklyReportDtoHelper.pullEntities(true, context, syncCallbacks, false);
+			}
 		}
-		syncCallbacks.ifPresent(c -> c.getLoadNextCallback().run());
-		if (aggregateReportsNeedPull) {
-			aggregateReportDtoHelper.pullEntities(true, context, syncCallbacks, false);
+		if (aggregateReportsVisible) {
+			syncCallbacks.ifPresent(c -> c.getLoadNextCallback().run());
+			if (aggregateReportsNeedPull) {
+				aggregateReportDtoHelper.pullEntities(true, context, syncCallbacks, false);
+			}
 		}
-		syncCallbacks.ifPresent(c -> c.getLoadNextCallback().run());
-		if (prescriptionsNeedPull) {
-			prescriptionDtoHelper.pullEntities(true, context, syncCallbacks, false);
+		if (prescriptionsVisible) {
+			syncCallbacks.ifPresent(c -> c.getLoadNextCallback().run());
+			if (prescriptionsNeedPull) {
+				prescriptionDtoHelper.pullEntities(true, context, syncCallbacks, false);
+			}
 		}
-		syncCallbacks.ifPresent(c -> c.getLoadNextCallback().run());
-		if (treatmentsNeedPull) {
-			treatmentDtoHelper.pullEntities(true, context, syncCallbacks, false);
+		if (treatmentsVisible) {
+			syncCallbacks.ifPresent(c -> c.getLoadNextCallback().run());
+			if (treatmentsNeedPull) {
+				treatmentDtoHelper.pullEntities(true, context, syncCallbacks, false);
+			}
 		}
-		syncCallbacks.ifPresent(c -> c.getLoadNextCallback().run());
-		if (clinicalVisitsNeedPull) {
-			clinicalVisitDtoHelper.pullEntities(true, context, syncCallbacks, false);
+		if (clinicalVisitsVisible) {
+			syncCallbacks.ifPresent(c -> c.getLoadNextCallback().run());
+			if (clinicalVisitsNeedPull) {
+				clinicalVisitDtoHelper.pullEntities(true, context, syncCallbacks, false);
+			}
 		}
 		syncCallbacks.ifPresent(c -> c.getLoadNextCallback().run());
 

--- a/sormas-app/app/src/main/java/de/symeda/sormas/app/rest/SynchronizeDataAsync.java
+++ b/sormas-app/app/src/main/java/de/symeda/sormas/app/rest/SynchronizeDataAsync.java
@@ -394,9 +394,12 @@ public class SynchronizeDataAsync extends AsyncTask<Void, Void, Void> {
 		if (sampleTestsNeedPull) {
 			pathogenTestDtoHelper.pullEntities(true, context, syncCallbacks, false);
 		}
-		syncCallbacks.ifPresent(c -> c.getLoadNextCallback().run());
-		if (additionalTestsNeedPull) {
-			additionalTestDtoHelper.pullEntities(true, context, syncCallbacks, false);
+		if (DtoUserRightsHelper.isViewAllowed(AdditionalTestDto.class)
+			&& !DatabaseHelper.getFeatureConfigurationDao().isFeatureDisabled(FeatureType.ADDITIONAL_TESTS)) {
+			syncCallbacks.ifPresent(c -> c.getLoadNextCallback().run());
+			if (additionalTestsNeedPull) {
+				additionalTestDtoHelper.pullEntities(true, context, syncCallbacks, false);
+			}
 		}
 		syncCallbacks.ifPresent(c -> c.getLoadNextCallback().run());
 		if (contactsNeedPull) {


### PR DESCRIPTION
- in case an entity is not enabled (FEATURE_CONFIG) or the user does not have rights to view the specified Entity, then sync dialog callbacks should be synced with the available to view entities list

<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #10520