### PR TITLE
Pop-up to let the user know that the person is already an event participant is triggered twice #10804 

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/events/EventController.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/events/EventController.java
@@ -507,8 +507,6 @@ public class EventController {
 				new Notification(I18nProperties.getString(Strings.messagePersonAlreadyEventParticipant), "", Type.HUMANIZED_MESSAGE);
 			notification.setDelayMsec(10000);
 			notification.show(Page.getCurrent());
-			NotificationHelper
-				.showNotification(I18nProperties.getString(Strings.messagePersonAlreadyEventParticipant), Type.HUMANIZED_MESSAGE, 10000);
 			return true;
 		}
 


### PR DESCRIPTION
Remove the duplicate popup that appears when a person is already an event participant and the user links the person's case to that event
Fixes #10804 