### PR TITLE
#10803 reinfection related checkboxes on case page remain unchecked

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/CaseController.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/CaseController.java
@@ -530,6 +530,12 @@ public class CaseController {
 
 	protected CaseDataDto saveCase(CaseDataDto cazeDto) {
 
+		if (cazeDto.getReInfection() == YesNoUnknown.NO || cazeDto.getReInfection() == YesNoUnknown.UNKNOWN) {
+			cazeDto.setPreviousInfectionDate(null);
+			cazeDto.setReinfectionDetails(Collections.emptyMap());
+			cazeDto.setReinfectionStatus(null);
+		}
+
 		// Compare old and new case
 		CaseDataDto existingDto = FacadeProvider.getCaseFacade().getCaseDataByUuid(cazeDto.getUuid());
 		CaseDataDto resultDto = FacadeProvider.getCaseFacade().save(cazeDto);

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/CaseDataForm.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/CaseDataForm.java
@@ -625,7 +625,7 @@ public class CaseDataForm extends AbstractEditForm<CaseDataDto> {
 			addField(CaseDataDto.PREVIOUS_INFECTION_DATE);
 			ComboBox tfReinfectionStatus = addField(CaseDataDto.REINFECTION_STATUS, ComboBox.class);
 			tfReinfectionStatus.setReadOnly(true);
-			FieldHelper.setVisibleWhen(getFieldGroup(), CaseDataDto.PREVIOUS_INFECTION_DATE, CaseDataDto.RE_INFECTION, YesNoUnknown.YES, true);
+			FieldHelper.setVisibleWhen(getFieldGroup(), CaseDataDto.PREVIOUS_INFECTION_DATE, CaseDataDto.RE_INFECTION, YesNoUnknown.YES, false);
 			FieldHelper.setVisibleWhen(getFieldGroup(), CaseDataDto.REINFECTION_STATUS, CaseDataDto.RE_INFECTION, YesNoUnknown.YES, false);
 
 			final Label reinfectionInfoLabel = new Label(VaadinIcons.EYE.getHtml(), ContentMode.HTML);
@@ -701,11 +701,6 @@ public class CaseDataForm extends AbstractEditForm<CaseDataDto> {
 				} else {
 					reinfectionInfoLabel.setDescription(null);
 					reinfectionInfoLabel.setVisible(false);
-
-					for (CaseReinfectionCheckBoxTree reinfectionTree : reinfectionTrees.values()) {
-						reinfectionTree.clearCheckBoxTree();
-					}
-
 					reinfectionDetailsLeftLayout.setVisible(false);
 					reinfectionDetailsRightLayout.setVisible(false);
 				}


### PR DESCRIPTION
The checkboxes associated with reinfection are cleared only if the user save the changes made.

Fixes #10803