### PR TITLE
#11502 - Handle region requirement

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/events/EventDataForm.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/events/EventDataForm.java
@@ -730,6 +730,7 @@ public class EventDataForm extends AbstractEditForm<EventDto> {
 		laboratoryDiagnosticEvidenceCheckBoxTree.setValues(newFieldValue.getLaboratoryDiagnosticEvidenceDetails());
 
 		if (!isCreateForm && FacadeProvider.getEventFacade().hasAnyEventParticipantWithoutJurisdiction(newFieldValue.getUuid())) {
+			locationForm.setHasEventParticipantsWithoutJurisdiction(true);
 			locationForm.setFieldsRequirement(true, LocationDto.REGION, LocationDto.DISTRICT);
 			locationForm.setCountryDisabledWithHint(I18nProperties.getString(Strings.infoCountryNotEditableEventParticipantsWithoutJurisdiction));
 		}

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/location/LocationEditForm.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/location/LocationEditForm.java
@@ -135,6 +135,7 @@ public class LocationEditForm extends AbstractEditForm<LocationDto> {
 	private boolean skipCountryValueChange;
 	private boolean skipFacilityTypeUpdate;
 	private boolean disableFacilityAddressCheck;
+	private boolean hasEventParticipantsWithoutJurisdiction;
 
 	public LocationEditForm(FieldVisibilityCheckers fieldVisibilityCheckers, UiFieldAccessCheckers fieldAccessCheckers) {
 		super(LocationDto.class, LocationDto.I18N_PREFIX, true, fieldVisibilityCheckers, fieldAccessCheckers);
@@ -595,7 +596,7 @@ public class LocationEditForm extends AbstractEditForm<LocationDto> {
 	private void updateRegionCombo(ComboBox region, ComboBox country) {
 		InfrastructureFieldsHelper.updateRegionBasedOnCountry(country, region, (isServerCountry) -> {
 			if (districtRequiredOnDefaultCountry) {
-				setFieldsRequirement(isServerCountry, LocationDto.REGION, LocationDto.DISTRICT);
+				setFieldsRequirement(hasEventParticipantsWithoutJurisdiction || isServerCountry, LocationDto.REGION, LocationDto.DISTRICT);
 			}
 		});
 	}
@@ -805,6 +806,10 @@ public class LocationEditForm extends AbstractEditForm<LocationDto> {
 
 	public void setDisableFacilityAddressCheck(boolean disableFacilityAddressCheck) {
 		this.disableFacilityAddressCheck = disableFacilityAddressCheck;
+	}
+
+	public void setHasEventParticipantsWithoutJurisdiction(boolean hasEventParticipantsWithoutJurisdiction) {
+		this.hasEventParticipantsWithoutJurisdiction = hasEventParticipantsWithoutJurisdiction;
 	}
 
 	private static class MapPopupView extends PopupView {


### PR DESCRIPTION
Ensure that region and district are required when there's at least one event participant without a jurisdiction in the event

<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #11502