### PR TITLE
#9054 case merge limit

### DIFF
--- a/sormas-api/src/main/java/de/symeda/sormas/api/caze/CaseCriteria.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/caze/CaseCriteria.java
@@ -477,6 +477,7 @@ public class CaseCriteria extends CriteriaWithDateType implements ExternalShareC
 		this.eventLike = eventLike;
 	}
 
+	@IgnoreForUrl
 	public String getEventLike() {
 		return eventLike;
 	}

--- a/sormas-api/src/main/java/de/symeda/sormas/api/caze/CaseCriteria.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/caze/CaseCriteria.java
@@ -477,7 +477,6 @@ public class CaseCriteria extends CriteriaWithDateType implements ExternalShareC
 		this.eventLike = eventLike;
 	}
 
-	@IgnoreForUrl
 	public String getEventLike() {
 		return eventLike;
 	}

--- a/sormas-api/src/main/java/de/symeda/sormas/api/caze/CaseFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/caze/CaseFacade.java
@@ -25,6 +25,7 @@ import java.util.Random;
 
 import javax.ejb.Remote;
 import javax.validation.Valid;
+import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
@@ -57,6 +58,9 @@ import de.symeda.sormas.api.vaccination.VaccinationDto;
 
 @Remote
 public interface CaseFacade extends CoreFacade<CaseDataDto, CaseIndexDto, CaseReferenceDto, CaseCriteria> {
+
+	int DUPLICATE_MERGING_LIMIT_DEFAULT = 100;
+	int DUPLICATE_MERGING_LIMIT_MAX = 1000;
 
 	long count(CaseCriteria caseCriteria, boolean ignoreUserFilter);
 
@@ -149,10 +153,7 @@ public interface CaseFacade extends CoreFacade<CaseDataDto, CaseIndexDto, CaseRe
 
 	List<CaseSelectionDto> getSimilarCases(CaseSimilarityCriteria criteria);
 
-	/**
-	 * @param limit null: no limit
-	 */
-	List<CaseIndexDto[]> getCasesForDuplicateMerging(CaseCriteria criteria, @Min(1) Integer limit, boolean showDuplicatesWithDifferentRegion);
+	List<CaseIndexDto[]> getCasesForDuplicateMerging(CaseCriteria criteria, @Min(1) @Max(DUPLICATE_MERGING_LIMIT_MAX) int limit, boolean showDuplicatesWithDifferentRegion);
 
 	void updateCompleteness(String caseUuid);
 

--- a/sormas-api/src/main/java/de/symeda/sormas/api/caze/CaseFacade.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/caze/CaseFacade.java
@@ -25,6 +25,7 @@ import java.util.Random;
 
 import javax.ejb.Remote;
 import javax.validation.Valid;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -148,7 +149,10 @@ public interface CaseFacade extends CoreFacade<CaseDataDto, CaseIndexDto, CaseRe
 
 	List<CaseSelectionDto> getSimilarCases(CaseSimilarityCriteria criteria);
 
-	List<CaseIndexDto[]> getCasesForDuplicateMerging(CaseCriteria criteria, boolean showDuplicatesWithDifferentRegion);
+	/**
+	 * @param limit null: no limit
+	 */
+	List<CaseIndexDto[]> getCasesForDuplicateMerging(CaseCriteria criteria, @Min(1) Integer limit, boolean showDuplicatesWithDifferentRegion);
 
 	void updateCompleteness(String caseUuid);
 

--- a/sormas-api/src/main/java/de/symeda/sormas/api/i18n/Captions.java
+++ b/sormas-api/src/main/java/de/symeda/sormas/api/i18n/Captions.java
@@ -1840,6 +1840,7 @@ public interface Captions {
 	String prescriptionNewPrescription = "prescriptionNewPrescription";
 	String prescriptionWithTreatment = "prescriptionWithTreatment";
 	String prescriptionWithTreatmentTitleDelete = "prescriptionWithTreatmentTitleDelete";
+	String QueryDetails_resultLimit = "QueryDetails.resultLimit";
 	String Region = "Region";
 	String Region_archived = "Region.archived";
 	String Region_country = "Region.country";

--- a/sormas-api/src/main/resources/captions.properties
+++ b/sormas-api/src/main/resources/captions.properties
@@ -1809,6 +1809,8 @@ PrescriptionExport.caseName=Case name
 prescriptionWithTreatmentTitleDelete=Delete prescriptions with treatments
 prescriptionAlone=Just Prescriptions
 prescriptionWithTreatment=Prescriptions With Treatments
+# QueryDetails
+QueryDetails.resultLimit=Limit result count
 # Continent
 continentActiveContinents=Active continents
 continentArchivedContinents=Archived continents

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseFacadeEjb.java
@@ -69,8 +69,6 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import javax.persistence.criteria.Subquery;
 import javax.validation.Valid;
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import org.apache.commons.collections.CollectionUtils;
@@ -1443,7 +1441,6 @@ public class CaseFacadeEjb extends AbstractCoreFacadeEjb<Case, CaseDataDto, Case
 
 	@Override
 	public List<CaseIndexDto[]> getCasesForDuplicateMerging(CaseCriteria criteria, int limit, boolean showDuplicatesWithDifferentRegion) {
-
 		return service.getCasesForDuplicateMerging(criteria, limit, showDuplicatesWithDifferentRegion, configFacade.getNameSimilarityThreshold());
 	}
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseFacadeEjb.java
@@ -1440,9 +1440,9 @@ public class CaseFacadeEjb extends AbstractCoreFacadeEjb<Case, CaseDataDto, Case
 	}
 
 	@Override
-	public List<CaseIndexDto[]> getCasesForDuplicateMerging(CaseCriteria criteria, boolean ignoreRegion) {
+	public List<CaseIndexDto[]> getCasesForDuplicateMerging(CaseCriteria criteria, Integer limit, boolean showDuplicatesWithDifferentRegion) {
 
-		return service.getCasesForDuplicateMerging(criteria, ignoreRegion, configFacade.getNameSimilarityThreshold());
+		return service.getCasesForDuplicateMerging(criteria, limit, showDuplicatesWithDifferentRegion, configFacade.getNameSimilarityThreshold());
 	}
 
 	@RightsAllowed(UserRight._CASE_EDIT)

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseFacadeEjb.java
@@ -69,6 +69,8 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import javax.persistence.criteria.Subquery;
 import javax.validation.Valid;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import org.apache.commons.collections.CollectionUtils;
@@ -1440,7 +1442,7 @@ public class CaseFacadeEjb extends AbstractCoreFacadeEjb<Case, CaseDataDto, Case
 	}
 
 	@Override
-	public List<CaseIndexDto[]> getCasesForDuplicateMerging(CaseCriteria criteria, Integer limit, boolean showDuplicatesWithDifferentRegion) {
+	public List<CaseIndexDto[]> getCasesForDuplicateMerging(CaseCriteria criteria, int limit, boolean showDuplicatesWithDifferentRegion) {
 
 		return service.getCasesForDuplicateMerging(criteria, limit, showDuplicatesWithDifferentRegion, configFacade.getNameSimilarityThreshold());
 	}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseService.java
@@ -858,8 +858,8 @@ public class CaseService extends AbstractCoreAdoService<Case, CaseJoins> {
 						.unaccentedIlike(cb, personQueryContext.getSubqueryExpression(PersonQueryContext.PERSON_EMAIL_SUBQUERY), textFilter),
 					CriteriaBuilderHelper
 						.unaccentedIlike(cb, personQueryContext.getSubqueryExpression(PersonQueryContext.PERSON_PRIMARY_OTHER_SUBQUERY), textFilter),
-					CriteriaBuilderHelper.unaccentedIlike(cb, joins.getPerson().get(Location.CITY), textFilter),
-					CriteriaBuilderHelper.ilike(cb, joins.getPerson().get(Location.POSTAL_CODE), textFilter)));
+					CriteriaBuilderHelper.unaccentedIlike(cb, joins.getPersonAddress().get(Location.CITY), textFilter),
+					CriteriaBuilderHelper.ilike(cb, joins.getPersonAddress().get(Location.POSTAL_CODE), textFilter)));
 
 			filter = CriteriaBuilderHelper.and(cb, filter, likeFilters);
 		}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseService.java
@@ -1904,10 +1904,16 @@ public class CaseService extends AbstractCoreAdoService<Case, CaseJoins> {
 	}
 
 	/**
-	 *
-	 * @param limit null: no limit
+	 * Performance: May be slow when there are 10000s of cases with similar report date in the same region.
+	 * 
+	 * @param limit
+	 *            null: no limit
 	 */
-	public List<CaseIndexDto[]> getCasesForDuplicateMerging(CaseCriteria criteria, @Min(1) Integer limit, boolean showDuplicatesWithDifferentRegion, double nameSimilarityThreshold) {
+	public List<CaseIndexDto[]> getCasesForDuplicateMerging(
+		CaseCriteria criteria,
+		@Min(1) Integer limit,
+		boolean showDuplicatesWithDifferentRegion,
+		double nameSimilarityThreshold) {
 
 		if (hasAnyToManyJoin(criteria)) {
 			// otherwise we would need to introduce a 'distinct' into the query
@@ -2029,7 +2035,7 @@ public class CaseService extends AbstractCoreAdoService<Case, CaseJoins> {
 		cq.orderBy(cb.desc(root.get(Case.CREATION_DATE)));
 
 		TypedQuery<Object[]> typedQuery = em.createQuery(cq).setParameter("date_type", "epoch");
-		if (limit !=  null) {
+		if (limit != null) {
 			typedQuery.setMaxResults(limit);
 		}
 

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseService.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/caze/CaseService.java
@@ -50,6 +50,7 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import javax.persistence.criteria.Subquery;
 import javax.transaction.Transactional;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import org.apache.commons.collections.CollectionUtils;
@@ -649,6 +650,16 @@ public class CaseService extends AbstractCoreAdoService<Case, CaseJoins> {
 		}
 	}
 
+	/**
+	 * @return Does the criteria lead to any join on a OneToMany or ManyToMany relation,
+	 *         which would lead to the same case being joined multiple times?
+	 */
+	public boolean hasAnyToManyJoin(CaseCriteria caseCriteria) {
+		return Boolean.TRUE.equals(caseCriteria.getOnlyCasesWithEvents())
+			|| !DataHelper.isNullOrEmpty(caseCriteria.getEventLike())
+			|| Boolean.TRUE.equals(caseCriteria.getOnlyContactsFromOtherInstances());
+	}
+
 	public <T extends AbstractDomainObject> Predicate createCriteriaFilter(CaseCriteria caseCriteria, CaseQueryContext caseQueryContext) {
 
 		final From<?, Case> from = caseQueryContext.getRoot();
@@ -656,16 +667,11 @@ public class CaseService extends AbstractCoreAdoService<Case, CaseJoins> {
 		final CriteriaQuery<?> cq = caseQueryContext.getQuery();
 		final CaseJoins joins = caseQueryContext.getJoins();
 
-		Join<Case, Person> person = joins.getPerson();
-		Join<Case, User> reportingUser = joins.getReportingUser();
-		Join<Case, Facility> facility = joins.getFacility();
-		Join<Person, Location> location = joins.getPersonAddress();
-
 		PersonQueryContext personQueryContext = new PersonQueryContext(cb, cq, joins.getPersonJoins());
 
 		Predicate filter = null;
 		if (caseCriteria.getReportingUserRole() != null) {
-			Join<User, UserRole> rolesJoin = reportingUser.join(User.USER_ROLES, JoinType.LEFT);
+			Join<User, UserRole> rolesJoin = joins.getReportingUser().join(User.USER_ROLES, JoinType.LEFT);
 			filter = CriteriaBuilderHelper.and(cb, filter, cb.equal(rolesJoin.get(UserRole.UUID), caseCriteria.getReportingUserRole().getUuid()));
 		}
 		if (caseCriteria.getDisease() != null) {
@@ -708,8 +714,8 @@ public class CaseService extends AbstractCoreAdoService<Case, CaseJoins> {
 			filter = CriteriaBuilderHelper.and(cb, filter, cb.lessThanOrEqualTo(from.get(Case.FOLLOW_UP_UNTIL), caseCriteria.getFollowUpUntilTo()));
 		}
 		if (caseCriteria.getSymptomJournalStatus() != null) {
-			filter =
-				CriteriaBuilderHelper.and(cb, filter, cb.equal(person.get(Person.SYMPTOM_JOURNAL_STATUS), caseCriteria.getSymptomJournalStatus()));
+			filter = CriteriaBuilderHelper
+				.and(cb, filter, cb.equal(joins.getPerson().get(Person.SYMPTOM_JOURNAL_STATUS), caseCriteria.getSymptomJournalStatus()));
 		}
 		if (caseCriteria.getVaccinationStatus() != null) {
 			filter = CriteriaBuilderHelper.and(cb, filter, cb.equal(from.get(Case.VACCINATION_STATUS), caseCriteria.getVaccinationStatus()));
@@ -749,7 +755,8 @@ public class CaseService extends AbstractCoreAdoService<Case, CaseJoins> {
 			filter = CriteriaBuilderHelper.and(cb, filter, cb.equal(from.get(Case.INVESTIGATION_STATUS), caseCriteria.getInvestigationStatus()));
 		}
 		if (caseCriteria.getPresentCondition() != null) {
-			filter = CriteriaBuilderHelper.and(cb, filter, cb.equal(person.get(Person.PRESENT_CONDITION), caseCriteria.getPresentCondition()));
+			filter =
+				CriteriaBuilderHelper.and(cb, filter, cb.equal(joins.getPerson().get(Person.PRESENT_CONDITION), caseCriteria.getPresentCondition()));
 		}
 		if (caseCriteria.getNewCaseDateFrom() != null && caseCriteria.getNewCaseDateTo() != null) {
 			filter = CriteriaBuilderHelper.and(
@@ -782,7 +789,7 @@ public class CaseService extends AbstractCoreAdoService<Case, CaseJoins> {
 					DateHelper.getEndOfDay(caseCriteria.getQuarantineTo())));
 		}
 		if (caseCriteria.getPerson() != null) {
-			filter = CriteriaBuilderHelper.and(cb, filter, cb.equal(person.get(Person.UUID), caseCriteria.getPerson().getUuid()));
+			filter = CriteriaBuilderHelper.and(cb, filter, cb.equal(joins.getPerson().get(Person.UUID), caseCriteria.getPerson().getUuid()));
 		}
 		if (caseCriteria.getMustHaveNoGeoCoordinates() != null && caseCriteria.getMustHaveNoGeoCoordinates() == true) {
 			Join<Person, Location> personAddress = joins.getPersonAddress();
@@ -843,16 +850,16 @@ public class CaseService extends AbstractCoreAdoService<Case, CaseJoins> {
 				caseCriteria.getPersonLike(),
 				textFilter -> cb.or(
 					// We should allow short and long versions of the UUID so let's do a LIKE behaving like a "starts with"
-					CriteriaBuilderHelper.ilikePrecise(cb, person.get(Person.UUID), textFilter + "%"),
-					CriteriaBuilderHelper.unaccentedIlike(cb, person.get(Person.FIRST_NAME), textFilter),
-					CriteriaBuilderHelper.unaccentedIlike(cb, person.get(Person.LAST_NAME), textFilter),
+					CriteriaBuilderHelper.ilikePrecise(cb, joins.getPerson().get(Person.UUID), textFilter + "%"),
+					CriteriaBuilderHelper.unaccentedIlike(cb, joins.getPerson().get(Person.FIRST_NAME), textFilter),
+					CriteriaBuilderHelper.unaccentedIlike(cb, joins.getPerson().get(Person.LAST_NAME), textFilter),
 					phoneNumberPredicate(cb, personQueryContext.getSubqueryExpression(PersonQueryContext.PERSON_PHONE_SUBQUERY), textFilter),
 					CriteriaBuilderHelper
 						.unaccentedIlike(cb, personQueryContext.getSubqueryExpression(PersonQueryContext.PERSON_EMAIL_SUBQUERY), textFilter),
 					CriteriaBuilderHelper
 						.unaccentedIlike(cb, personQueryContext.getSubqueryExpression(PersonQueryContext.PERSON_PRIMARY_OTHER_SUBQUERY), textFilter),
-					CriteriaBuilderHelper.unaccentedIlike(cb, location.get(Location.CITY), textFilter),
-					CriteriaBuilderHelper.ilike(cb, location.get(Location.POSTAL_CODE), textFilter)));
+					CriteriaBuilderHelper.unaccentedIlike(cb, joins.getPerson().get(Location.CITY), textFilter),
+					CriteriaBuilderHelper.ilike(cb, joins.getPerson().get(Location.POSTAL_CODE), textFilter)));
 
 			filter = CriteriaBuilderHelper.and(cb, filter, likeFilters);
 		}
@@ -863,7 +870,7 @@ public class CaseService extends AbstractCoreAdoService<Case, CaseJoins> {
 				textFilter -> cb.or(
 					CriteriaBuilderHelper.ilike(cb, from.get(Case.UUID), textFilter),
 					CriteriaBuilderHelper.ilike(cb, from.get(Case.EPID_NUMBER), textFilter),
-					CriteriaBuilderHelper.unaccentedIlike(cb, facility.get(Facility.NAME), textFilter),
+					CriteriaBuilderHelper.unaccentedIlike(cb, joins.getFacility().get(Facility.NAME), textFilter),
 					CriteriaBuilderHelper.ilike(cb, from.get(Case.EXTERNAL_ID), textFilter),
 					CriteriaBuilderHelper.ilike(cb, from.get(Case.EXTERNAL_TOKEN), textFilter),
 					CriteriaBuilderHelper.unaccentedIlike(cb, from.get(Case.HEALTH_FACILITY_DETAILS), textFilter),
@@ -900,20 +907,20 @@ public class CaseService extends AbstractCoreAdoService<Case, CaseJoins> {
 			String[] textFilters = caseCriteria.getReportingUserLike().split("\\s+");
 			for (String textFilter : textFilters) {
 				Predicate likeFilters = cb.or(
-					CriteriaBuilderHelper.unaccentedIlike(cb, reportingUser.get(User.FIRST_NAME), textFilter),
-					CriteriaBuilderHelper.unaccentedIlike(cb, reportingUser.get(User.LAST_NAME), textFilter),
-					CriteriaBuilderHelper.unaccentedIlike(cb, reportingUser.get(User.USER_NAME), textFilter));
+					CriteriaBuilderHelper.unaccentedIlike(cb, joins.getReportingUser().get(User.FIRST_NAME), textFilter),
+					CriteriaBuilderHelper.unaccentedIlike(cb, joins.getReportingUser().get(User.LAST_NAME), textFilter),
+					CriteriaBuilderHelper.unaccentedIlike(cb, joins.getReportingUser().get(User.USER_NAME), textFilter));
 				filter = CriteriaBuilderHelper.and(cb, filter, likeFilters);
 			}
 		}
 		if (caseCriteria.getBirthdateYYYY() != null) {
-			filter = CriteriaBuilderHelper.and(cb, filter, cb.equal(person.get(Person.BIRTHDATE_YYYY), caseCriteria.getBirthdateYYYY()));
+			filter = CriteriaBuilderHelper.and(cb, filter, cb.equal(joins.getPerson().get(Person.BIRTHDATE_YYYY), caseCriteria.getBirthdateYYYY()));
 		}
 		if (caseCriteria.getBirthdateMM() != null) {
-			filter = CriteriaBuilderHelper.and(cb, filter, cb.equal(person.get(Person.BIRTHDATE_MM), caseCriteria.getBirthdateMM()));
+			filter = CriteriaBuilderHelper.and(cb, filter, cb.equal(joins.getPerson().get(Person.BIRTHDATE_MM), caseCriteria.getBirthdateMM()));
 		}
 		if (caseCriteria.getBirthdateDD() != null) {
-			filter = CriteriaBuilderHelper.and(cb, filter, cb.equal(person.get(Person.BIRTHDATE_DD), caseCriteria.getBirthdateDD()));
+			filter = CriteriaBuilderHelper.and(cb, filter, cb.equal(joins.getPerson().get(Person.BIRTHDATE_DD), caseCriteria.getBirthdateDD()));
 		}
 		if (Boolean.TRUE.equals(caseCriteria.getOnlyContactsFromOtherInstances())) {
 			filter = CriteriaBuilderHelper.and(
@@ -1896,7 +1903,16 @@ public class CaseService extends AbstractCoreAdoService<Case, CaseJoins> {
 		return filter;
 	}
 
-	public List<CaseIndexDto[]> getCasesForDuplicateMerging(CaseCriteria criteria, boolean ignoreRegion, double nameSimilarityThreshold) {
+	/**
+	 *
+	 * @param limit null: no limit
+	 */
+	public List<CaseIndexDto[]> getCasesForDuplicateMerging(CaseCriteria criteria, @Min(1) Integer limit, boolean showDuplicatesWithDifferentRegion, double nameSimilarityThreshold) {
+
+		if (hasAnyToManyJoin(criteria)) {
+			// otherwise we would need to introduce a 'distinct' into the query
+			throw new IllegalArgumentException("Using a criteria based on a OneToMany or ManyToMany relation is not supported.");
+		}
 
 		final CriteriaBuilder cb = em.getCriteriaBuilder();
 		final CriteriaQuery<Object[]> cq = cb.createQuery(Object[].class);
@@ -1910,14 +1926,8 @@ public class CaseService extends AbstractCoreAdoService<Case, CaseJoins> {
 
 		Join<Case, Person> person = joins.getPerson();
 		Join<Case, Person> person2 = joins2.getPerson();
-		Join<Case, Region> responsibleRegion = joins.getResponsibleRegion();
-		Join<Case, Region> responsibleRegion2 = joins2.getResponsibleRegion();
-		Join<Case, Region> region = joins.getRegion();
-		Join<Case, Region> region2 = joins2.getRegion();
 		Join<Case, Symptoms> symptoms = joins.getSymptoms();
 		Join<Case, Symptoms> symptoms2 = joins2.getSymptoms();
-
-		cq.distinct(true);
 
 		// similarity:
 		// * first & last name concatenated with whitespace. Similarity function with default threshold of 0.65D
@@ -1939,8 +1949,8 @@ public class CaseService extends AbstractCoreAdoService<Case, CaseJoins> {
 			cb.gt(cb.function("similarity", double.class, nameSimilarityExpr, nameSimilarityExpr2), nameSimilarityThreshold);
 		Predicate diseaseFilter = cb.equal(root.get(Case.DISEASE), root2.get(Case.DISEASE));
 		Predicate regionFilter = cb.and(
-			cb.equal(responsibleRegion.get(Region.ID), responsibleRegion2.get(Region.ID)),
-			cb.or(cb.and(cb.isNull(region)), cb.equal(region.get(Region.ID), region2.get(Region.ID))));
+			cb.equal(root.get(Case.RESPONSIBLE_REGION), root2.get(Case.RESPONSIBLE_REGION)),
+			cb.or(cb.and(cb.isNull(root.get(Case.REGION))), cb.equal(root.get(Case.REGION), root2.get(Case.REGION))));
 		Predicate reportDateFilter = cb.lessThanOrEqualTo(
 			cb.abs(
 				cb.diff(
@@ -1999,7 +2009,7 @@ public class CaseService extends AbstractCoreAdoService<Case, CaseJoins> {
 		}
 		filter = cb.and(filter, diseaseFilter);
 
-		if (!ignoreRegion) {
+		if (!showDuplicatesWithDifferentRegion) {
 			filter = cb.and(filter, regionFilter);
 		}
 
@@ -2018,7 +2028,12 @@ public class CaseService extends AbstractCoreAdoService<Case, CaseJoins> {
 		cq.multiselect(root.get(Case.ID), root2.get(Case.ID), root.get(Case.CREATION_DATE));
 		cq.orderBy(cb.desc(root.get(Case.CREATION_DATE)));
 
-		List<Object[]> foundIds = em.createQuery(cq).setParameter("date_type", "epoch").getResultList();
+		TypedQuery<Object[]> typedQuery = em.createQuery(cq).setParameter("date_type", "epoch");
+		if (limit !=  null) {
+			typedQuery.setMaxResults(limit);
+		}
+
+		List<Object[]> foundIds = typedQuery.getResultList();
 		List<CaseIndexDto[]> resultList = new ArrayList<>();
 
 		if (!foundIds.isEmpty()) {

--- a/sormas-backend/src/main/resources/sql/sormas_schema.sql
+++ b/sormas-backend/src/main/resources/sql/sormas_schema.sql
@@ -12279,5 +12279,11 @@ UPDATE featureconfiguration SET properties = properties::jsonb || json_build_obj
 
 INSERT INTO schema_version (version_number, comment) VALUES (506, 'Add max change date period property to limited synchronization feature #7305');
 
+-- 2023-02-07 Improve performance or case duplicate merging lists #9054
+CREATE INDEX IF NOT EXISTS idx_cases_creationdate_desc ON cases USING btree (creationdate DESC);
+
+INSERT INTO schema_version (version_number, comment) VALUES (507, 'Add index to improve performance or case duplicate merging lists #9054');
+
+
 
 -- *** Insert new sql commands BEFORE this line. Remember to always consider _history tables. ***

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/caze/CaseFacadeEjbTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/caze/CaseFacadeEjbTest.java
@@ -51,8 +51,6 @@ import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 
-import de.symeda.sormas.backend.infrastructure.community.Community;
-import de.symeda.sormas.backend.infrastructure.facility.Facility;
 import org.apache.commons.lang3.time.DateUtils;
 import org.hamcrest.MatcherAssert;
 import org.hibernate.internal.SessionImpl;
@@ -70,6 +68,7 @@ import de.symeda.sormas.api.caze.CaseCriteria;
 import de.symeda.sormas.api.caze.CaseDataDto;
 import de.symeda.sormas.api.caze.CaseExportDto;
 import de.symeda.sormas.api.caze.CaseExportType;
+import de.symeda.sormas.api.caze.CaseFacade;
 import de.symeda.sormas.api.caze.CaseIndexDetailedDto;
 import de.symeda.sormas.api.caze.CaseIndexDto;
 import de.symeda.sormas.api.caze.CaseLogic;
@@ -169,7 +168,9 @@ import de.symeda.sormas.backend.AbstractBeanTest;
 import de.symeda.sormas.backend.TestDataCreator;
 import de.symeda.sormas.backend.TestDataCreator.RDCF;
 import de.symeda.sormas.backend.TestDataCreator.RDCFEntities;
+import de.symeda.sormas.backend.infrastructure.community.Community;
 import de.symeda.sormas.backend.infrastructure.district.District;
+import de.symeda.sormas.backend.infrastructure.facility.Facility;
 import de.symeda.sormas.backend.infrastructure.region.Region;
 import de.symeda.sormas.backend.share.ExternalShareInfo;
 import de.symeda.sormas.backend.util.DtoHelper;
@@ -306,10 +307,14 @@ public class CaseFacadeEjbTest extends AbstractBeanTest {
 			DateUtils.addMinutes(today, -3),
 			rdcf);
 
-		final List<CaseIndexDto[]> casesForDuplicateMergingToday =
-			getCaseFacade().getCasesForDuplicateMerging(new CaseCriteria().creationDateFrom(today).creationDateTo(today), 100, true);
-		final List<CaseIndexDto[]> casesForDuplicateMergingThreeDaysAgo =
-			getCaseFacade().getCasesForDuplicateMerging(new CaseCriteria().creationDateFrom(threeDaysAgo).creationDateTo(threeDaysAgo), 100, true);
+		final List<CaseIndexDto[]> casesForDuplicateMergingToday = getCaseFacade().getCasesForDuplicateMerging(
+			new CaseCriteria().creationDateFrom(today).creationDateTo(today),
+			CaseFacade.DUPLICATE_MERGING_LIMIT_DEFAULT,
+			true);
+		final List<CaseIndexDto[]> casesForDuplicateMergingThreeDaysAgo = getCaseFacade().getCasesForDuplicateMerging(
+			new CaseCriteria().creationDateFrom(threeDaysAgo).creationDateTo(threeDaysAgo),
+			CaseFacade.DUPLICATE_MERGING_LIMIT_DEFAULT,
+			true);
 		assertEquals(1, casesForDuplicateMergingToday.size());
 		assertEquals(1, casesForDuplicateMergingThreeDaysAgo.size());
 	}
@@ -347,7 +352,14 @@ public class CaseFacadeEjbTest extends AbstractBeanTest {
 			DateUtils.addMinutes(today, -3),
 			rdcf);
 
-		assertEquals(0, getCaseFacade().getCasesForDuplicateMerging(new CaseCriteria().creationDateFrom(today).creationDateTo(today), 100, true).size());
+		assertEquals(
+			0,
+			getCaseFacade()
+				.getCasesForDuplicateMerging(
+					new CaseCriteria().creationDateFrom(today).creationDateTo(today),
+					CaseFacade.DUPLICATE_MERGING_LIMIT_DEFAULT,
+					true)
+				.size());
 	}
 
 	@Test
@@ -383,7 +395,14 @@ public class CaseFacadeEjbTest extends AbstractBeanTest {
 			DateUtils.addMinutes(today, -3),
 			rdcf);
 
-		assertEquals(0, getCaseFacade().getCasesForDuplicateMerging(new CaseCriteria().creationDateFrom(today).creationDateTo(today), 100, true).size());
+		assertEquals(
+			0,
+			getCaseFacade()
+				.getCasesForDuplicateMerging(
+					new CaseCriteria().creationDateFrom(today).creationDateTo(today),
+					CaseFacade.DUPLICATE_MERGING_LIMIT_DEFAULT,
+					true)
+				.size());
 	}
 
 	@Test
@@ -419,7 +438,14 @@ public class CaseFacadeEjbTest extends AbstractBeanTest {
 			DateUtils.addMinutes(today, -3),
 			rdcf);
 
-		assertEquals(1, getCaseFacade().getCasesForDuplicateMerging(new CaseCriteria().creationDateFrom(today).creationDateTo(today), 100, true).size());
+		assertEquals(
+			1,
+			getCaseFacade()
+				.getCasesForDuplicateMerging(
+					new CaseCriteria().creationDateFrom(today).creationDateTo(today),
+					CaseFacade.DUPLICATE_MERGING_LIMIT_DEFAULT,
+					true)
+				.size());
 	}
 
 	@Test

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/caze/CaseFacadeEjbTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/caze/CaseFacadeEjbTest.java
@@ -307,9 +307,9 @@ public class CaseFacadeEjbTest extends AbstractBeanTest {
 			rdcf);
 
 		final List<CaseIndexDto[]> casesForDuplicateMergingToday =
-			getCaseFacade().getCasesForDuplicateMerging(new CaseCriteria().creationDateFrom(today).creationDateTo(today), true);
+			getCaseFacade().getCasesForDuplicateMerging(new CaseCriteria().creationDateFrom(today).creationDateTo(today), 100, true);
 		final List<CaseIndexDto[]> casesForDuplicateMergingThreeDaysAgo =
-			getCaseFacade().getCasesForDuplicateMerging(new CaseCriteria().creationDateFrom(threeDaysAgo).creationDateTo(threeDaysAgo), true);
+			getCaseFacade().getCasesForDuplicateMerging(new CaseCriteria().creationDateFrom(threeDaysAgo).creationDateTo(threeDaysAgo), 100, true);
 		assertEquals(1, casesForDuplicateMergingToday.size());
 		assertEquals(1, casesForDuplicateMergingThreeDaysAgo.size());
 	}
@@ -347,7 +347,7 @@ public class CaseFacadeEjbTest extends AbstractBeanTest {
 			DateUtils.addMinutes(today, -3),
 			rdcf);
 
-		assertEquals(0, getCaseFacade().getCasesForDuplicateMerging(new CaseCriteria().creationDateFrom(today).creationDateTo(today), true).size());
+		assertEquals(0, getCaseFacade().getCasesForDuplicateMerging(new CaseCriteria().creationDateFrom(today).creationDateTo(today), 100, true).size());
 	}
 
 	@Test
@@ -383,7 +383,7 @@ public class CaseFacadeEjbTest extends AbstractBeanTest {
 			DateUtils.addMinutes(today, -3),
 			rdcf);
 
-		assertEquals(0, getCaseFacade().getCasesForDuplicateMerging(new CaseCriteria().creationDateFrom(today).creationDateTo(today), true).size());
+		assertEquals(0, getCaseFacade().getCasesForDuplicateMerging(new CaseCriteria().creationDateFrom(today).creationDateTo(today), 100, true).size());
 	}
 
 	@Test
@@ -419,7 +419,7 @@ public class CaseFacadeEjbTest extends AbstractBeanTest {
 			DateUtils.addMinutes(today, -3),
 			rdcf);
 
-		assertEquals(1, getCaseFacade().getCasesForDuplicateMerging(new CaseCriteria().creationDateFrom(today).creationDateTo(today), true).size());
+		assertEquals(1, getCaseFacade().getCasesForDuplicateMerging(new CaseCriteria().creationDateFrom(today).creationDateTo(today), 100, true).size());
 	}
 
 	@Test

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/MergeCasesFilterComponent.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/MergeCasesFilterComponent.java
@@ -31,6 +31,7 @@ import de.symeda.sormas.ui.UserProvider;
 import de.symeda.sormas.ui.ViewModelProviders;
 import de.symeda.sormas.ui.utils.ButtonHelper;
 import de.symeda.sormas.ui.utils.CssStyles;
+import de.symeda.sormas.ui.utils.QueryDetails;
 
 @SuppressWarnings("serial")
 public class MergeCasesFilterComponent extends VerticalLayout {
@@ -50,31 +51,40 @@ public class MergeCasesFilterComponent extends VerticalLayout {
 	private ComboBox<RegionReferenceDto> cbRegion;
 	private ComboBox<DistrictReferenceDto> cbDistrict;
 	private ComboBox<NewCaseDateType> cbNewCaseDateType;
+	private ComboBox<Integer> cbResultLimit;
 	private DateField dfNewCaseDateFrom;
 	private DateField dfNewCaseDateTo;
 	private Button btnConfirmFilters;
 	private Button btnResetFilters;
 
-	private Binder<CaseCriteria> binder = new Binder<>(CaseCriteria.class);
+	private Binder<CaseCriteria> criteriaBinder = new Binder<>(CaseCriteria.class);
 	private CaseCriteria criteria;
+	private Binder<QueryDetails> queryDetailsBinder = new Binder<>(QueryDetails.class);
+	private QueryDetails queryDetails;
 	private Runnable filtersUpdatedCallback;
 	private Consumer<Boolean> ignoreRegionCallback;
 
 	private Label lblNumberOfDuplicates;
 
-	public MergeCasesFilterComponent(CaseCriteria criteria) {
+	public MergeCasesFilterComponent(CaseCriteria criteria, QueryDetails queryDetails) {
 
 		setSpacing(false);
 		setMargin(false);
 		setWidth(100, Unit.PERCENTAGE);
 
-		this.criteria = criteria;
-
 		addFirstRowLayout();
 		addSecondRowLayout();
 		addThirdRowLayout();
 
-		binder.readBean(this.criteria);
+		setValue(criteria, queryDetails);
+	}
+
+	public void setValue(CaseCriteria criteria, QueryDetails queryDetails) {
+		this.criteria = criteria;
+		this.queryDetails = queryDetails;
+
+		criteriaBinder.readBean(this.criteria);
+		queryDetailsBinder.readBean(this.queryDetails);
 	}
 
 	private void addFirstRowLayout() {
@@ -88,7 +98,9 @@ public class MergeCasesFilterComponent extends VerticalLayout {
 		dfCreationDateFrom.setWidth(120, Unit.PIXELS);
 		dfCreationDateFrom.setPlaceholder(I18nProperties.getString(Strings.promptCreationDateFrom));
 		dfCreationDateFrom.setCaption(I18nProperties.getCaption(Captions.creationDate));
-		binder.forField(dfCreationDateFrom).withConverter(new LocalDateToDateConverter(ZoneId.systemDefault())).bind(CaseCriteria.CREATION_DATE_FROM);
+		criteriaBinder.forField(dfCreationDateFrom)
+			.withConverter(new LocalDateToDateConverter(ZoneId.systemDefault()))
+			.bind(CaseCriteria.CREATION_DATE_FROM);
 		firstRowLayout.addComponent(dfCreationDateFrom);
 
 		dfCreationDateTo = new DateField();
@@ -96,7 +108,9 @@ public class MergeCasesFilterComponent extends VerticalLayout {
 		dfCreationDateTo.setWidth(120, Unit.PIXELS);
 		CssStyles.style(dfCreationDateTo, CssStyles.FORCE_CAPTION);
 		dfCreationDateTo.setPlaceholder(I18nProperties.getString(Strings.promptDateTo));
-		binder.forField(dfCreationDateTo).withConverter(new LocalDateToDateConverter(ZoneId.systemDefault())).bind(CaseCriteria.CREATION_DATE_TO);
+		criteriaBinder.forField(dfCreationDateTo)
+			.withConverter(new LocalDateToDateConverter(ZoneId.systemDefault()))
+			.bind(CaseCriteria.CREATION_DATE_TO);
 		firstRowLayout.addComponent(dfCreationDateTo);
 
 		cbDisease = new ComboBox<>();
@@ -105,7 +119,7 @@ public class MergeCasesFilterComponent extends VerticalLayout {
 		CssStyles.style(cbDisease, CssStyles.FORCE_CAPTION);
 		cbDisease.setPlaceholder(I18nProperties.getPrefixCaption(CaseDataDto.I18N_PREFIX, CaseDataDto.DISEASE));
 		cbDisease.setItems(FacadeProvider.getDiseaseConfigurationFacade().getAllDiseases(true, true, true));
-		binder.bind(cbDisease, CaseDataDto.DISEASE);
+		criteriaBinder.bind(cbDisease, CaseDataDto.DISEASE);
 		firstRowLayout.addComponent(cbDisease);
 
 		tfSearch = new TextField();
@@ -113,7 +127,7 @@ public class MergeCasesFilterComponent extends VerticalLayout {
 		tfSearch.setWidth(200, Unit.PIXELS);
 		CssStyles.style(tfSearch, CssStyles.FORCE_CAPTION);
 		tfSearch.setPlaceholder(I18nProperties.getString(Strings.promptCasesSearchField));
-		binder.bind(tfSearch, CaseCriteria.CASE_LIKE);
+		criteriaBinder.bind(tfSearch, CaseCriteria.CASE_LIKE);
 		firstRowLayout.addComponent(tfSearch);
 
 		eventSearch = new TextField();
@@ -121,7 +135,7 @@ public class MergeCasesFilterComponent extends VerticalLayout {
 		eventSearch.setWidth(200, Unit.PIXELS);
 		CssStyles.style(eventSearch, CssStyles.FORCE_CAPTION);
 		eventSearch.setPlaceholder(I18nProperties.getString(Strings.promptCaseOrContactEventSearchField));
-		binder.bind(eventSearch, CaseCriteria.EVENT_LIKE);
+		criteriaBinder.bind(eventSearch, CaseCriteria.EVENT_LIKE);
 		firstRowLayout.addComponent(eventSearch);
 
 		tfReportingUser = new TextField();
@@ -129,7 +143,7 @@ public class MergeCasesFilterComponent extends VerticalLayout {
 		tfReportingUser.setWidth(200, Unit.PIXELS);
 		CssStyles.style(tfReportingUser, CssStyles.FORCE_CAPTION);
 		tfReportingUser.setPlaceholder(I18nProperties.getPrefixCaption(CaseDataDto.I18N_PREFIX, CaseDataDto.REPORTING_USER));
-		binder.bind(tfReportingUser, CaseCriteria.REPORTING_USER_LIKE);
+		criteriaBinder.bind(tfReportingUser, CaseCriteria.REPORTING_USER_LIKE);
 		firstRowLayout.addComponent(tfReportingUser);
 		firstRowLayout.setExpandRatio(tfReportingUser, 1);
 
@@ -152,7 +166,7 @@ public class MergeCasesFilterComponent extends VerticalLayout {
 		CssStyles.style(cbRegion, CssStyles.FORCE_CAPTION);
 		cbRegion.setPlaceholder(I18nProperties.getPrefixCaption(CaseDataDto.I18N_PREFIX, CaseDataDto.REGION));
 		cbRegion.setItems(FacadeProvider.getRegionFacade().getAllActiveByServerCountry());
-		binder.bind(cbRegion, CaseDataDto.REGION);
+		criteriaBinder.bind(cbRegion, CaseDataDto.REGION);
 		cbRegion.addValueChangeListener(e -> {
 			RegionReferenceDto region = e.getValue();
 			cbDistrict.clear();
@@ -172,7 +186,7 @@ public class MergeCasesFilterComponent extends VerticalLayout {
 		cbDistrict.setWidth(200, Unit.PIXELS);
 		CssStyles.style(cbDistrict, CssStyles.FORCE_CAPTION);
 		cbDistrict.setPlaceholder(I18nProperties.getPrefixCaption(CaseDataDto.I18N_PREFIX, CaseDataDto.DISTRICT));
-		binder.bind(cbDistrict, CaseDataDto.DISTRICT);
+		criteriaBinder.bind(cbDistrict, CaseDataDto.DISTRICT);
 		secondRowLayout.addComponent(cbDistrict);
 
 		cbIgnoreRegion = new CheckBox();
@@ -197,13 +211,14 @@ public class MergeCasesFilterComponent extends VerticalLayout {
 		cbNewCaseDateType = new ComboBox<>();
 		dfNewCaseDateFrom = new DateField();
 		dfNewCaseDateTo = new DateField();
+		cbResultLimit = new ComboBox<>();
 
 		cbNewCaseDateType.setId(CaseCriteria.NEW_CASE_DATE_TYPE);
 		cbNewCaseDateType.setWidth(200, Unit.PIXELS);
 		cbNewCaseDateType.setPlaceholder(I18nProperties.getString(Strings.promptNewCaseDateType));
 		cbNewCaseDateType.setCaption(I18nProperties.getCaption(Captions.caseNewCaseDate));
 		cbNewCaseDateType.setItems(NewCaseDateType.values());
-		binder.bind(cbNewCaseDateType, CaseCriteria.NEW_CASE_DATE_TYPE);
+		criteriaBinder.bind(cbNewCaseDateType, CaseCriteria.NEW_CASE_DATE_TYPE);
 		cbNewCaseDateType.addValueChangeListener(event -> {
 			dfNewCaseDateFrom.setEnabled(event.getValue() != null);
 			dfNewCaseDateTo.setEnabled(event.getValue() != null);
@@ -214,7 +229,9 @@ public class MergeCasesFilterComponent extends VerticalLayout {
 		dfNewCaseDateFrom.setWidth(120, Unit.PIXELS);
 		CssStyles.style(dfNewCaseDateFrom, CssStyles.FORCE_CAPTION);
 		dfNewCaseDateFrom.setPlaceholder(I18nProperties.getString(Strings.promptCasesDateFrom));
-		binder.forField(dfNewCaseDateFrom).withConverter(new LocalDateToDateConverter(ZoneId.systemDefault())).bind(CaseCriteria.NEW_CASE_DATE_FROM);
+		criteriaBinder.forField(dfNewCaseDateFrom)
+			.withConverter(new LocalDateToDateConverter(ZoneId.systemDefault()))
+			.bind(CaseCriteria.NEW_CASE_DATE_FROM);
 		dfNewCaseDateFrom.setEnabled(false);
 		thirdRowLayout.addComponent(dfNewCaseDateFrom);
 
@@ -222,13 +239,25 @@ public class MergeCasesFilterComponent extends VerticalLayout {
 		dfNewCaseDateTo.setWidth(120, Unit.PIXELS);
 		CssStyles.style(dfNewCaseDateTo, CssStyles.FORCE_CAPTION);
 		dfNewCaseDateTo.setPlaceholder(I18nProperties.getString(Strings.promptDateTo));
-		binder.forField(dfNewCaseDateTo).withConverter(new LocalDateToDateConverter(ZoneId.systemDefault())).bind(CaseCriteria.NEW_CASE_DATE_TO);
+		criteriaBinder.forField(dfNewCaseDateTo)
+			.withConverter(new LocalDateToDateConverter(ZoneId.systemDefault()))
+			.bind(CaseCriteria.NEW_CASE_DATE_TO);
 		dfNewCaseDateTo.setEnabled(false);
 		thirdRowLayout.addComponent(dfNewCaseDateTo);
 
+		cbResultLimit.setId(QueryDetails.RESULT_LIMIT);
+		cbResultLimit.setWidth(200, Unit.PIXELS);
+		cbResultLimit.setPlaceholder(I18nProperties.getString(Strings.none));
+		cbResultLimit.setCaption("Limit result count");
+		cbResultLimit.setItems(50, 100, 500, 1000);
+		cbResultLimit.setEmptySelectionAllowed(true);
+		queryDetailsBinder.bind(cbResultLimit, QueryDetails.RESULT_LIMIT);
+		thirdRowLayout.addComponent(cbResultLimit);
+
 		btnConfirmFilters = ButtonHelper.createButton(Captions.actionConfirmFilters, event -> {
 			try {
-				binder.writeBean(criteria);
+				criteriaBinder.writeBean(criteria);
+				queryDetailsBinder.writeBean(queryDetails);
 				filtersUpdatedCallback.run();
 			} catch (ValidationException e) {
 				// No validation needed

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/MergeCasesFilterComponent.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/MergeCasesFilterComponent.java
@@ -19,6 +19,7 @@ import com.vaadin.ui.themes.ValoTheme;
 
 import de.symeda.sormas.api.Disease;
 import de.symeda.sormas.api.FacadeProvider;
+import de.symeda.sormas.api.ReferenceDto;
 import de.symeda.sormas.api.caze.CaseCriteria;
 import de.symeda.sormas.api.caze.CaseDataDto;
 import de.symeda.sormas.api.caze.NewCaseDateType;
@@ -51,7 +52,6 @@ public class MergeCasesFilterComponent extends VerticalLayout {
 	private ComboBox<RegionReferenceDto> cbRegion;
 	private ComboBox<DistrictReferenceDto> cbDistrict;
 	private ComboBox<NewCaseDateType> cbNewCaseDateType;
-	private ComboBox<Integer> cbResultLimit;
 	private DateField dfNewCaseDateFrom;
 	private DateField dfNewCaseDateTo;
 	private Button btnConfirmFilters;
@@ -158,8 +158,8 @@ public class MergeCasesFilterComponent extends VerticalLayout {
 
 		cbRegion = new ComboBox<>();
 		cbDistrict = new ComboBox<>();
-		cbRegion.setItemCaptionGenerator(item -> item.buildCaption());
-		cbDistrict.setItemCaptionGenerator(item -> item.buildCaption());
+		cbRegion.setItemCaptionGenerator(ReferenceDto::buildCaption);
+		cbDistrict.setItemCaptionGenerator(ReferenceDto::buildCaption);
 
 		cbRegion.setId(CaseDataDto.REGION);
 		cbRegion.setWidth(200, Unit.PIXELS);
@@ -193,9 +193,7 @@ public class MergeCasesFilterComponent extends VerticalLayout {
 		cbIgnoreRegion.setId(Captions.caseFilterWithDifferentRegion);
 		CssStyles.style(cbIgnoreRegion, CssStyles.CHECKBOX_FILTER_INLINE);
 		cbIgnoreRegion.setCaption(I18nProperties.getCaption(Captions.caseFilterWithDifferentRegion));
-		cbIgnoreRegion.addValueChangeListener(e -> {
-			ignoreRegionCallback.accept(e.getValue());
-		});
+		cbIgnoreRegion.addValueChangeListener(e -> ignoreRegionCallback.accept(e.getValue()));
 		secondRowLayout.addComponent(cbIgnoreRegion);
 		secondRowLayout.setComponentAlignment(cbIgnoreRegion, Alignment.MIDDLE_LEFT);
 		secondRowLayout.setExpandRatio(cbIgnoreRegion, 1);
@@ -211,7 +209,7 @@ public class MergeCasesFilterComponent extends VerticalLayout {
 		cbNewCaseDateType = new ComboBox<>();
 		dfNewCaseDateFrom = new DateField();
 		dfNewCaseDateTo = new DateField();
-		cbResultLimit = new ComboBox<>();
+		ComboBox<Integer> cbResultLimit = new ComboBox<>();
 
 		cbNewCaseDateType.setId(CaseCriteria.NEW_CASE_DATE_TYPE);
 		cbNewCaseDateType.setWidth(200, Unit.PIXELS);

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/MergeCasesFilterComponent.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/MergeCasesFilterComponent.java
@@ -247,10 +247,9 @@ public class MergeCasesFilterComponent extends VerticalLayout {
 
 		cbResultLimit.setId(QueryDetails.RESULT_LIMIT);
 		cbResultLimit.setWidth(200, Unit.PIXELS);
-		cbResultLimit.setPlaceholder(I18nProperties.getString(Strings.none));
 		cbResultLimit.setCaption(I18nProperties.getCaption(Captions.QueryDetails_resultLimit));
 		cbResultLimit.setItems(50, 100, 500, 1000);
-		cbResultLimit.setEmptySelectionAllowed(true);
+		cbResultLimit.setEmptySelectionAllowed(false);
 		queryDetailsBinder.bind(cbResultLimit, QueryDetails.RESULT_LIMIT);
 		thirdRowLayout.addComponent(cbResultLimit);
 

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/MergeCasesFilterComponent.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/MergeCasesFilterComponent.java
@@ -248,7 +248,7 @@ public class MergeCasesFilterComponent extends VerticalLayout {
 		cbResultLimit.setId(QueryDetails.RESULT_LIMIT);
 		cbResultLimit.setWidth(200, Unit.PIXELS);
 		cbResultLimit.setPlaceholder(I18nProperties.getString(Strings.none));
-		cbResultLimit.setCaption("Limit result count");
+		cbResultLimit.setCaption(I18nProperties.getCaption(Captions.QueryDetails_resultLimit));
 		cbResultLimit.setItems(50, 100, 500, 1000);
 		cbResultLimit.setEmptySelectionAllowed(true);
 		queryDetailsBinder.bind(cbResultLimit, QueryDetails.RESULT_LIMIT);

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/MergeCasesGrid.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/MergeCasesGrid.java
@@ -80,7 +80,7 @@ public class MergeCasesGrid extends AbstractMergeGrid<CaseIndexDto, CaseCriteria
 
 	@Override
 	protected List<CaseIndexDto[]> getItemForDuplicateMerging() {
-		return FacadeProvider.getCaseFacade().getCasesForDuplicateMerging(criteria, ignoreRegion);
+		return FacadeProvider.getCaseFacade().getCasesForDuplicateMerging(criteria, queryDetails.getResultLimit(), ignoreRegion);
 	}
 
 	@Override

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/MergeCasesGrid.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/caze/MergeCasesGrid.java
@@ -1,6 +1,5 @@
 package de.symeda.sormas.ui.caze;
 
-import de.symeda.sormas.api.externalsurveillancetool.ExternalSurveillanceToolException;
 import java.util.Date;
 import java.util.List;
 
@@ -17,6 +16,7 @@ import de.symeda.sormas.api.FacadeProvider;
 import de.symeda.sormas.api.Language;
 import de.symeda.sormas.api.caze.AgeAndBirthDateDto;
 import de.symeda.sormas.api.caze.CaseCriteria;
+import de.symeda.sormas.api.caze.CaseFacade;
 import de.symeda.sormas.api.caze.CaseIndexDto;
 import de.symeda.sormas.api.externalsurveillancetool.ExternalSurveillanceToolRuntimeException;
 import de.symeda.sormas.api.i18n.Captions;
@@ -80,7 +80,11 @@ public class MergeCasesGrid extends AbstractMergeGrid<CaseIndexDto, CaseCriteria
 
 	@Override
 	protected List<CaseIndexDto[]> getItemForDuplicateMerging() {
-		return FacadeProvider.getCaseFacade().getCasesForDuplicateMerging(criteria, queryDetails.getResultLimit(), ignoreRegion);
+		return FacadeProvider.getCaseFacade()
+			.getCasesForDuplicateMerging(
+				criteria,
+				queryDetails.getResultLimit() != null ? queryDetails.getResultLimit().intValue() : CaseFacade.DUPLICATE_MERGING_LIMIT_DEFAULT,
+				ignoreRegion);
 	}
 
 	@Override

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/AbstractMergeGrid.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/AbstractMergeGrid.java
@@ -49,6 +49,9 @@ public abstract class AbstractMergeGrid<T1 extends MergeableIndexDto, T2 extends
 	private static final String COMPLETENESS = "completeness";
 
 	protected T2 criteria;
+
+	protected QueryDetails queryDetails;
+
 	protected boolean ignoreRegion;
 
 	protected List<String[]> hiddenUuidPairs;
@@ -240,5 +243,13 @@ public abstract class AbstractMergeGrid<T1 extends MergeableIndexDto, T2 extends
 
 	public void setCriteria(T2 criteria) {
 		this.criteria = criteria;
+	}
+
+	public QueryDetails getQueryDetails() {
+		return queryDetails;
+	}
+
+	public void setQueryDetails(QueryDetails queryDetails) {
+		this.queryDetails = queryDetails;
 	}
 }

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/AbstractView.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/AbstractView.java
@@ -175,14 +175,16 @@ public abstract class AbstractView extends VerticalLayout implements View {
 		}
 
 		StringBuilder urlParams = new StringBuilder();
-		for (BaseCriteria criteria : criteriaList) {
-			if (criteria != null) {
-				String params = criteria.toUrlParams();
-				if (!DataHelper.isNullOrEmpty(params))
-					if (urlParams.length() > 0) {
-						urlParams.append('&');
-					}
-				urlParams.append(params);
+		if (criteriaList != null) {
+			for (BaseCriteria criteria : criteriaList) {
+				if (criteria != null) {
+					String params = criteria.toUrlParams();
+					if (!DataHelper.isNullOrEmpty(params))
+						if (urlParams.length() > 0) {
+							urlParams.append('&');
+						}
+					urlParams.append(params);
+				}
 			}
 		}
 

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/AbstractView.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/AbstractView.java
@@ -19,6 +19,7 @@ package de.symeda.sormas.ui.utils;
 
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import org.vaadin.hene.popupbutton.PopupButton;
 
@@ -74,8 +75,8 @@ public abstract class AbstractView extends VerticalLayout implements View {
 			viewTitleLayout.setMargin(false);
 
 			// note: splitting title and subtitle into labels does not work with the css
-			String viewTitle = I18nProperties.getPrefixCaption("View", viewName.replaceAll("/", "."));
-			String viewSubTitle = I18nProperties.getPrefixCaption("View", viewName.replaceAll("/", ".") + ".sub", "");
+			String viewTitle = I18nProperties.getPrefixCaption("View", viewName.replace("/", "."));
+			String viewSubTitle = I18nProperties.getPrefixCaption("View", viewName.replace("/", ".") + ".sub", "");
 			viewTitleLabel = new Label(viewTitle);
 			viewTitleLabel.setSizeUndefined();
 			CssStyles.style(viewTitleLabel, CssStyles.H1, CssStyles.VSPACE_NONE);
@@ -174,26 +175,17 @@ public abstract class AbstractView extends VerticalLayout implements View {
 			newState = newState.substring(0, paramsIndex);
 		}
 
-		StringBuilder urlParams = new StringBuilder();
-		if (criteriaList != null) {
-			for (BaseCriteria criteria : criteriaList) {
-				if (criteria != null) {
-					String params = criteria.toUrlParams();
-					if (!DataHelper.isNullOrEmpty(params))
-						if (urlParams.length() > 0) {
-							urlParams.append('&');
-						}
-					urlParams.append(params);
-				}
-			}
-		}
+		String urlParams = Arrays.stream(criteriaList)
+				.filter(Objects::nonNull)
+				.map(BaseCriteria::toUrlParams)
+				.filter(params -> !DataHelper.isNullOrEmpty(params))
+				.collect(Collectors.joining("&"));
 
 		if (urlParams.length() > 0) {
 			if (newState.charAt(newState.length() - 1) != '/') {
 				newState += "/";
 			}
-
-			newState += "?" + urlParams.toString();
+			newState += "?" + urlParams;
 		}
 
 		return newState;

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/QueryDetails.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/QueryDetails.java
@@ -6,6 +6,8 @@ public class QueryDetails extends BaseCriteria {
 
     public static final String RESULT_LIMIT = "resultLimit";
 
+    protected Integer resultLimit;
+
     public Integer getResultLimit() {
         return resultLimit;
     }
@@ -13,6 +15,4 @@ public class QueryDetails extends BaseCriteria {
     public void setResultLimit(Integer resultLimit) {
         this.resultLimit = resultLimit;
     }
-
-    protected Integer resultLimit = 100;
 }

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/QueryDetails.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/QueryDetails.java
@@ -1,0 +1,18 @@
+package de.symeda.sormas.ui.utils;
+
+import de.symeda.sormas.api.utils.criteria.BaseCriteria;
+
+public class QueryDetails extends BaseCriteria {
+
+    public static final String RESULT_LIMIT = "resultLimit";
+
+    public Integer getResultLimit() {
+        return resultLimit;
+    }
+
+    public void setResultLimit(Integer resultLimit) {
+        this.resultLimit = resultLimit;
+    }
+
+    protected Integer resultLimit = 100;
+}

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/QueryDetails.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/utils/QueryDetails.java
@@ -6,7 +6,7 @@ public class QueryDetails extends BaseCriteria {
 
     public static final String RESULT_LIMIT = "resultLimit";
 
-    protected Integer resultLimit;
+    private Integer resultLimit;
 
     public Integer getResultLimit() {
         return resultLimit;


### PR DESCRIPTION
<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #9054

I have not adjusted the content of the existing warning in the duplicate view, because I have added a drop-down for the result count and was not sure how to adjust the existing text anyway.

I have tested it on a database with 85000 cases that result in 82000 potential duplicates, because they are generated. Using the limit of 100 or 1000 resulted in an execution of 1-3 seconds. Leaving the limitation away took more than 2 minutes.