### PR TITLE
qu-auro/SORQA-743 Stabilize "Test Hide country specific fields in the 'Pick or create person' form of the duplicate detection pop-up, in German and French systems"

### DIFF
--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/cases/CreateNewCaseSteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/cases/CreateNewCaseSteps.java
@@ -744,7 +744,7 @@ public class CreateNewCaseSteps implements En {
           webDriverHelpers.waitForPageLoadingSpinnerToDisappear(30);
         });
     When(
-        "^I check if National Health Id, Nickname and Passport number appear in Pick or create person popup$",
+        "^I check if National Health Id, Nickname and Passport number do not appear in Pick or create person popup$",
         () -> {
           softly.assertEquals(
               false, webDriverHelpers.isElementVisibleWithTimeout(NICKNAME_ATTRIBUTE, 2));

--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/events/EditEventSteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/events/EditEventSteps.java
@@ -1974,6 +1974,12 @@ public class EditEventSteps implements En {
         () -> {
           webDriverHelpers.fillAndSubmitInWebElement(SEARCH_EVENT_BY_FREE_TEXT_INPUT, eventUUID);
         });
+
+    And(
+        "^I save Add participant form$",
+        () -> {
+          webDriverHelpers.clickOnWebElementBySelector(SAVE_BUTTON_FOR_POPUP_WINDOWS);
+        });
   }
 
   private String collectEventParticipantUuid() {

--- a/sormas-e2e-tests/src/test/resources/features/sanity/web/Case.feature
+++ b/sormas-e2e-tests/src/test/resources/features/sanity/web/Case.feature
@@ -1156,7 +1156,7 @@ Feature: Case end to end tests
     And I click on the NEW CASE button
     When I fill a new case form with same person details for DE version
     And I click on Save button in Case form
-    Then I check if National Health Id, Nickname and Passport number appear in Pick or create person popup
+    Then I check if National Health Id, Nickname and Passport number do not appear in Pick or create person popup
     And I open the Case Contacts tab
     And I click on the NEW CONTACT button
     And I fill a new contact form with same person data for DE version
@@ -1165,7 +1165,7 @@ Feature: Case end to end tests
     And I click on the NEW CONTACT button
     And I fill a new contact form with same person data for DE version
     And I click on SAVE new contact case button
-    Then I check if National Health Id, Nickname and Passport number appear in Pick or create person popup
+    Then I check if National Health Id, Nickname and Passport number do not appear in Pick or create person popup
 
   @tmsLink=SORDEV-8413 @env_main
   Scenario: Test Hide specific enum values based on the related disease

--- a/sormas-e2e-tests/src/test/resources/features/sanity/web/Contacts.feature
+++ b/sormas-e2e-tests/src/test/resources/features/sanity/web/Contacts.feature
@@ -756,7 +756,7 @@ Feature: Contacts end to end tests
     And I click on the NEW CONTACT button
     And I fill a new contact form with same person data for DE version
     And I click on SAVE new contact case button
-    And I check if National Health Id, Nickname and Passport number appear in Pick or create person popup
+    And I check if National Health Id, Nickname and Passport number do not appear in Pick or create person popup
 
   @tmsLink=SORDEV-6434 @env_main
   Scenario: Check if username shows up in visit origin

--- a/sormas-e2e-tests/src/test/resources/features/sanity/web/Event.feature
+++ b/sormas-e2e-tests/src/test/resources/features/sanity/web/Event.feature
@@ -713,12 +713,12 @@ Feature: Create events
     Then I navigate to EVENT PARTICIPANT from edit event page
     And I click on Add Participant button
     Then I add Participant to an Event with same person data
-    And I click on save button in Add Participant form
+    And I save Add participant form
     Then I navigate to EVENT PARTICIPANT from edit event page
     And I click on Add Participant button
     Then I add Participant to an Event with same person data
-    And I click on save button in Add Participant form
-    And I check if National Health Id, Nickname and Passport number appear in Pick or create person popup
+    And I save Add participant form
+    And I check if National Health Id, Nickname and Passport number do not appear in Pick or create person popup
 
   @env_main @tmsLink=SORDEV-7460
   Scenario: Test Extend the exposure and event startDate and endDate to include a startTime and endTime


### PR DESCRIPTION
<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #