### PR TITLE
Change/9708 refactor count facility

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/facility/FacilityFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/facility/FacilityFacadeEjb.java
@@ -539,26 +539,6 @@ public class FacilityFacadeEjb
 
 	@Override
 	@RightsAllowed({
-		UserRight._INFRASTRUCTURE_VIEW,
-		UserRight._SYSTEM })
-	public long count(FacilityCriteria criteria) {
-
-		CriteriaBuilder cb = em.getCriteriaBuilder();
-		CriteriaQuery<Long> cq = cb.createQuery(Long.class);
-		Root<Facility> root = cq.from(Facility.class);
-
-		Predicate filter = service.buildCriteriaFilter(criteria, cb, root);
-
-		if (filter != null) {
-			cq.where(filter);
-		}
-
-		cq.select(cb.count(root));
-		return em.createQuery(cq).getSingleResult();
-	}
-
-	@Override
-	@RightsAllowed({
 		UserRight._INFRASTRUCTURE_CREATE,
 		UserRight._INFRASTRUCTURE_EDIT })
 	public FacilityDto save(FacilityDto dto, boolean allowMerge) {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/facility/FacilityFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/facility/FacilityFacadeEjb.java
@@ -424,7 +424,7 @@ public class FacilityFacadeEjb
 		Join<Facility, District> district = facility.join(Facility.DISTRICT, JoinType.LEFT);
 		Join<Facility, Community> community = facility.join(Facility.COMMUNITY, JoinType.LEFT);
 
-		Predicate filter = buildCriteriaFilterExcludingConstFacilities(facilityCriteria, cb, facility);
+		Predicate filter = service.buildCriteriaFilter(facilityCriteria, cb, facility);
 
 		if (filter != null) {
 			cq.where(filter);
@@ -523,7 +523,7 @@ public class FacilityFacadeEjb
 			facility.get(Facility.LONGITUDE),
 			facility.get(Facility.EXTERNAL_ID));
 
-		Predicate filter = buildCriteriaFilterExcludingConstFacilities(facilityCriteria, cb, facility);
+		Predicate filter = service.buildCriteriaFilter(facilityCriteria, cb, facility);
 
 		filter = CriteriaBuilderHelper.andInValues(selectedRows, filter, cb, facility.get(Facility.UUID));
 
@@ -547,7 +547,7 @@ public class FacilityFacadeEjb
 		CriteriaQuery<Long> cq = cb.createQuery(Long.class);
 		Root<Facility> root = cq.from(Facility.class);
 
-		Predicate filter = buildCriteriaFilterExcludingConstFacilities(criteria, cb, root);
+		Predicate filter = service.buildCriteriaFilter(criteria, cb, root);
 
 		if (filter != null) {
 			cq.where(filter);
@@ -555,22 +555,6 @@ public class FacilityFacadeEjb
 
 		cq.select(cb.count(root));
 		return em.createQuery(cq).getSingleResult();
-	}
-
-	private Predicate buildCriteriaFilterExcludingConstFacilities(FacilityCriteria criteria, CriteriaBuilder cb, Root<Facility> root) {
-
-		// these two facilities are constant and created on startup by FacilityService.createConstantFacilities()
-		Predicate excludeConstantFacilities = cb.and(
-				cb.notEqual(root.get(Facility.UUID), FacilityDto.OTHER_FACILITY_UUID),
-				cb.notEqual(root.get(Facility.UUID), FacilityDto.NONE_FACILITY_UUID));
-
-		Predicate filter = service.buildCriteriaFilter(criteria, cb, root);
-
-		if (filter == null) {
-			return excludeConstantFacilities;
-		} else {
-			return CriteriaBuilderHelper.and(cb, filter, excludeConstantFacilities);
-		}
 	}
 
 	@Override

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/facility/FacilityService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/facility/FacilityService.java
@@ -229,8 +229,13 @@ public class FacilityService extends AbstractInfrastructureAdoService<Facility, 
 	@Override
 	public Predicate buildCriteriaFilter(FacilityCriteria facilityCriteria, CriteriaBuilder cb, Root<Facility> root) {
 
+		// these two facilities are constant and created on startup by createConstantFacilities()
+		Predicate excludeConstantFacilities = cb.and(
+				cb.notEqual(root.get(Facility.UUID), FacilityDto.OTHER_FACILITY_UUID),
+				cb.notEqual(root.get(Facility.UUID), FacilityDto.NONE_FACILITY_UUID));
+
 		if (facilityCriteria == null) {
-			return null;
+			return excludeConstantFacilities;
 		}
 
 		Predicate filter = null;
@@ -293,7 +298,7 @@ public class FacilityService extends AbstractInfrastructureAdoService<Facility, 
 				filter = CriteriaBuilderHelper.and(cb, filter, cb.equal(root.get(Facility.ARCHIVED), true));
 			}
 		}
-		return filter;
+		return CriteriaBuilderHelper.and(cb, filter, excludeConstantFacilities);
 	}
 
 	public void createConstantFacilities() {

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/facility/FacilityService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/facility/FacilityService.java
@@ -1,6 +1,6 @@
-/*******************************************************************************
+/*
  * SORMAS® - Surveillance Outbreak Response Management & Analysis System
- * Copyright © 2016-2018 Helmholtz-Zentrum für Infektionsforschung GmbH (HZI)
+ * Copyright © 2016-2022 Helmholtz-Zentrum für Infektionsforschung GmbH (HZI)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,7 +14,8 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
- *******************************************************************************/
+*/
+
 package de.symeda.sormas.backend.infrastructure.facility;
 
 import java.util.List;

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/facility/FacilityService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/infrastructure/facility/FacilityService.java
@@ -227,14 +227,19 @@ public class FacilityService extends AbstractInfrastructureAdoService<Facility, 
 	}
 
 	@Override
-	public Predicate buildCriteriaFilter(FacilityCriteria facilityCriteria, CriteriaBuilder cb, Root<Facility> from) {
+	public Predicate buildCriteriaFilter(FacilityCriteria facilityCriteria, CriteriaBuilder cb, Root<Facility> root) {
+
+		if (facilityCriteria == null) {
+			return null;
+		}
+
 		Predicate filter = null;
 
 		CountryReferenceDto country = facilityCriteria.getCountry();
 		if (country != null) {
 			CountryReferenceDto serverCountry = countryFacade.getServerCountry();
 
-			Path<Object> countryUuid = from.join(Facility.REGION, JoinType.LEFT).join(Region.COUNTRY, JoinType.LEFT).get(Country.UUID);
+			Path<Object> countryUuid = root.join(Facility.REGION, JoinType.LEFT).join(Region.COUNTRY, JoinType.LEFT).get(Country.UUID);
 			Predicate countryFilter = cb.equal(countryUuid, country.getUuid());
 
 			if (country.equals(serverCountry)) {
@@ -246,17 +251,17 @@ public class FacilityService extends AbstractInfrastructureAdoService<Facility, 
 
 		if (facilityCriteria.getRegion() != null) {
 			filter = CriteriaBuilderHelper
-				.and(cb, filter, cb.equal(from.join(Facility.REGION, JoinType.LEFT).get(Region.UUID), facilityCriteria.getRegion().getUuid()));
+				.and(cb, filter, cb.equal(root.join(Facility.REGION, JoinType.LEFT).get(Region.UUID), facilityCriteria.getRegion().getUuid()));
 		}
 		if (facilityCriteria.getDistrict() != null) {
 			filter = CriteriaBuilderHelper
-				.and(cb, filter, cb.equal(from.join(Facility.DISTRICT, JoinType.LEFT).get(District.UUID), facilityCriteria.getDistrict().getUuid()));
+				.and(cb, filter, cb.equal(root.join(Facility.DISTRICT, JoinType.LEFT).get(District.UUID), facilityCriteria.getDistrict().getUuid()));
 		}
 		if (facilityCriteria.getCommunity() != null) {
 			filter = CriteriaBuilderHelper.and(
 				cb,
 				filter,
-				cb.equal(from.join(Facility.COMMUNITY, JoinType.LEFT).get(District.UUID), facilityCriteria.getCommunity().getUuid()));
+				cb.equal(root.join(Facility.COMMUNITY, JoinType.LEFT).get(District.UUID), facilityCriteria.getCommunity().getUuid()));
 		}
 		if (facilityCriteria.getNameAddressLike() != null) {
 			String[] textFilters = facilityCriteria.getNameAddressLike().split("\\s+");
@@ -266,26 +271,26 @@ public class FacilityService extends AbstractInfrastructureAdoService<Facility, 
 				}
 
 				Predicate likeFilters = cb.or(
-					CriteriaBuilderHelper.unaccentedIlike(cb, from.get(Facility.NAME), textFilter),
-					CriteriaBuilderHelper.unaccentedIlike(cb, from.get(Facility.POSTAL_CODE), textFilter),
-					CriteriaBuilderHelper.unaccentedIlike(cb, from.get(Facility.CITY), textFilter),
-					CriteriaBuilderHelper.unaccentedIlike(cb, from.get(Facility.STREET), textFilter),
-					CriteriaBuilderHelper.unaccentedIlike(cb, from.get(Facility.HOUSE_NUMBER), textFilter),
-					CriteriaBuilderHelper.unaccentedIlike(cb, from.get(Facility.ADDITIONAL_INFORMATION), textFilter));
+					CriteriaBuilderHelper.unaccentedIlike(cb, root.get(Facility.NAME), textFilter),
+					CriteriaBuilderHelper.unaccentedIlike(cb, root.get(Facility.POSTAL_CODE), textFilter),
+					CriteriaBuilderHelper.unaccentedIlike(cb, root.get(Facility.CITY), textFilter),
+					CriteriaBuilderHelper.unaccentedIlike(cb, root.get(Facility.STREET), textFilter),
+					CriteriaBuilderHelper.unaccentedIlike(cb, root.get(Facility.HOUSE_NUMBER), textFilter),
+					CriteriaBuilderHelper.unaccentedIlike(cb, root.get(Facility.ADDITIONAL_INFORMATION), textFilter));
 				filter = CriteriaBuilderHelper.and(cb, filter, likeFilters);
 			}
 		}
 		if (facilityCriteria.getType() != null) {
-			filter = CriteriaBuilderHelper.and(cb, filter, cb.equal(from.get(Facility.TYPE), facilityCriteria.getType()));
+			filter = CriteriaBuilderHelper.and(cb, filter, cb.equal(root.get(Facility.TYPE), facilityCriteria.getType()));
 		} else {
-			filter = CriteriaBuilderHelper.and(cb, filter, cb.isNotNull(from.get(Facility.TYPE)));
+			filter = CriteriaBuilderHelper.and(cb, filter, cb.isNotNull(root.get(Facility.TYPE)));
 		}
 		if (facilityCriteria.getRelevanceStatus() != null) {
 			if (facilityCriteria.getRelevanceStatus() == EntityRelevanceStatus.ACTIVE) {
 				filter = CriteriaBuilderHelper
-					.and(cb, filter, cb.or(cb.equal(from.get(Facility.ARCHIVED), false), cb.isNull(from.get(Facility.ARCHIVED))));
+					.and(cb, filter, cb.or(cb.equal(root.get(Facility.ARCHIVED), false), cb.isNull(root.get(Facility.ARCHIVED))));
 			} else if (facilityCriteria.getRelevanceStatus() == EntityRelevanceStatus.ARCHIVED) {
-				filter = CriteriaBuilderHelper.and(cb, filter, cb.equal(from.get(Facility.ARCHIVED), true));
+				filter = CriteriaBuilderHelper.and(cb, filter, cb.equal(root.get(Facility.ARCHIVED), true));
 			}
 		}
 		return filter;

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/infrastructure/facility/FacilityFacadeEjbTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/infrastructure/facility/FacilityFacadeEjbTest.java
@@ -17,6 +17,7 @@ import de.symeda.sormas.api.infrastructure.community.CommunityReferenceDto;
 import de.symeda.sormas.api.infrastructure.district.DistrictReferenceDto;
 import de.symeda.sormas.api.infrastructure.facility.FacilityCriteria;
 import de.symeda.sormas.api.infrastructure.facility.FacilityDto;
+import de.symeda.sormas.api.infrastructure.facility.FacilityFacade;
 import de.symeda.sormas.api.infrastructure.facility.FacilityIndexDto;
 import de.symeda.sormas.api.infrastructure.facility.FacilityType;
 import de.symeda.sormas.api.utils.SortProperty;
@@ -26,10 +27,10 @@ import de.symeda.sormas.backend.infrastructure.community.Community;
 import de.symeda.sormas.backend.infrastructure.district.District;
 import de.symeda.sormas.backend.infrastructure.region.Region;
 
-public class FacilityFacadeEjbTest extends AbstractBeanTest {
+class FacilityFacadeEjbTest extends AbstractBeanTest {
 
 	@Test
-	public void testGetAllByRegionAfter() throws InterruptedException {
+	void testGetAllByRegionAfter() throws InterruptedException {
 
 		RDCF rdcf = creator.createRDCF();
 		getFacilityService().doFlush();
@@ -53,7 +54,7 @@ public class FacilityFacadeEjbTest extends AbstractBeanTest {
 	}
 
 	@Test
-	public void testGetAllWithoutRegionAfter() throws InterruptedException {
+	void testGetAllWithoutRegionAfter() throws InterruptedException {
 
 		FacilityDto facility = FacilityDto.build();
 		facility.setName("facility");
@@ -81,7 +82,7 @@ public class FacilityFacadeEjbTest extends AbstractBeanTest {
 	}
 
 	@Test
-	public void testGetActiveHealthFacilitiesByCommunity() {
+	void testGetActiveHealthFacilitiesByCommunity() {
 
 		Region r = creator.createRegion("r");
 		District d = creator.createDistrict("d", r);
@@ -99,7 +100,7 @@ public class FacilityFacadeEjbTest extends AbstractBeanTest {
 	}
 
 	@Test
-	public void testGetActiveHealthFacilitiesByDistrict() {
+	void testGetActiveHealthFacilitiesByDistrict() {
 
 		Region r = creator.createRegion("r");
 		District d = creator.createDistrict("d", r);
@@ -117,7 +118,7 @@ public class FacilityFacadeEjbTest extends AbstractBeanTest {
 	}
 
 	@Test
-	public void testGetAllActiveLaboratories() {
+	void testGetAllActiveLaboratories() {
 
 		RDCF rdcf = creator.createRDCF("r", "d", "c", "f");
 		FacilityDto f1 = getFacilityFacade().getByUuid(rdcf.facility.getUuid());
@@ -137,13 +138,13 @@ public class FacilityFacadeEjbTest extends AbstractBeanTest {
 	 * If no facilities are present, no parent of them is archived.
 	 */
 	@Test
-	public void testHasArchivedParentInfrastructureNoFacilities() {
+	void testHasArchivedParentInfrastructureNoFacilities() {
 
 		assertFalse(getFacilityFacade().hasArchivedParentInfrastructure(Collections.emptyList()));
 	}
 
 	@Test
-	public void testGetIndexListMappedSorting() {
+	void testGetIndexListMappedSorting() {
 
 		FacilityCriteria facilityCriteria = new FacilityCriteria();
 
@@ -171,5 +172,52 @@ public class FacilityFacadeEjbTest extends AbstractBeanTest {
 		// 2. Sort by all properties at once
 		getFacilityFacade().getIndexList(facilityCriteria, null, null, allSortProperties);
 		assertThat(result, is(empty()));
+	}
+
+	@Test
+	void testCount() {
+
+		getFacilityService().createConstantFacilities();
+		FacilityFacade facilityFacade = getFacilityFacade();
+		assertEquals(0, facilityFacade.count(null));
+		assertEquals(0, facilityFacade.count(new FacilityCriteria()));
+
+		Region region = creator.createRegion("Region1");
+		District district = creator.createDistrict("District1", region);
+		Community community = creator.createCommunity("Community1", district);
+
+		creator.createFacility("lab", FacilityType.LABORATORY, region, district, community);
+		assertEquals(1, facilityFacade.count(null));
+		assertEquals(1, facilityFacade.count(new FacilityCriteria()));
+
+		creator.createFacility("hospital", FacilityType.HOSPITAL, region, district, community);
+		assertEquals(2, facilityFacade.count(null));
+		assertEquals(2, facilityFacade.count(new FacilityCriteria()));
+
+		assertEquals(1, facilityFacade.count(new FacilityCriteria().type(FacilityType.LABORATORY)));
+	}
+
+	@Test
+	void testConstantFacilitiesAreNeverExported() {
+
+		getFacilityService().createConstantFacilities();
+		FacilityFacade facilityFacade = getFacilityFacade();
+		assertEquals(0, facilityFacade.getExportList(null, Collections.emptyList(), 0, 100).size());
+		assertEquals(0, facilityFacade.getExportList(new FacilityCriteria(), Collections.emptyList(), 0, 100).size());
+
+		Region region = creator.createRegion("Region1");
+		District district = creator.createDistrict("District1", region);
+		Community community = creator.createCommunity("Community1", district);
+
+		Facility lab = creator.createFacility("lab", FacilityType.LABORATORY, region, district, community);
+		creator.createFacility("lab", FacilityType.LABORATORY, region, district, community);
+		creator.createFacility("hospital", FacilityType.HOSPITAL, region, district, community);
+
+		assertEquals(3, facilityFacade.getExportList(null, Collections.emptyList(), 0, 100).size());
+		assertEquals(3, facilityFacade.getExportList(new FacilityCriteria(), Collections.emptyList(), 0, 100).size());
+		assertEquals(2, facilityFacade.getExportList(new FacilityCriteria().type(FacilityType.LABORATORY), Collections.emptyList(), 0, 100).size());
+		assertEquals(
+			1,
+			facilityFacade.getExportList(null, Collections.singletonList(getFacilityFacade().getByUuid(lab.getUuid()).getUuid()), 0, 100).size());
 	}
 }


### PR DESCRIPTION
Found while working on #9708 
I found a way how to unify the count method and I now started to clean up the implementations.

This PR includes the exclusion of the constant facilities into the criteria filtering. It was previously duplicated at every call site, so this unifies this. Also, this fixes a potential bug for the export list. Constant facilities where not included in the index list or in count, but were exported, although they are not a real facility. This PR ensures that they are never exported.  

---

Edit: `count` has been removed from `FacilityFacadeEjb` as its parent implements it with `@PermitAll` annotation