### PR TITLE
#11819 remove backend logic for setting the user's jurisdiction on ev…

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/event/EventParticipantFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/event/EventParticipantFacadeEjb.java
@@ -85,9 +85,7 @@ import de.symeda.sormas.api.i18n.Strings;
 import de.symeda.sormas.api.i18n.Validations;
 import de.symeda.sormas.api.immunization.MeansOfImmunization;
 import de.symeda.sormas.api.importexport.ExportConfigurationDto;
-import de.symeda.sormas.api.infrastructure.district.DistrictReferenceDto;
 import de.symeda.sormas.api.infrastructure.facility.FacilityHelper;
-import de.symeda.sormas.api.infrastructure.region.RegionReferenceDto;
 import de.symeda.sormas.api.location.LocationDto;
 import de.symeda.sormas.api.person.PersonDto;
 import de.symeda.sormas.api.person.PersonReferenceDto;
@@ -320,13 +318,6 @@ public class EventParticipantFacadeEjb
 
 		EventReferenceDto eventReferenceDto = dto.getEvent();
 		Event event = eventService.getByUuid(eventReferenceDto.getUuid());
-
-		if (!eventService.inJurisdiction(event) && (dto.getRegion() == null || dto.getDistrict() == null)) {
-			Region region = user.getRegion();
-			dto.setRegion(region != null ? new RegionReferenceDto(region.getUuid(), region.getName(), region.getExternalID()) : null);
-			District district = user.getDistrict();
-			dto.setDistrict(district != null ? new DistrictReferenceDto(district.getUuid(), district.getName(), district.getExternalID()) : null);
-		}
 
 		Pseudonymizer pseudonymizer = createPseudonymizer();
 		restorePseudonymizedDto(dto, existingDto, existingParticipant, pseudonymizer);

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/caze/CaseFacadeEjbTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/caze/CaseFacadeEjbTest.java
@@ -764,7 +764,8 @@ public class CaseFacadeEjbTest extends AbstractBeanTest {
 			null,
 			null);
 
-		EventParticipantDto event1Participant1 = creator.createEventParticipant(event1.toReference(), person1, surveillanceSupervisor.toReference());
+		EventParticipantDto event1Participant1 =
+			creator.createEventParticipant(event1.toReference(), person1, "Involved", surveillanceSupervisor.toReference(), rdcf);
 		EventParticipantDto event1Participant2 = creator.createEventParticipant(event1.toReference(), person2, surveillanceSupervisor.toReference());
 
 		CaseDataDto case1 = creator.createCase(

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/contact/ContactFacadeEjbTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/contact/ContactFacadeEjbTest.java
@@ -849,7 +849,7 @@ public class ContactFacadeEjbTest extends AbstractBeanTest {
 			null,
 			null);
 
-		EventParticipantDto event1Participant1 = creator.createEventParticipant(event1.toReference(), person1, user.toReference());
+		EventParticipantDto event1Participant1 = creator.createEventParticipant(event1.toReference(), person1, "Involved", user.toReference(), rdcf);
 		creator.createEventParticipant(event1.toReference(), person2, user.toReference());
 
 		CaseDataDto case1 = creator.createCase(

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/event/EventParticipantFacadeEjbPseudonymizationTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/event/EventParticipantFacadeEjbPseudonymizationTest.java
@@ -18,7 +18,6 @@ package de.symeda.sormas.backend.event;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyString;
-import static org.hamcrest.Matchers.nullValue;
 
 import java.util.Arrays;
 import java.util.List;
@@ -33,6 +32,7 @@ import de.symeda.sormas.api.person.PersonDto;
 import de.symeda.sormas.api.person.Sex;
 import de.symeda.sormas.api.user.DefaultUserRole;
 import de.symeda.sormas.api.user.UserDto;
+import de.symeda.sormas.api.utils.AccessDeniedException;
 import de.symeda.sormas.backend.AbstractBeanTest;
 import de.symeda.sormas.backend.TestDataCreator;
 
@@ -80,9 +80,7 @@ public class EventParticipantFacadeEjbPseudonymizationTest extends AbstractBeanT
 	public void testEventOutsideJurisdiction() {
 		EventParticipantDto eventParticipant = createEventParticipant(user1, rdcf1);
 
-//		assertPseudonymized(getEventParticipantFacade().getEventParticipantByUuid(eventParticipant.getUuid()));
-		// pseudonymization disabled for now
-		assertNotPseudonymized(getEventParticipantFacade().getEventParticipantByUuid(eventParticipant.getUuid()));
+		assertPseudonymized(getEventParticipantFacade().getEventParticipantByUuid(eventParticipant.getUuid()));
 	}
 
 	@Test
@@ -94,9 +92,7 @@ public class EventParticipantFacadeEjbPseudonymizationTest extends AbstractBeanT
 			getEventParticipantFacade().getByUuids(Arrays.asList(eventParticipant1.getUuid(), eventParticipant2.getUuid()));
 
 		assertNotPseudonymized(participants.stream().filter(p -> p.getUuid().equals(eventParticipant1.getUuid())).findFirst().get());
-//		assertPseudonymized(participants.stream().filter(p -> p.getUuid().equals(eventParticipant2.getUuid())).findFirst().get());
-		// pseudonymization disabled for now
-		assertNotPseudonymized(participants.stream().filter(p -> p.getUuid().equals(eventParticipant2.getUuid())).findFirst().get());
+		assertPseudonymized(participants.stream().filter(p -> p.getUuid().equals(eventParticipant2.getUuid())).findFirst().get());
 	}
 
 	@Test
@@ -114,30 +110,24 @@ public class EventParticipantFacadeEjbPseudonymizationTest extends AbstractBeanT
 		// saving event participant should be done in 2 steps: person and participant
 
 		getPersonFacade().save(participant.getPerson());
+
+		// personal and sensitive data should not be updated
+		loginWith(user1);
 		PersonDto savedPerson = getPersonFacade().getByUuid(participant.getPerson().getUuid());
 
-//		assertThat(savedPerson.getFirstName(), is("John"));
-//		assertThat(savedPerson.getLastName(), is("Smith"));
-//		assertThat(savedPerson.getAddress().getStreet(), is("Test Street"));
-//		assertThat(savedPerson.getAddress().getHouseNumber(), is("Test Number"));
-//		assertThat(savedPerson.getAddress().getAdditionalInformation(), is("Test Information"));
-//		assertThat(savedPerson.getAddress().getCity(), is("Test City"));
+		assertThat(savedPerson.getFirstName(), is("John"));
+		assertThat(savedPerson.getLastName(), is("Smith"));
+		assertThat(savedPerson.getAddress().getStreet(), is("Test Street"));
+		assertThat(savedPerson.getAddress().getHouseNumber(), is("Test Number"));
+		assertThat(savedPerson.getAddress().getAdditionalInformation(), is("Test Information"));
+		assertThat(savedPerson.getAddress().getCity(), is("Test City"));
 
-		// pseudonymization disabled for now
-		assertThat(savedPerson.getFirstName(), is("James"));
-		assertThat(savedPerson.getLastName(), is("Doe"));
-		assertThat(savedPerson.getAddress().getStreet(), is(nullValue()));
-		assertThat(savedPerson.getAddress().getHouseNumber(), is(nullValue()));
-		assertThat(savedPerson.getAddress().getAdditionalInformation(), is(nullValue()));
-		assertThat(savedPerson.getAddress().getCity(), is(nullValue()));
-
-		getEventParticipantFacade().save(participant);
-		EventParticipant savedParticipant = getEventParticipantService().getByUuid(participant.getUuid());
-
-//		assertThat(savedParticipant.getInvolvementDescription(), is("Test involvement descr"));
-
-		// pseudonymization disabled for now
-		assertThat(savedParticipant.getInvolvementDescription(), is(""));
+		loginWith(user2);
+		// saving of invent participant should not be possible
+		assertThrowsWithMessage(
+			AccessDeniedException.class,
+			"This event participant is not editable any more",
+			() -> getEventParticipantFacade().save(participant));
 	}
 
 	@Test

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/event/EventParticipantFacadeEjbPseudonymizationTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/event/EventParticipantFacadeEjbPseudonymizationTest.java
@@ -142,7 +142,7 @@ public class EventParticipantFacadeEjbPseudonymizationTest extends AbstractBeanT
 
 	@Test
 	public void testUpdateWithPseudonymizedDto() {
-		EventParticipantDto participant = createEventParticipant(user1, rdcf1);
+		EventParticipantDto participant = createEventParticipant(user2, rdcf2);
 
 		participant.setPseudonymized(true);
 		participant.setInvolvementDescription(null);
@@ -180,7 +180,7 @@ public class EventParticipantFacadeEjbPseudonymizationTest extends AbstractBeanT
 			p.getAddress().setCity("Test City");
 		});
 
-		return creator.createEventParticipant(event.toReference(), person, "Test involvement descr", user.toReference());
+		return creator.createEventParticipant(event.toReference(), person, "Test involvement descr", user.toReference(), rdcf);
 	}
 
 	private void assertNotPseudonymized(EventParticipantDto eventParticipant) {

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/event/EventServiceTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/event/EventServiceTest.java
@@ -133,9 +133,13 @@ public class EventServiceTest extends AbstractBeanTest {
 		EventDto eventDto = creator.createEvent(user.toReference(), caze.getDisease());
 		Event event = getEventService().getByUuid(eventDto.getUuid());
 		getExternalShareInfoService().createAndPersistShareInfo(event, ExternalShareStatus.SHARED);
-		EventParticipantDto participant = creator.createEventParticipant(eventDto.toReference(), contactPerson, user.toReference());
-		participant.setResultingCase(caze.toReference());
-		getEventParticipantFacade().save(participant);
+		EventParticipantDto participant = creator.createEventParticipant(
+			eventDto.toReference(),
+			contactPerson,
+			"Involved",
+			user.toReference(),
+			ep -> ep.setResultingCase(caze.toReference()),
+			null);
 
 		EventService sut = getEventService();
 

--- a/sormas-backend/src/test/java/de/symeda/sormas/backend/person/PersonFacadeEjbPseudonymizationTest.java
+++ b/sormas-backend/src/test/java/de/symeda/sormas/backend/person/PersonFacadeEjbPseudonymizationTest.java
@@ -311,8 +311,7 @@ public class PersonFacadeEjbPseudonymizationTest extends AbstractBeanTest {
 		person = createPerson();
 		EventDto event = creator.createEvent(districtUser1.toReference());
 		creator.createEventParticipant(event.toReference(), person, districtUser1.toReference());
-//		assertPseudonymised(getPersonFacade().getPersonByUuid(person.getUuid()));
-		assertNotPseudonymized(getPersonFacade().getByUuid(person.getUuid()));
+		assertPseudonymised(getPersonFacade().getByUuid(person.getUuid()));
 	}
 
 	@Test
@@ -333,11 +332,8 @@ public class PersonFacadeEjbPseudonymizationTest extends AbstractBeanTest {
 		person = createPerson();
 		EventDto event = creator.createEvent(districtUser1.toReference());
 		creator.createEventParticipant(event.toReference(), person, districtUser1.toReference());
-//		updatePerson(true);
-//		assertPersonNotUpdated();
-		// pseudonymization disabled for now
-		updatePerson(false);
-		assertPersonUpdated();
+		updatePerson(true);
+		assertPersonNotUpdated();
 	}
 
 	@Test


### PR DESCRIPTION
ent participant because it should have been on the UI only but it's no longer needed

<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #11819

remove backend logic for setting the user's jurisdiction on event participant because it should have been on the UI only but it's no longer needed
