### PR TITLE
#11982 [Samples] The person reference DTO is displayed on sample page…

### DIFF
--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/contact/ContactInfoLayout.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/contact/ContactInfoLayout.java
@@ -67,7 +67,7 @@ public class ContactInfoLayout extends AbstractInfoLayout<ContactDto> {
 			addDescLabel(
 				firstColumn,
 				ContactDto.PERSON,
-				contactDto.getPerson(),
+				contactDto.getPerson().buildCaption(),
 				I18nProperties.getPrefixCaption(ContactDto.I18N_PREFIX, ContactDto.PERSON));
 
 			if (UserProvider.getCurrent().hasUserRight(UserRight.CONTACT_VIEW)) {

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/events/EventParticipantInfoLayout.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/events/EventParticipantInfoLayout.java
@@ -96,7 +96,7 @@ public class EventParticipantInfoLayout extends AbstractInfoLayout<EventParticip
 		addDescLabel(
 			secondColumn,
 			EventParticipantDto.PERSON,
-			personDto,
+			personDto.buildCaption(),
 			I18nProperties.getPrefixCaption(EventParticipantDto.I18N_PREFIX, EventParticipantDto.PERSON));
 
 		final HorizontalLayout ageSexRow = new HorizontalLayout();


### PR DESCRIPTION
…s associated with contacts and/or event participants instead of the person name

<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #11982