### PR TITLE
#10644 Do not append error messages with "null" text

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/CommitDiscardWrapperComponent.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/CommitDiscardWrapperComponent.java
@@ -619,10 +619,16 @@ public class CommitDiscardWrapperComponent<C extends Component> extends Vertical
 						}
 						htmlMsg.append("</ul>");
 					} else if (firstCause != null) {
-						htmlMsg.append(findHtmlMessage(firstCause));
+						String info = findHtmlMessage(firstCause);
+						boolean validInfo = nonNull(info) && !info.isEmpty() && !info.equalsIgnoreCase("null");
+						if (validInfo) {
+							htmlMsg.append(info);
+						}
 						String additionalInfo = findHtmlMessageDetails(firstCause);
 						if (nonNull(additionalInfo) && !additionalInfo.isEmpty()) {
-							htmlMsg.append(" : ");
+							if (validInfo) {
+								htmlMsg.append(" : ");
+							}
 							htmlMsg.append(findHtmlMessageDetails(firstCause));
 						}
 					}


### PR DESCRIPTION
- seems like Vaadin is throwing an error with "null" text so it has to be ignored

<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #10644