### PR TITLE
[#9708] add count method to vaccination

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/vaccination/VaccinationFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/vaccination/VaccinationFacade.java
@@ -100,4 +100,6 @@ public interface VaccinationFacade {
 	VaccinationDto postUpdate(String uuid, JsonNode vaccinationDtoJson);
 
 	boolean isVaccinationRelevant(CaseDataDto caze, VaccinationDto vaccination);
+
+	long count(VaccinationListCriteria criteria);
 }

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/vaccination/VaccinationFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/vaccination/VaccinationFacadeEjb.java
@@ -298,6 +298,11 @@ public class VaccinationFacadeEjb implements VaccinationFacade {
 	}
 
 	@Override
+	public long count(VaccinationListCriteria criteria) {
+		return vaccinationService.count((cb, root) -> vaccinationService.buildCriteriaFilter(criteria, cb, root));
+	}
+
+	@Override
 	public List<VaccinationDto> getRelevantVaccinationsForCase(CaseDataDto cazeDto) {
 
 		Case caze = caseService.getByUuid(cazeDto.getUuid());


### PR DESCRIPTION
Needed for vaccination refactoring in #9708

I'm a little bit unsure about the content of `createCiriteriaFilter` and consequentially about the function of `count` and `getByCriteriaFilter` as some fields of the criteria are/were not covered. Would be great to receive some feedback if this is correct or if I should add the other fields.