### PR TITLE
#11913 [Samples - S2S] 'Share' card on samples shared via S2S indicat…

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/AbstractSormasToSormasInterface.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/AbstractSormasToSormasInterface.java
@@ -733,7 +733,11 @@ public abstract class AbstractSormasToSormasInterface<ADO extends CoreAdo & Sorm
 		sormasToSormasRestClient.post(originInfo.getOrganizationId(), syncEndpoint, new SyncDataDto(shareData, criteria), null);
 
 		// remove existing shares from the request info
-		shareRequestInfo.setShares(shareRequestInfo.getShares().stream().filter(s -> s.getId() == null).collect(Collectors.toList()));
+		shareRequestInfo.setShares(
+			shareRequestInfo.getShares()
+				.stream()
+				.filter(s -> s.getSharedEntity().getSormasToSormasOriginInfo() == null && s.getId() == null)
+				.collect(Collectors.toList()));
 		if (!shareRequestInfo.getShares().isEmpty()) {
 			shareRequestInfoService.ensurePersisted(shareRequestInfo);
 		}

--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/share/outgoing/SormasToSormasShareInfo.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/sormastosormas/share/outgoing/SormasToSormasShareInfo.java
@@ -17,6 +17,8 @@ package de.symeda.sormas.backend.sormastosormas.share.outgoing;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -25,6 +27,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
+import javax.persistence.Transient;
 
 import de.symeda.sormas.api.utils.FieldConstraints;
 import de.symeda.sormas.backend.caze.Case;
@@ -35,6 +38,7 @@ import de.symeda.sormas.backend.event.Event;
 import de.symeda.sormas.backend.event.EventParticipant;
 import de.symeda.sormas.backend.immunization.entity.Immunization;
 import de.symeda.sormas.backend.sample.Sample;
+import de.symeda.sormas.backend.sormastosormas.entities.SormasToSormasShareable;
 
 @Entity(name = "sormastosormasshareinfo")
 public class SormasToSormasShareInfo extends AbstractDomainObject {
@@ -169,5 +173,13 @@ public class SormasToSormasShareInfo extends AbstractDomainObject {
 
 	public void setOwnershipHandedOver(boolean ownershipHandedOver) {
 		this.ownershipHandedOver = ownershipHandedOver;
+	}
+
+	@Transient
+	public SormasToSormasShareable getSharedEntity() {
+		return Stream.of(caze, contact, sample, immunization, surveillanceReport, event, eventParticipant)
+			.filter(Objects::nonNull)
+			.findFirst()
+			.orElseThrow(() -> new RuntimeException("ShareInfo[" + getUuid() + "] does not contain an entity"));
 	}
 }


### PR DESCRIPTION
…e that the sample was shared twice in the target system

<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #11913