### PR TITLE
[#9708] better use of getByUuid from parent class

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/campaign/CampaignFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/campaign/CampaignFacadeEjb.java
@@ -380,11 +380,6 @@ public class CampaignFacadeEjb
 	}
 
 	@Override
-	public List<CampaignDto> getByUuids(List<String> uuids) {
-		return service.getByUuids(uuids).stream().map(c -> toDto(c)).collect(Collectors.toList());
-	}
-
-	@Override
 	public List<String> getAllActiveUuids() {
 		if (userService.getCurrentUser() == null) {
 			return Collections.emptyList();

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/AbstractBaseEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/AbstractBaseEjb.java
@@ -44,7 +44,7 @@ public abstract class AbstractBaseEjb<ADO extends AbstractDomainObject, DTO exte
 
 	@Override
 	public DTO getByUuid(String uuid) {
-		return toDto(service.getByUuid(uuid));
+		return Optional.of(uuid).map(u -> service.getByUuid(u, true)).map(this::toPseudonymizedDto).orElse(null);
 	}
 
 	@Override
@@ -54,7 +54,8 @@ public abstract class AbstractBaseEjb<ADO extends AbstractDomainObject, DTO exte
 
 	@Override
 	public List<DTO> getByUuids(List<String> uuids) {
-		return service.getByUuids(uuids).stream().map(this::toDto).collect(Collectors.toList());
+		Pseudonymizer pseudonymizer = createPseudonymizer();
+		return service.getByUuids(uuids).stream().map(source -> toPseudonymizedDto(source, pseudonymizer)).collect(Collectors.toList());
 	}
 
 	@Override

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/common/AbstractCoreFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/common/AbstractCoreFacadeEjb.java
@@ -70,17 +70,6 @@ public abstract class AbstractCoreFacadeEjb<ADO extends CoreAdo, DTO extends Ent
 	}
 
 	@Override
-	public DTO getByUuid(String uuid) {
-		return toPseudonymizedDto(service.getByUuid(uuid, true));
-	}
-
-	@Override
-	public List<DTO> getByUuids(List<String> uuids) {
-		Pseudonymizer pseudonymizer = Pseudonymizer.getDefault(userService::hasRight);
-		return service.getByUuids(uuids).stream().map(c -> toPseudonymizedDto(c, pseudonymizer)).collect(Collectors.toList());
-	}
-
-	@Override
 	public List<DTO> getAllAfter(Date date) {
 		return getAllAfter(date, null, null);
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/AbstractInfrastructureFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/AbstractInfrastructureFacadeEjb.java
@@ -6,7 +6,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import javax.annotation.security.PermitAll;
@@ -76,19 +75,19 @@ public abstract class AbstractInfrastructureFacadeEjb<ADO extends Infrastructure
 	@Override
 	@PermitAll
 	public DTO getByUuid(String uuid) {
-		return toDto(service.getByUuid(uuid));
+		return super.getByUuid(uuid);
 	}
 
 	@Override
 	@PermitAll
 	public REF_DTO getReferenceByUuid(String uuid) {
-		return Optional.ofNullable(uuid).map(u -> service.getByUuid(u)).map(this::toRefDto).orElse(null);
+		return super.getReferenceByUuid(uuid);
 	}
 
 	@Override
 	@PermitAll
 	public List<DTO> getByUuids(List<String> uuids) {
-		return service.getByUuids(uuids).stream().map(this::toDto).collect(Collectors.toList());
+		return super.getByUuids(uuids);
 	}
 
 	@Override

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonFacadeEjb.java
@@ -288,11 +288,6 @@ public class PersonFacadeEjb extends AbstractBaseEjb<Person, PersonDto, PersonIn
 	}
 
 	@Override
-	public List<PersonDto> getByUuids(List<String> uuids) {
-		return toPseudonymizedDtos(service.getByUuids(uuids));
-	}
-
-	@Override
 	public List<PersonDto> getByExternalIds(List<String> externalIds) {
 		return toPseudonymizedDtos(service.getByExternalIds(externalIds));
 	}
@@ -322,7 +317,7 @@ public class PersonFacadeEjb extends AbstractBaseEjb<Person, PersonDto, PersonIn
 		UserRight._PERSON_VIEW,
 		UserRight._EXTERNAL_VISITS })
 	public PersonDto getByUuid(String uuid) {
-		return Optional.of(uuid).map(u -> service.getByUuid(u)).map(this::toPseudonymizedDto).orElse(null);
+		return super.getByUuid(uuid);
 	}
 
 	@Override


### PR DESCRIPTION
Important for #9708 as all of the missing classes use `toPseudonymizedDto` and not `toDto` in `getByUuid`. Switching this to `toPseudonymizedDto` does no harm as `toDto` is still called internally and classes for which pseudonymization is not important (infra classes etc.) have a NOP.