### PR TITLE
SORQA-893 Stabilize "Testing Event group adding for new event". Time …

### DIFF
--- a/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/events/EventDirectorySteps.java
+++ b/sormas-e2e-tests/src/test/java/org/sormas/e2etests/steps/web/application/events/EventDirectorySteps.java
@@ -203,7 +203,7 @@ public class EventDirectorySteps implements En {
     When(
         "I fill EVENT ID filter by API",
         () -> {
-          TimeUnit.SECONDS.sleep(2); // wait for reaction
+          TimeUnit.SECONDS.sleep(5); // wait for reaction
           String eventUuid = apiState.getCreatedEvent().getUuid();
           webDriverHelpers.waitUntilIdentifiedElementIsPresent(SEARCH_EVENT_BY_FREE_TEXT);
           webDriverHelpers.fillInWebElement(


### PR DESCRIPTION
…sleep before filling EVENT ID in search event input has been extended to 5 seconds.

<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #